### PR TITLE
Add some information about actors and their intent

### DIFF
--- a/packages/ciphernode/core/src/committee.rs
+++ b/packages/ciphernode/core/src/committee.rs
@@ -9,17 +9,17 @@ use crate::{
     fhe::Fhe,
 };
 
-pub struct Committee {
+pub struct CommitteeManager {
     bus: Addr<EventBus>,
     fhe: Addr<Fhe>,
     aggregators: HashMap<E3id, Addr<CommitteeKey>>,
 }
 
-impl Actor for Committee {
+impl Actor for CommitteeManager {
     type Context = Context<Self>;
 }
 
-impl Committee {
+impl CommitteeManager {
     pub fn new(bus: Addr<EventBus>, fhe: Addr<Fhe>) -> Self {
         Self {
             bus,
@@ -29,7 +29,7 @@ impl Committee {
     }
 }
 
-impl Handler<EnclaveEvent> for Committee {
+impl Handler<EnclaveEvent> for CommitteeManager {
     type Result = ();
 
     fn handle(&mut self, event: EnclaveEvent, _ctx: &mut Self::Context) -> Self::Result {

--- a/packages/ciphernode/core/src/committee_key.rs
+++ b/packages/ciphernode/core/src/committee_key.rs
@@ -38,6 +38,12 @@ pub struct CommitteeKey {
     state: CommitteeKeyState,
 }
 
+/// Aggregate PublicKey for a committee of nodes. This actor listens for KeyshareCreated events
+/// around a particular e3_id and aggregates the public key based on this and once done broadcasts 
+/// a EnclaveEvent::PublicKeyAggregated event on the event bus. Note events are hashed and
+/// identical events will not be triggered twice.
+/// It is expected to change this mechanism as we work through adversarial scenarios and write tests
+/// for them.
 impl CommitteeKey {
     pub fn new(fhe: Addr<Fhe>, bus: Addr<EventBus>, e3_id: E3id, nodecount: usize) -> Self {
         CommitteeKey {

--- a/packages/ciphernode/core/src/enclave_contract.rs
+++ b/packages/ciphernode/core/src/enclave_contract.rs
@@ -1,0 +1,16 @@
+
+use actix::{Actor, Context};
+
+/// Manage an internal web3 instance and express protocol specific behaviour through the events it
+/// accepts and emits to the EventBus
+/// Monitor contract events using `contract.events().create_filter()` and rebroadcast to eventbus by
+/// creating `EnclaveEvent` events
+/// Delegate signing to a separate actor responsible for managing Eth keys
+/// Accept eventbus events and forward as appropriate contract calls as required
+pub struct EnclaveContract;
+
+impl Actor for EnclaveContract{
+    type Context = Context<Self>;
+}
+
+

--- a/packages/ciphernode/core/src/eventbus.rs
+++ b/packages/ciphernode/core/src/eventbus.rs
@@ -22,6 +22,12 @@ impl Subscribe {
 #[rtype(result = "Vec<EnclaveEvent>")]
 pub struct GetHistory;
 
+
+/// Central EventBus for each node. Actors publish events to this bus by sending it EnclaveEvents.
+/// All events sent to this bus are assumed to be published over the network via pubsub.
+/// Other actors such as the P2p and Evm actor connect to outside services and control which events 
+/// actually get published as well as ensure that local events are not rebroadcast locally after 
+/// being published.
 pub struct EventBus {
     capture: bool,
     history: Vec<EnclaveEvent>,

--- a/packages/ciphernode/core/src/fhe.rs
+++ b/packages/ciphernode/core/src/fhe.rs
@@ -59,6 +59,9 @@ impl WrappedPublicKeyShare {
     } 
 }
 
+/// Wrapped PublicKey. This is wrapped to provide an inflection point
+/// as we use this library elsewhere we only implement traits as we need them
+/// and avoid exposing underlying structures from fhe.rs
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct WrappedPublicKey(pub PublicKey);
 
@@ -80,15 +83,21 @@ impl PartialOrd for WrappedPublicKey {
     }
 }
 
-
+/// Wrapped SecretKey. This is wrapped to provide an inflection point
+/// as we use this library elsewhere we only implement traits as we need them
+/// and avoid exposing underlying structures from fhe.rs
+// We should favor consuming patterns and avoid cloning and copying this value around in memory.
+// Underlying key Zeroizes on drop
 #[derive(PartialEq)]
 pub struct WrappedSecretKey(pub SecretKey);
+
 impl WrappedSecretKey {
     pub fn unsafe_to_vec(&self) -> Vec<u8> {
         serialize_box_i64(self.0.coeffs.clone())
     }
 }
 
+/// Fhe library adaptor. All FHE computations should happen through this actor.
 pub struct Fhe {
     params: Arc<BfvParameters>,
     crp: CommonRandomPoly,

--- a/packages/ciphernode/core/src/lib.rs
+++ b/packages/ciphernode/core/src/lib.rs
@@ -10,6 +10,8 @@ mod eventbus;
 mod events;
 mod fhe;
 mod ordered_set;
+mod p2p;
+mod enclave_contract;
 
 // pub struct Core {
 //     pub name: String,
@@ -34,7 +36,7 @@ mod tests {
 
     use crate::{
         ciphernode::Ciphernode,
-        committee::Committee,
+        committee::CommitteeManager,
         data::Data,
         eventbus::{EventBus, GetHistory, Subscribe},
         events::{ComputationRequested, E3id, EnclaveEvent, KeyshareCreated, PublicKeyAggregated},
@@ -94,8 +96,8 @@ mod tests {
         Ok((pk, rng))
     }
 
-    fn setup_committee_manager(bus: Addr<EventBus>, fhe: Addr<Fhe>) -> Addr<Committee> {
-        let committee = Committee::new(bus.clone(), fhe.clone()).start();
+    fn setup_committee_manager(bus: Addr<EventBus>, fhe: Addr<Fhe>) -> Addr<CommitteeManager> {
+        let committee = CommitteeManager::new(bus.clone(), fhe.clone()).start();
 
         bus.do_send(Subscribe::new(
             "ComputationRequested",
@@ -118,7 +120,7 @@ mod tests {
     }
 
     #[actix::test]
-    async fn test_ciphernode() -> Result<()> {
+    async fn test_public_key_aggregation() -> Result<()> {
         // Setup EventBus
         let bus = EventBus::new(true).start();
 
@@ -199,5 +201,14 @@ mod tests {
         );
 
         Ok(())
+    }
+
+
+    fn test_p2p_event_broadcasting() {
+        // Setup two Vec<u8> channels to simulate libp2p
+        // 1. command channel
+        // 2. event channel
+        // Pass them to the p2p actor
+        // connect the p2p actor to the event bus actor and monitor which events are broadcast 
     }
 }

--- a/packages/ciphernode/core/src/lib.rs
+++ b/packages/ciphernode/core/src/lib.rs
@@ -203,7 +203,7 @@ mod tests {
         Ok(())
     }
 
-
+    // TODO: Test p2p
     fn test_p2p_event_broadcasting() {
         // Setup two Vec<u8> channels to simulate libp2p
         // 1. command channel

--- a/packages/ciphernode/core/src/p2p.rs
+++ b/packages/ciphernode/core/src/p2p.rs
@@ -1,11 +1,24 @@
+/// Actor for connecting to an libp2p client via it's mpsc channel interface 
+/// This Actor should be responsible for 
+/// 1. Sending and Recieving Vec<u8> messages with libp2p
+/// 2. Converting between Vec<u8> and EnclaveEvents::Xxxxxxxxx()
+/// 3. Broadcasting over the local eventbus
+/// 4. Listening to the local eventbus for messages to be published to libp2p
 use actix::{Actor, Context};
-
+use tokio::sync::mpsc::{Receiver, Sender};
 use p2p::EnclaveRouter;
-pub struct P2pActor;
 
+pub struct P2p;
 
-impl Actor for P2pActor{
+impl Actor for P2p{
     type Context = Context<Self>;
 }
 
-
+impl P2p {
+    pub fn new() {
+        // Construct owning Libp2p module
+    }
+    pub fn from_channel(tx:Sender<Vec<u8>>, rx:Receiver<Vec<u8>>){
+        // Construct from tx/rx
+    }
+}


### PR DESCRIPTION
This adds some docs around the idea behind various actors and renames `Committee` to `CommitteeManager` to be clearer about what that actor does.