### PR TITLE
Add serde serialization to events and wrapped FHE structures

### DIFF
--- a/packages/ciphernode/Cargo.lock
+++ b/packages/ciphernode/Cargo.lock
@@ -910,6 +910,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "secp256k1",
+ "serde",
  "sha2",
  "tokio",
 ]
@@ -3350,18 +3351,18 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.204"
+version = "1.0.208"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
+checksum = "cff085d2cb684faa248efb494c39b68e522822ac0de72ccf08109abde717cfb2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.204"
+version = "1.0.208"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
+checksum = "24008e81ff7613ed8e5ba0cfaf24e2c2f1e5b8a0495711e44fcd4882fca62bcf"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/packages/ciphernode/core/Cargo.toml
+++ b/packages/ciphernode/core/Cargo.toml
@@ -24,4 +24,5 @@ secp256k1 = "0.29.0"
 tokio = { version = "1.39.3", features = ["full"] }
 sha2 = "0.10.8"
 bs58 = "0.5.1"
+serde = { version = "1.0.208", features = ["derive"] }
 

--- a/packages/ciphernode/core/src/events.rs
+++ b/packages/ciphernode/core/src/events.rs
@@ -1,4 +1,5 @@
 use actix::Message;
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::{
     fmt,
@@ -7,7 +8,7 @@ use std::{
 
 use crate::fhe::{WrappedPublicKey, WrappedPublicKeyShare};
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct E3id(pub String);
 impl fmt::Display for E3id {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -21,7 +22,7 @@ impl E3id {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct EventId(pub [u8; 32]);
 
 impl EventId {
@@ -42,8 +43,7 @@ impl fmt::Display for EventId {
     }
 }
 
-
-#[derive(Message, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Message, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[rtype(result = "()")]
 pub enum EnclaveEvent {
     KeyshareCreated {
@@ -66,11 +66,11 @@ pub enum EnclaveEvent {
 
 impl From<EnclaveEvent> for EventId {
     fn from(value: EnclaveEvent) -> Self {
-       match value {
-           EnclaveEvent::KeyshareCreated { id, .. } => id,
-           EnclaveEvent::ComputationRequested { id, .. } => id,
-           EnclaveEvent::PublicKeyAggregated { id, .. } => id,
-       } 
+        match value {
+            EnclaveEvent::KeyshareCreated { id, .. } => id,
+            EnclaveEvent::ComputationRequested { id, .. } => id,
+            EnclaveEvent::PublicKeyAggregated { id, .. } => id,
+        }
     }
 }
 
@@ -84,7 +84,7 @@ impl From<KeyshareCreated> for EnclaveEvent {
 }
 
 impl From<ComputationRequested> for EnclaveEvent {
-    fn from(data:ComputationRequested) -> Self {
+    fn from(data: ComputationRequested) -> Self {
         EnclaveEvent::ComputationRequested {
             id: EventId::from(data.clone()),
             data: data.clone(),
@@ -92,8 +92,8 @@ impl From<ComputationRequested> for EnclaveEvent {
     }
 }
 
-impl From<PublicKeyAggregated> for EnclaveEvent{
-    fn from(data:PublicKeyAggregated) -> Self {
+impl From<PublicKeyAggregated> for EnclaveEvent {
+    fn from(data: PublicKeyAggregated) -> Self {
         EnclaveEvent::PublicKeyAggregated {
             id: EventId::from(data.clone()),
             data: data.clone(),
@@ -101,21 +101,21 @@ impl From<PublicKeyAggregated> for EnclaveEvent{
     }
 }
 
-#[derive(Message, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Message, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[rtype(result = "anyhow::Result<()>")]
 pub struct KeyshareCreated {
     pub pubkey: WrappedPublicKeyShare,
     pub e3_id: E3id,
 }
 
-#[derive(Message, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Message, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[rtype(result = "()")]
 pub struct PublicKeyAggregated {
     pub pubkey: WrappedPublicKey,
     pub e3_id: E3id,
 }
 
-#[derive(Message, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Message, Clone, Debug, PartialEq, Eq, Hash, Serialize,Deserialize)]
 #[rtype(result = "()")]
 pub struct ComputationRequested {
     pub e3_id: E3id,

--- a/packages/ciphernode/core/src/fhe.rs
+++ b/packages/ciphernode/core/src/fhe.rs
@@ -6,8 +6,10 @@ use fhe::{
     bfv::{BfvParameters, PublicKey, SecretKey},
     mbfv::{AggregateIter, CommonRandomPoly, PublicKeyShare},
 };
-use fhe_traits::Serialize;
+use fhe_traits::{Deserialize, DeserializeParametrized, Serialize};
 use rand_chacha::ChaCha20Rng;
+use serde::Serializer;
+// use serde::{Deserialize, Serialize};
 
 use crate::ordered_set::OrderedSet;
 
@@ -27,11 +29,29 @@ pub struct GetAggregatePublicKey {
 /// as we use this library elsewhere we only implement traits as we need them
 /// and avoid exposing underlying structures from fhe.rs
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct WrappedPublicKeyShare(pub PublicKeyShare);
+pub struct WrappedPublicKeyShare {
+    inner: PublicKeyShare,
+    params: Arc<BfvParameters>,
+    crp: CommonRandomPoly,
+}
+
+impl WrappedPublicKeyShare {
+    pub fn from_fhe_rs(
+        inner: PublicKeyShare,
+        params: Arc<BfvParameters>,
+        crp: CommonRandomPoly,
+    ) -> Self {
+        Self { inner, params, crp }
+    }
+
+    pub fn clone_inner(&self) -> PublicKeyShare {
+        self.inner.clone()
+    }
+}
 
 impl Ord for WrappedPublicKeyShare {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.0.to_bytes().cmp(&other.0.to_bytes())
+        self.inner.to_bytes().cmp(&other.inner.to_bytes())
     }
 }
 
@@ -43,37 +63,127 @@ impl PartialOrd for WrappedPublicKeyShare {
 
 impl From<WrappedPublicKeyShare> for Vec<u8> {
     fn from(share: WrappedPublicKeyShare) -> Self {
-        share.0.to_bytes()
+        share.inner.to_bytes()
     }
 }
 
 impl Hash for WrappedPublicKeyShare {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.0.to_bytes().hash(state)
+        self.inner.to_bytes().hash(state)
     }
 }
 
-impl WrappedPublicKeyShare {
-    fn clone_inner(&self) -> PublicKeyShare {
-        self.0.clone()
-    } 
+/// Deserialize from serde to WrappedPublicKeyShare
+impl<'de> serde::Deserialize<'de> for WrappedPublicKeyShare {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // Intermediate struct for deserialization
+        #[derive(serde::Deserialize)]
+        struct PublicKeyShareBytes {
+            par_bytes: Vec<u8>,
+            crp_bytes: Vec<u8>,
+            bytes: Vec<u8>,
+        }
+        let PublicKeyShareBytes {
+            par_bytes,
+            crp_bytes,
+            bytes,
+        } = PublicKeyShareBytes::deserialize(deserializer)?;
+        let params = Arc::new(BfvParameters::try_deserialize(&par_bytes).unwrap());
+        let crp =
+            CommonRandomPoly::deserialize(&crp_bytes, &params).map_err(serde::de::Error::custom)?;
+        let inner = PublicKeyShare::deserialize(&bytes, &params, crp.clone())
+            .map_err(serde::de::Error::custom)?;
+        std::result::Result::Ok(WrappedPublicKeyShare::from_fhe_rs(inner, params, crp))
+    }
+}
+
+/// Serialize to intermediate struct
+impl serde::Serialize for WrappedPublicKeyShare {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        // let par = self.0.
+        let bytes = self.inner.to_bytes();
+        let par_bytes = self.params.to_bytes();
+        let crp_bytes = self.params.to_bytes();
+        let mut state = serializer.serialize_struct("PublicKeyShare", 2)?;
+        state.serialize_field("par_bytes", &par_bytes)?;
+        state.serialize_field("crp_bytes", &crp_bytes)?;
+        state.serialize_field("bytes", &bytes)?;
+        state.end()
+    }
 }
 
 /// Wrapped PublicKey. This is wrapped to provide an inflection point
 /// as we use this library elsewhere we only implement traits as we need them
 /// and avoid exposing underlying structures from fhe.rs
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct WrappedPublicKey(pub PublicKey);
+pub struct WrappedPublicKey {
+    inner: PublicKey,
+    params: Arc<BfvParameters>,
+}
+
+impl WrappedPublicKey {
+    pub fn from_fhe_rs(inner: PublicKey, params: Arc<BfvParameters>) -> Self {
+        Self { inner, params }
+    }
+}
+
+impl fhe_traits::Serialize for WrappedPublicKey {
+    fn to_bytes(&self) -> Vec<u8> {
+        self.inner.to_bytes()
+    }
+}
+
+/// Deserialize from serde to WrappedPublicKey
+impl<'de> serde::Deserialize<'de> for WrappedPublicKey {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(serde::Deserialize)]
+        struct PublicKeyBytes {
+            par: Vec<u8>,
+            bytes: Vec<u8>,
+        }
+        let PublicKeyBytes { par, bytes } = PublicKeyBytes::deserialize(deserializer)?;
+        let params = Arc::new(BfvParameters::try_deserialize(&par).unwrap());
+        let inner = PublicKey::from_bytes(&bytes, &params).map_err(serde::de::Error::custom)?;
+        std::result::Result::Ok(WrappedPublicKey::from_fhe_rs(inner, params))
+    }
+}
+
+/// Serialize to intermediate struct
+impl serde::Serialize for WrappedPublicKey {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        // let par = self.0.
+        let bytes = self.inner.to_bytes();
+        let par_bytes = self.params.to_bytes();
+        let mut state = serializer.serialize_struct("PublicKey", 2)?;
+        state.serialize_field("par_bytes", &par_bytes)?;
+        state.serialize_field("bytes", &bytes)?;
+        state.end()
+    }
+}
 
 impl Hash for WrappedPublicKey {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.0.to_bytes().hash(state)
+        self.inner.to_bytes().hash(state)
     }
 }
 
 impl Ord for WrappedPublicKey {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.0.to_bytes().cmp(&other.0.to_bytes())
+        self.inner.to_bytes().cmp(&other.inner.to_bytes())
     }
 }
 
@@ -123,7 +233,10 @@ impl Handler<GenerateKeyshare> for Fhe {
     fn handle(&mut self, _event: GenerateKeyshare, _: &mut Self::Context) -> Self::Result {
         let sk_share = { SecretKey::random(&self.params, &mut self.rng) };
         let pk_share = { PublicKeyShare::new(&sk_share, self.crp.clone(), &mut self.rng)? };
-        Ok((WrappedSecretKey(sk_share), WrappedPublicKeyShare(pk_share)))
+        Ok((
+            WrappedSecretKey(sk_share),
+            WrappedPublicKeyShare::from_fhe_rs(pk_share, self.params.clone(), self.crp.clone()),
+        ))
     }
 }
 
@@ -133,7 +246,10 @@ impl Handler<GetAggregatePublicKey> for Fhe {
     fn handle(&mut self, msg: GetAggregatePublicKey, _: &mut Self::Context) -> Self::Result {
         // Could implement Aggregate for Wrapped keys but that leaks traits
         let public_key: PublicKey = msg.keyshares.iter().map(|k| k.clone_inner()).aggregate()?;
-        Ok(WrappedPublicKey(public_key))
+        Ok(WrappedPublicKey::from_fhe_rs(
+            public_key,
+            self.params.clone(),
+        ))
     }
 }
 

--- a/packages/ciphernode/core/src/fhe.rs
+++ b/packages/ciphernode/core/src/fhe.rs
@@ -82,7 +82,7 @@ impl<'de> serde::Deserialize<'de> for WrappedPublicKeyShare {
     where
         D: serde::Deserializer<'de>,
     {
-        // Intermediate struct for deserialization
+        // Intermediate struct of bytes for deserialization
         #[derive(serde::Deserialize)]
         struct PublicKeyShareBytes {
             par_bytes: Vec<u8>,
@@ -99,11 +99,12 @@ impl<'de> serde::Deserialize<'de> for WrappedPublicKeyShare {
             CommonRandomPoly::deserialize(&crp_bytes, &params).map_err(serde::de::Error::custom)?;
         let inner = PublicKeyShare::deserialize(&bytes, &params, crp.clone())
             .map_err(serde::de::Error::custom)?;
+        // TODO: how do we create an invariant that the deserialized params match the global params?
         std::result::Result::Ok(WrappedPublicKeyShare::from_fhe_rs(inner, params, crp))
     }
 }
 
-/// Serialize to intermediate struct
+/// Serialize to serde bytes representation
 impl serde::Serialize for WrappedPublicKeyShare {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -113,6 +114,7 @@ impl serde::Serialize for WrappedPublicKeyShare {
         let bytes = self.inner.to_bytes();
         let par_bytes = self.params.to_bytes();
         let crp_bytes = self.params.to_bytes();
+        // Intermediate struct of bytes
         let mut state = serializer.serialize_struct("PublicKeyShare", 2)?;
         state.serialize_field("par_bytes", &par_bytes)?;
         state.serialize_field("crp_bytes", &crp_bytes)?;
@@ -148,6 +150,7 @@ impl<'de> serde::Deserialize<'de> for WrappedPublicKey {
     where
         D: serde::Deserializer<'de>,
     {
+        // Intermediate struct of bytes for deserialization
         #[derive(serde::Deserialize)]
         struct PublicKeyBytes {
             par: Vec<u8>,
@@ -161,16 +164,16 @@ impl<'de> serde::Deserialize<'de> for WrappedPublicKey {
     }
 }
 
-/// Serialize to bytes representation
+/// Serialize to serde bytes representation
 impl serde::Serialize for WrappedPublicKey {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
         use serde::ser::SerializeStruct;
-        // let par = self.0.
         let bytes = self.inner.to_bytes();
         let par_bytes = self.params.to_bytes();
+        // Intermediate struct of bytes
         let mut state = serializer.serialize_struct("PublicKey", 2)?;
         state.serialize_field("par_bytes", &par_bytes)?;
         state.serialize_field("bytes", &bytes)?;

--- a/packages/ciphernode/core/src/fhe.rs
+++ b/packages/ciphernode/core/src/fhe.rs
@@ -9,7 +9,6 @@ use fhe::{
 use fhe_traits::{Deserialize, DeserializeParametrized, Serialize};
 use rand_chacha::ChaCha20Rng;
 use serde::Serializer;
-// use serde::{Deserialize, Serialize};
 
 use crate::ordered_set::OrderedSet;
 

--- a/packages/ciphernode/core/src/lib.rs
+++ b/packages/ciphernode/core/src/lib.rs
@@ -6,12 +6,12 @@ mod ciphernode;
 mod committee;
 mod committee_key;
 mod data;
+mod enclave_contract;
 mod eventbus;
 mod events;
 mod fhe;
 mod ordered_set;
 mod p2p;
-mod enclave_contract;
 
 // pub struct Core {
 //     pub name: String,
@@ -92,7 +92,11 @@ mod tests {
         mut rng: ChaCha20Rng,
     ) -> Result<(WrappedPublicKeyShare, ChaCha20Rng)> {
         let sk = SecretKey::random(&params, &mut rng);
-        let pk = WrappedPublicKeyShare(PublicKeyShare::new(&sk, crp.clone(), &mut rng)?);
+        let pk = WrappedPublicKeyShare::from_fhe_rs(
+            PublicKeyShare::new(&sk, crp.clone(), &mut rng)?,
+            params.clone(),
+            crp,
+        );
         Ok((pk, rng))
     }
 
@@ -168,7 +172,7 @@ mod tests {
 
         let aggregated: PublicKey = vec![p1.clone(), p2.clone(), p3.clone()]
             .iter()
-            .map(|k| k.0.clone())
+            .map(|k| k.clone_inner())
             .aggregate()?;
 
         assert_eq!(history.len(), 5);
@@ -194,7 +198,7 @@ mod tests {
                     e3_id: e3_id.clone()
                 }),
                 EnclaveEvent::from(PublicKeyAggregated {
-                    pubkey: WrappedPublicKey(aggregated),
+                    pubkey: WrappedPublicKey::from_fhe_rs(aggregated, params),
                     e3_id: e3_id.clone()
                 })
             ]
@@ -209,6 +213,6 @@ mod tests {
         // 1. command channel
         // 2. event channel
         // Pass them to the p2p actor
-        // connect the p2p actor to the event bus actor and monitor which events are broadcast 
+        // connect the p2p actor to the event bus actor and monitor which events are broadcast
     }
 }


### PR DESCRIPTION
This enables serde serialization / deserialization on our wrapped fhe structures. This is required in order to parse bytes coming in from libp2p. 

In order to make this work I had to store copies of the params and crp within the wrapped struct. Ideally we would use the internal types and reach in and take the data but that is not possible without further downstream changes which we can refactor in later.  