### PR TITLE
Start ciphernode binary example first commit (wip)

### DIFF
--- a/packages/ciphernode/Cargo.lock
+++ b/packages/ciphernode/Cargo.lock
@@ -929,7 +929,9 @@ dependencies = [
 name = "enclave_node"
 version = "0.1.0"
 dependencies = [
+ "actix-rt",
  "async-std",
+ "enclave-core",
  "eth",
  "fhe",
  "fhe-traits",

--- a/packages/ciphernode/core/src/lib.rs
+++ b/packages/ciphernode/core/src/lib.rs
@@ -13,6 +13,16 @@ mod fhe;
 mod ordered_set;
 mod p2p;
 
+pub use data::*;
+pub use ciphernode::*;
+pub use committee::*;
+pub use committee_key::*;
+pub use eventbus::*;
+pub use events::*;
+pub use fhe::*;
+pub use p2p::*;
+pub use actix::prelude::*;
+
 // pub struct Core {
 //     pub name: String,
 // }

--- a/packages/ciphernode/enclave_node/Cargo.toml
+++ b/packages/ciphernode/enclave_node/Cargo.toml
@@ -10,8 +10,10 @@ repository = "https://github.com/gnosisguild/enclave/packages/ciphernode"
 [dependencies]
 eth = { path = "../eth" }
 p2p = { path = "../p2p" }
+enclave-core = { path = "../core" }
 async-std = "1.12.0"
 fhe = { git = "https://github.com/gnosisguild/fhe.rs", version = "0.1.0-beta.7" }
 fhe-traits = { git = "https://github.com/gnosisguild/fhe.rs", version = "0.1.0-beta.7" }
 fhe-util = { git = "https://github.com/gnosisguild/fhe.rs", version = "0.1.0-beta.7" }
 tokio = { version = "1.38", features = ["full"] }
+actix-rt = "2.10.0"

--- a/packages/ciphernode/enclave_node/src/bin/ciphernode.rs
+++ b/packages/ciphernode/enclave_node/src/bin/ciphernode.rs
@@ -14,7 +14,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let data = Data::new(true).start(); // TODO: Use a sled backed Data Actor
     let _node = Ciphernode::new(bus.clone(), fhe.clone(), data.clone()).start();
     let (_, h) = P2p::spawn_libp2p(bus.clone())?;
-    println!("CipherAg");
+    println!("Ciphernode");
     let _ = tokio::join!(h);
     Ok(())
 }

--- a/packages/ciphernode/enclave_node/src/bin/ciphernode.rs
+++ b/packages/ciphernode/enclave_node/src/bin/ciphernode.rs
@@ -1,0 +1,20 @@
+use std::error::Error;
+
+use enclave_core::Actor;
+use enclave_core::Ciphernode;
+use enclave_core::Data;
+use enclave_core::EventBus;
+use enclave_core::Fhe;
+use enclave_core::P2p;
+
+#[actix_rt::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let fhe = Fhe::try_default()?.start();
+    let bus = EventBus::new(true).start();
+    let data = Data::new(true).start(); // TODO: Use a sled backed Data Actor
+    let _node = Ciphernode::new(bus.clone(), fhe.clone(), data.clone()).start();
+    let (_, h) = P2p::spawn_libp2p(bus.clone())?;
+    println!("CipherAg");
+    let _ = tokio::join!(h);
+    Ok(())
+}


### PR DESCRIPTION
Setting up a binary node over libp2p as a concrete example of the actor model setup.

- over exporting some stuff from core for now in order to get things working
- setup libp2p within the event bus system 
- untested for now as we don't have a way to manually test this

Still to do:

- setup libp2p client that dispatches some test events on the network