### PR TITLE
Setup node bin

### DIFF
--- a/packages/ciphernode/core/src/eventbus.rs
+++ b/packages/ciphernode/core/src/eventbus.rs
@@ -83,7 +83,7 @@ impl Handler<EnclaveEvent> for EventBus {
             // We have seen this before
             return;
         }
-
+        
         // TODO: How can we ensure the event we see is coming in in the correct order?
         if let Some(listeners) = self.listeners.get("*") {
             for listener in listeners {

--- a/packages/ciphernode/core/src/fhe.rs
+++ b/packages/ciphernode/core/src/fhe.rs
@@ -113,7 +113,7 @@ impl serde::Serialize for WrappedPublicKeyShare {
         use serde::ser::SerializeStruct;
         let bytes = self.inner.to_bytes();
         let par_bytes = self.params.to_bytes();
-        let crp_bytes = self.params.to_bytes();
+        let crp_bytes = self.crp.to_bytes();
         // Intermediate struct of bytes
         let mut state = serializer.serialize_struct("PublicKeyShare", 2)?;
         state.serialize_field("par_bytes", &par_bytes)?;
@@ -122,6 +122,7 @@ impl serde::Serialize for WrappedPublicKeyShare {
         state.end()
     }
 }
+
 
 /// Wrapped PublicKey. This is wrapped to provide an inflection point
 /// as we use this library elsewhere we only implement traits as we need them

--- a/packages/ciphernode/core/src/lib.rs
+++ b/packages/ciphernode/core/src/lib.rs
@@ -12,6 +12,19 @@ mod events;
 mod fhe;
 mod ordered_set;
 mod p2p;
+mod logger;
+
+// TODO: this is too permissive
+pub use data::*;
+pub use ciphernode::*;
+pub use committee::*;
+pub use committee_key::*;
+pub use eventbus::*;
+pub use events::*;
+pub use fhe::*;
+pub use p2p::*;
+pub use actix::prelude::*;
+pub use logger::*;
 
 pub use data::*;
 pub use ciphernode::*;

--- a/packages/ciphernode/core/src/logger.rs
+++ b/packages/ciphernode/core/src/logger.rs
@@ -1,0 +1,27 @@
+use actix::{Actor, Addr, Context, Handler};
+
+use crate::{EnclaveEvent, EventBus, Subscribe};
+
+pub struct SimpleLogger;
+
+impl SimpleLogger {
+    pub fn attach(bus:Addr<EventBus>) -> Addr<Self>{
+       let addr = Self.start();
+       bus.do_send(Subscribe { 
+           listener:addr.clone().recipient(),
+           event_type: "*".to_string() 
+       });
+       addr
+    }
+}
+
+impl Actor for SimpleLogger {
+    type Context = Context<Self>;
+}
+
+impl Handler<EnclaveEvent> for SimpleLogger {
+    type Result = ();
+    fn handle(&mut self, msg: EnclaveEvent, _: &mut Self::Context) -> Self::Result {
+        println!("{}", msg);
+    }
+}

--- a/packages/ciphernode/core/src/p2p.rs
+++ b/packages/ciphernode/core/src/p2p.rs
@@ -2,12 +2,7 @@ use std::{collections::HashSet, error::Error};
 
 /// Actor for connecting to an libp2p client via it's mpsc channel interface
 /// This Actor should be responsible for
-/// 1. Sending and Recieving Vec<u8> messages with libp2p
-/// 2. Converting between Vec<u8> and EnclaveEvents::Xxxxxxxxx()
-/// 3. Broadcasting over the local eventbus
-/// 4. Listening to the local eventbus for messages to be published to libp2p
 use actix::prelude::*;
-use anyhow::anyhow;
 use p2p::EnclaveRouter;
 use tokio::sync::mpsc::{Receiver, Sender};
 

--- a/packages/ciphernode/enclave_node/src/bin/ciphernode.rs
+++ b/packages/ciphernode/enclave_node/src/bin/ciphernode.rs
@@ -1,18 +1,21 @@
-use std::error::Error;
-
 use enclave_core::Actor;
 use enclave_core::Ciphernode;
+use enclave_core::CommitteeManager;
 use enclave_core::Data;
 use enclave_core::EventBus;
 use enclave_core::Fhe;
 use enclave_core::P2p;
+use enclave_core::SimpleLogger;
+use std::error::Error;
 
 #[actix_rt::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     let fhe = Fhe::try_default()?.start();
     let bus = EventBus::new(true).start();
     let data = Data::new(true).start(); // TODO: Use a sled backed Data Actor
-    let _node = Ciphernode::new(bus.clone(), fhe.clone(), data.clone()).start();
+    SimpleLogger::attach(bus.clone());
+    Ciphernode::attach(bus.clone(), fhe.clone(), data.clone());
+    CommitteeManager::attach(bus.clone(), fhe.clone());
     let (_, h) = P2p::spawn_libp2p(bus.clone())?;
     println!("Ciphernode");
     let _ = tokio::join!(h);

--- a/packages/ciphernode/enclave_node/src/bin/cmd.rs
+++ b/packages/ciphernode/enclave_node/src/bin/cmd.rs
@@ -1,0 +1,39 @@
+use std::error::Error;
+
+use enclave_core::Actor;
+use enclave_core::ComputationRequested;
+use enclave_core::E3id;
+use enclave_core::EnclaveEvent;
+use enclave_core::EventBus;
+use enclave_core::P2p;
+use tokio::{
+    self,
+    io::{self, AsyncBufReadExt, BufReader},
+};
+
+#[actix_rt::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let bus = EventBus::new(true).start();
+    let (_, t1) = P2p::spawn_libp2p(bus.clone())?;
+    let mut stdin = BufReader::new(io::stdin()).lines();
+    let t2 = tokio::spawn(async move {
+        let mut id: u32 = 1000;
+        while let Ok(Some(line)) = stdin.next_line().await {
+            match line.as_str() {
+                "test" => {
+                    id += 1;
+                    bus.do_send(EnclaveEvent::from(ComputationRequested {
+                        e3_id: E3id::from(id),
+                        nodecount: 3,
+                        threshold: 3,
+                        sortition_seed: 100,
+                    }));
+                }
+                _ => println!("Unknown command"),
+            }
+        }
+    });
+
+    let _ = tokio::join!(t1, t2);
+    Ok(())
+}

--- a/packages/ciphernode/p2p/src/lib.rs
+++ b/packages/ciphernode/p2p/src/lib.rs
@@ -127,7 +127,6 @@ impl EnclaveRouter {
         loop {
             select! {
                 Some(line) = self.cmd_rx.recv() => {
-                    println!("Receiving input");
                     if let Err(e) = self.swarm.as_mut().unwrap()
                         .behaviour_mut().gossipsub
                         .publish(self.topic.as_mut().unwrap().clone(), line) {
@@ -153,9 +152,9 @@ impl EnclaveRouter {
                         message,
                     })) => {
                         println!(
-                            "Got message: '{}' with id: {id} from peer: {peer_id}",
-                            String::from_utf8_lossy(&message.data),
+                            "Got message with id: {id} from peer: {peer_id}",
                         );
+                        println!("{:?}", message);
                         self.evt_tx.send(message.data).await?;
                     },
                     SwarmEvent::NewListenAddr { address, .. } => {


### PR DESCRIPTION
This makes it possible to do basic distributed key aggregation between separate binaries using the actor model architecture.

To test:


Enter the `enclave_node` sub project

Launch **three** of these in separate terminals:

```
cargo run --bin ciphernode
```

In a fourth run the following:

```
cargo run --bin cmd
```

Once they have all synced in the `cmd` window type `test` and hit enter this will send a EnclaveEvent to the others to request a computation. 

Notice the last event was an aggregation event.

![image](https://github.com/user-attachments/assets/92b06a81-343c-4bfe-83eb-d517509736de)
