### PR TITLE
Move all wrapped types out to module for deletion

### DIFF
--- a/packages/ciphernode/core/src/ciphernode.rs
+++ b/packages/ciphernode/core/src/ciphernode.rs
@@ -1,10 +1,5 @@
 use crate::{
-    data::{Data, Insert},
-    eventbus::EventBus,
-    events::{ComputationRequested, EnclaveEvent, KeyshareCreated},
-    fhe::{Fhe, GenerateKeyshare},
-    DecryptCiphertext, DecryptionRequested, DecryptionshareCreated, Get, Subscribe,
-    WrappedSecretKey,
+    data::{Data, Insert}, eventbus::EventBus, events::{ComputationRequested, EnclaveEvent, KeyshareCreated}, fhe::{Fhe, GenerateKeyshare}, wrapped::WrappedSecretKey, DecryptCiphertext, DecryptionRequested, DecryptionshareCreated, Get, Subscribe
 };
 use actix::prelude::*;
 use anyhow::Result;

--- a/packages/ciphernode/core/src/committee_key.rs
+++ b/packages/ciphernode/core/src/committee_key.rs
@@ -1,7 +1,7 @@
 use crate::{
     eventbus::EventBus,
     events::{E3id, EnclaveEvent, KeyshareCreated, PublicKeyAggregated},
-    fhe::{Fhe, GetAggregatePublicKey, WrappedPublicKey, WrappedPublicKeyShare}, ordered_set::OrderedSet,
+    fhe::{Fhe, GetAggregatePublicKey}, ordered_set::OrderedSet, wrapped::{WrappedPublicKey, WrappedPublicKeyShare},
 };
 use actix::prelude::*;
 use anyhow::{anyhow, Result};

--- a/packages/ciphernode/core/src/events.rs
+++ b/packages/ciphernode/core/src/events.rs
@@ -1,7 +1,4 @@
-use crate::{
-    fhe::{WrappedPublicKey, WrappedPublicKeyShare},
-    WrappedCiphertext, WrappedDecryptionShare,
-};
+use crate::wrapped::{WrappedCiphertext, WrappedDecryptionShare, WrappedPublicKey, WrappedPublicKeyShare};
 use actix::Message;
 use bincode;
 use serde::{Deserialize, Serialize};
@@ -69,16 +66,15 @@ pub enum EnclaveEvent {
     },
     DecryptionRequested {
         id: EventId,
-        data: DecryptionRequested
+        data: DecryptionRequested,
     },
     DecryptionshareCreated {
         id: EventId,
-        data: DecryptionshareCreated
-    }
-    // CommitteeSelected,
-    // OutputDecrypted,
-    // CiphernodeRegistered,
-    // CiphernodeDeregistered,
+        data: DecryptionshareCreated,
+    }, // CommitteeSelected,
+       // OutputDecrypted,
+       // CiphernodeRegistered,
+       // CiphernodeDeregistered,
 }
 
 impl EnclaveEvent {
@@ -102,7 +98,7 @@ impl From<EnclaveEvent> for EventId {
             EnclaveEvent::ComputationRequested { id, .. } => id,
             EnclaveEvent::PublicKeyAggregated { id, .. } => id,
             EnclaveEvent::DecryptionRequested { id, .. } => id,
-            EnclaveEvent::DecryptionshareCreated { id, .. } => id
+            EnclaveEvent::DecryptionshareCreated { id, .. } => id,
         }
     }
 }
@@ -133,7 +129,6 @@ impl From<PublicKeyAggregated> for EnclaveEvent {
         }
     }
 }
-
 
 impl From<DecryptionRequested> for EnclaveEvent {
     fn from(data: DecryptionRequested) -> Self {
@@ -166,12 +161,11 @@ pub struct KeyshareCreated {
     pub e3_id: E3id,
 }
 
-
 #[derive(Message, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[rtype(result = "anyhow::Result<()>")]
-pub struct  DecryptionshareCreated {
+pub struct DecryptionshareCreated {
     pub decryption_share: WrappedDecryptionShare,
-    pub e3_id: E3id
+    pub e3_id: E3id,
 }
 
 #[derive(Message, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -230,7 +224,7 @@ mod tests {
     use rand::SeedableRng;
     use rand_chacha::ChaCha20Rng;
 
-    use crate::{events::extract_enclave_event_name, E3id, KeyshareCreated, WrappedPublicKeyShare};
+    use crate::{events::extract_enclave_event_name, wrapped::WrappedPublicKeyShare, E3id, KeyshareCreated};
 
     use super::EnclaveEvent;
 

--- a/packages/ciphernode/core/src/fhe.rs
+++ b/packages/ciphernode/core/src/fhe.rs
@@ -1,357 +1,46 @@
-use std::{cmp::Ordering, hash::Hash, mem, sync::Arc};
-
-use crate::ordered_set::OrderedSet;
+use crate::{
+    ordered_set::OrderedSet,
+    wrapped::{
+        WrappedCiphertext, WrappedDecryptionShare, WrappedPlaintext, WrappedPublicKey, WrappedPublicKeyShare, WrappedSecretKey
+    },
+};
 use actix::{Actor, Context, Handler, Message};
 use anyhow::*;
 use fhe::{
-    bfv::{BfvParameters, BfvParametersBuilder, Ciphertext, Plaintext, PublicKey, SecretKey},
+    bfv::{BfvParameters, BfvParametersBuilder, Plaintext, PublicKey, SecretKey},
     mbfv::{AggregateIter, CommonRandomPoly, DecryptionShare, PublicKeyShare},
 };
-use fhe_traits::{Deserialize, DeserializeParametrized, Serialize};
 use rand::SeedableRng;
 use rand_chacha::ChaCha20Rng;
-use serde::Serializer;
-
-// TODO: remove all this wrapping and serialization/deserialization code by ensuring everything from fhe.rs has a to_bytes() and deserialize() -> T methods and return only Vec<u8> outside of this actor
+use std::{hash::Hash, sync::Arc};
 
 #[derive(Message, Clone, Debug, PartialEq, Eq, Hash)]
 #[rtype(result = "Result<(WrappedSecretKey, WrappedPublicKeyShare)>")]
+// TODO: Result<(Vec<u8>,Vec<u8>)>
 pub struct GenerateKeyshare {
     // responder_pk: Vec<u8>, // TODO: use this to encrypt the secret data
 }
 
 #[derive(Message, Clone, Debug, PartialEq, Eq)]
 #[rtype(result = "Result<(WrappedPublicKey)>")]
+// TODO: Result<Vec<u8>>
 pub struct GetAggregatePublicKey {
     pub keyshares: OrderedSet<WrappedPublicKeyShare>,
 }
 
 #[derive(Message, Clone, Debug, PartialEq, Eq)]
 #[rtype(result = "Result<(WrappedPlaintext)>")]
+// TODO: Result<Vec<u8>>
 pub struct GetAggregatePlaintext {
     pub decryptions: OrderedSet<WrappedDecryptionShare>,
 }
 
 #[derive(Message, Clone, Debug, PartialEq, Eq)]
 #[rtype(result = "Result<(WrappedDecryptionShare)>")]
+// TODO: Result<Vec<u8>>
 pub struct DecryptCiphertext {
     pub unsafe_secret: WrappedSecretKey,
     pub ciphertext: WrappedCiphertext,
-}
-
-/// Wrapped PublicKeyShare. This is wrapped to provide an inflection point
-/// as we use this library elsewhere we only implement traits as we need them
-/// and avoid exposing underlying structures from fhe.rs
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct WrappedPublicKeyShare {
-    inner: PublicKeyShare,
-    // We need to hold copies of the params and crp in order to effectively serialize and
-    // deserialize the wrapped type
-    params: Arc<BfvParameters>,
-    crp: CommonRandomPoly,
-}
-
-impl WrappedPublicKeyShare {
-    /// Public function to serialize specifically from the wrapped type including types that are
-    /// private from outside the crate
-    pub fn from_fhe_rs(
-        inner: PublicKeyShare,
-        params: Arc<BfvParameters>,
-        crp: CommonRandomPoly,
-    ) -> Self {
-        Self { inner, params, crp }
-    }
-
-    pub fn clone_inner(&self) -> PublicKeyShare {
-        self.inner.clone()
-    }
-}
-
-impl Ord for WrappedPublicKeyShare {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.inner.to_bytes().cmp(&other.inner.to_bytes())
-    }
-}
-
-impl PartialOrd for WrappedPublicKeyShare {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl From<WrappedPublicKeyShare> for Vec<u8> {
-    fn from(share: WrappedPublicKeyShare) -> Self {
-        share.inner.to_bytes()
-    }
-}
-
-impl Hash for WrappedPublicKeyShare {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.inner.to_bytes().hash(state)
-    }
-}
-
-/// Deserialize from serde to WrappedPublicKeyShare
-impl<'de> serde::Deserialize<'de> for WrappedPublicKeyShare {
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        // Intermediate struct of bytes for deserialization
-        #[derive(serde::Deserialize)]
-        struct PublicKeyShareBytes {
-            par_bytes: Vec<u8>,
-            crp_bytes: Vec<u8>,
-            bytes: Vec<u8>,
-        }
-        let PublicKeyShareBytes {
-            par_bytes,
-            crp_bytes,
-            bytes,
-        } = PublicKeyShareBytes::deserialize(deserializer)?;
-        let params = Arc::new(BfvParameters::try_deserialize(&par_bytes).unwrap());
-        let crp =
-            CommonRandomPoly::deserialize(&crp_bytes, &params).map_err(serde::de::Error::custom)?;
-        let inner = PublicKeyShare::deserialize(&bytes, &params, crp.clone())
-            .map_err(serde::de::Error::custom)?;
-        // TODO: how do we create an invariant that the deserialized params match the global params?
-        std::result::Result::Ok(WrappedPublicKeyShare::from_fhe_rs(inner, params, crp))
-    }
-}
-
-/// Serialize to serde bytes representation
-impl serde::Serialize for WrappedPublicKeyShare {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        use serde::ser::SerializeStruct;
-        let bytes = self.inner.to_bytes();
-        let par_bytes = self.params.to_bytes();
-        let crp_bytes = self.crp.to_bytes();
-        // Intermediate struct of bytes
-        let mut state = serializer.serialize_struct("PublicKeyShare", 3)?;
-        state.serialize_field("par_bytes", &par_bytes)?;
-        state.serialize_field("crp_bytes", &crp_bytes)?;
-        state.serialize_field("bytes", &bytes)?;
-        state.end()
-    }
-}
-
-/// Wrapped PublicKey. This is wrapped to provide an inflection point
-/// as we use this library elsewhere we only implement traits as we need them
-/// and avoid exposing underlying structures from fhe.rs
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct WrappedPublicKey {
-    inner: PublicKey,
-    params: Arc<BfvParameters>,
-}
-
-impl WrappedPublicKey {
-    pub fn from_fhe_rs(inner: PublicKey, params: Arc<BfvParameters>) -> Self {
-        Self { inner, params }
-    }
-}
-
-impl fhe_traits::Serialize for WrappedPublicKey {
-    fn to_bytes(&self) -> Vec<u8> {
-        self.inner.to_bytes()
-    }
-}
-
-/// Deserialize from serde to WrappedPublicKey
-impl<'de> serde::Deserialize<'de> for WrappedPublicKey {
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        // Intermediate struct of bytes for deserialization
-        #[derive(serde::Deserialize)]
-        struct PublicKeyBytes {
-            par: Vec<u8>,
-            bytes: Vec<u8>,
-        }
-        let PublicKeyBytes { par, bytes } = PublicKeyBytes::deserialize(deserializer)?;
-        let params = Arc::new(BfvParameters::try_deserialize(&par).unwrap()); // TODO: fix errors
-        let inner = PublicKey::from_bytes(&bytes, &params).map_err(serde::de::Error::custom)?;
-        // TODO: how do we create an invariant that the deserialized params match the global params?
-        std::result::Result::Ok(WrappedPublicKey::from_fhe_rs(inner, params))
-    }
-}
-
-/// Serialize to serde bytes representation
-impl serde::Serialize for WrappedPublicKey {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        use serde::ser::SerializeStruct;
-        let bytes = self.inner.to_bytes();
-        let par_bytes = self.params.to_bytes();
-        // Intermediate struct of bytes
-        let mut state = serializer.serialize_struct("PublicKey", 2)?;
-        state.serialize_field("par_bytes", &par_bytes)?;
-        state.serialize_field("bytes", &bytes)?;
-        state.end()
-    }
-}
-
-impl Hash for WrappedPublicKey {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.inner.to_bytes().hash(state)
-    }
-}
-
-impl Ord for WrappedPublicKey {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.inner.to_bytes().cmp(&other.inner.to_bytes())
-    }
-}
-
-impl PartialOrd for WrappedPublicKey {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-/// Wrapped SecretKey. This is wrapped to provide an inflection point
-/// as we use this library elsewhere we only implement traits as we need them
-/// and avoid exposing underlying structures from fhe.rs
-// We should favor consuming patterns and avoid cloning and copying this value around in memory.
-// Underlying key Zeroizes on drop
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct WrappedSecretKey {
-    inner: SecretKey,
-    params: Arc<BfvParameters>,
-}
-
-impl WrappedSecretKey {
-    pub fn from_fhe_rs(inner: SecretKey, params: Arc<BfvParameters>) -> Self {
-        Self { inner, params }
-    }
-}
-
-#[derive(serde::Serialize, serde::Deserialize)]
-struct SecretKeyData {
-    coeffs: Box<[i64]>,
-    par: Vec<u8>,
-}
-
-impl WrappedSecretKey {
-    pub fn unsafe_serialize(&self) -> Result<Vec<u8>> {
-        Ok(bincode::serialize(&SecretKeyData {
-            coeffs: self.inner.coeffs.clone(),
-            par: self.params.clone().to_bytes(),
-        })?)
-    }
-
-    pub fn deserialize(bytes: Vec<u8>) -> Result<WrappedSecretKey> {
-        let SecretKeyData { coeffs, par } = bincode::deserialize(&bytes)?;
-        let params = Arc::new(BfvParameters::try_deserialize(&par).unwrap());
-        Ok(WrappedSecretKey::from_fhe_rs(
-            SecretKey::new(coeffs.to_vec(), &params),
-            params,
-        ))
-    }
-}
-
-/// Wrapped Ciphertext. This is wrapped to provide an inflection point
-/// as we use this library elsewhere we only implement traits as we need them
-/// and avoid exposing underlying structures from fhe.rs
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct WrappedCiphertext {
-    inner: Ciphertext,
-    params: Arc<BfvParameters>,
-}
-
-impl WrappedCiphertext {
-    pub fn from_fhe_rs(inner: Ciphertext, params: Arc<BfvParameters>) -> Self {
-        Self { inner, params }
-    }
-}
-
-impl Hash for WrappedCiphertext {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.inner.to_bytes().hash(state)
-    }
-}
-
-/// Deserialize from serde to WrappedPublicKey
-impl<'de> serde::Deserialize<'de> for WrappedCiphertext {
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        // Intermediate struct of bytes for deserialization
-        #[derive(serde::Deserialize)]
-        struct DeserializedBytes {
-            par: Vec<u8>,
-            bytes: Vec<u8>,
-        }
-        let DeserializedBytes { par, bytes } = DeserializedBytes::deserialize(deserializer)?;
-        let params = Arc::new(BfvParameters::try_deserialize(&par).unwrap());
-        let inner = Ciphertext::from_bytes(&bytes, &params).map_err(serde::de::Error::custom)?;
-        std::result::Result::Ok(WrappedCiphertext::from_fhe_rs(inner, params))
-    }
-}
-impl serde::Serialize for WrappedCiphertext {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        use serde::ser::SerializeStruct;
-        let bytes = self.inner.to_bytes();
-        let par_bytes = self.params.to_bytes();
-        // Intermediate struct of bytes
-        let mut state = serializer.serialize_struct("Ciphertext", 2)?;
-        state.serialize_field("par_bytes", &par_bytes)?;
-        state.serialize_field("bytes", &bytes)?;
-        state.end()
-    }
-}
-
-#[derive(
-    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
-)]
-pub struct WrappedDecryptionShare {
-    inner: Vec<u8>,
-    params: Vec<u8>,
-    ct: Vec<u8>,
-}
-
-impl WrappedDecryptionShare {
-    pub fn from_fhe_rs(
-        inner: DecryptionShare,
-        params: Arc<BfvParameters>,
-        ct: Arc<Ciphertext>,
-    ) -> Self {
-        // Have to serialize immediately in order to clone etc.
-        let inner_bytes = inner.to_bytes();
-        let params_bytes = params.to_bytes();
-        let ct_bytes = ct.to_bytes();
-        Self {
-            inner: inner_bytes,
-            params: params_bytes,
-            ct: ct_bytes,
-        }
-    }
-
-    pub fn try_inner(self) -> Result<DecryptionShare> {
-        let params = Arc::new(BfvParameters::try_deserialize(&self.params)?);
-        let ct = Arc::new(Ciphertext::from_bytes(&self.ct, &params)?);
-        Ok(DecryptionShare::deserialize(&self.inner, &params, ct)?)
-    }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct WrappedPlaintext {
-    inner: Plaintext,
-}
-
-impl WrappedPlaintext {
-    pub fn from_fhe_rs(inner: Plaintext /* params: Arc<BfvParameters> */) -> Self {
-        Self { inner }
-    }
 }
 
 /// Fhe library adaptor. All FHE computations should happen through this actor.

--- a/packages/ciphernode/core/src/lib.rs
+++ b/packages/ciphernode/core/src/lib.rs
@@ -13,6 +13,7 @@ mod fhe;
 mod logger;
 mod ordered_set;
 mod p2p;
+mod wrapped;
 
 // TODO: this is too permissive
 pub use actix::prelude::*;
@@ -56,18 +57,16 @@ pub use p2p::*;
 // TODO: move these out to a test folder
 #[cfg(test)]
 mod tests {
-    use std::{sync::Arc, time::Duration};
-
     use crate::{
         ciphernode::Ciphernode,
         committee::CommitteeManager,
         data::{Data, GetLog},
         eventbus::{EventBus, GetHistory, Subscribe},
         events::{ComputationRequested, E3id, EnclaveEvent, KeyshareCreated, PublicKeyAggregated},
-        fhe::{Fhe, WrappedPublicKey, WrappedPublicKeyShare},
+        fhe::Fhe,
         p2p::P2p,
-        DecryptionRequested, DecryptionshareCreated, ResetHistory, WrappedCiphertext,
-        WrappedDecryptionShare,
+        wrapped::{WrappedCiphertext, WrappedDecryptionShare, WrappedPublicKey, WrappedPublicKeyShare},
+        DecryptionRequested, DecryptionshareCreated, ResetHistory,
     };
     use actix::prelude::*;
     use anyhow::*;
@@ -78,6 +77,7 @@ mod tests {
     use fhe_traits::{FheEncoder, FheEncrypter};
     use rand::SeedableRng;
     use rand_chacha::ChaCha20Rng;
+    use std::{sync::Arc, time::Duration};
     use tokio::sync::Mutex;
     use tokio::{sync::mpsc::channel, time::sleep};
 

--- a/packages/ciphernode/core/src/wrapped/ciphertext.rs
+++ b/packages/ciphernode/core/src/wrapped/ciphertext.rs
@@ -1,0 +1,59 @@
+use fhe::bfv::{BfvParameters, Ciphertext};
+use fhe_traits::{Deserialize, DeserializeParametrized, Serialize};
+use serde::Serializer;
+use std::{hash::Hash, sync::Arc};
+
+/// Wrapped Ciphertext. This is wrapped to provide an inflection point
+/// as we use this library elsewhere we only implement traits as we need them
+/// and avoid exposing underlying structures from fhe.rs
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WrappedCiphertext {
+    pub inner: Ciphertext,
+    pub params: Arc<BfvParameters>,
+}
+
+impl WrappedCiphertext {
+    pub fn from_fhe_rs(inner: Ciphertext, params: Arc<BfvParameters>) -> Self {
+        Self { inner, params }
+    }
+}
+
+impl Hash for WrappedCiphertext {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.inner.to_bytes().hash(state)
+    }
+}
+
+/// Deserialize from serde to WrappedPublicKey
+impl<'de> serde::Deserialize<'de> for WrappedCiphertext {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // Intermediate struct of bytes for deserialization
+        #[derive(serde::Deserialize)]
+        struct DeserializedBytes {
+            par: Vec<u8>,
+            bytes: Vec<u8>,
+        }
+        let DeserializedBytes { par, bytes } = DeserializedBytes::deserialize(deserializer)?;
+        let params = Arc::new(BfvParameters::try_deserialize(&par).unwrap());
+        let inner = Ciphertext::from_bytes(&bytes, &params).map_err(serde::de::Error::custom)?;
+        std::result::Result::Ok(WrappedCiphertext::from_fhe_rs(inner, params))
+    }
+}
+impl serde::Serialize for WrappedCiphertext {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let bytes = self.inner.to_bytes();
+        let par_bytes = self.params.to_bytes();
+        // Intermediate struct of bytes
+        let mut state = serializer.serialize_struct("Ciphertext", 2)?;
+        state.serialize_field("par_bytes", &par_bytes)?;
+        state.serialize_field("bytes", &bytes)?;
+        state.end()
+    }
+}

--- a/packages/ciphernode/core/src/wrapped/decryption_share.rs
+++ b/packages/ciphernode/core/src/wrapped/decryption_share.rs
@@ -1,0 +1,40 @@
+use anyhow::*;
+use fhe::{
+    bfv::{BfvParameters, Ciphertext},
+    mbfv::DecryptionShare,
+};
+use fhe_traits::{Deserialize, DeserializeParametrized, Serialize};
+use std::sync::Arc;
+
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
+)]
+pub struct WrappedDecryptionShare {
+    inner: Vec<u8>,
+    params: Vec<u8>,
+    ct: Vec<u8>,
+}
+
+impl WrappedDecryptionShare {
+    pub fn from_fhe_rs(
+        inner: DecryptionShare,
+        params: Arc<BfvParameters>,
+        ct: Arc<Ciphertext>,
+    ) -> Self {
+        // Have to serialize immediately in order to clone etc.
+        let inner_bytes = inner.to_bytes();
+        let params_bytes = params.to_bytes();
+        let ct_bytes = ct.to_bytes();
+        Self {
+            inner: inner_bytes,
+            params: params_bytes,
+            ct: ct_bytes,
+        }
+    }
+
+    pub fn try_inner(self) -> Result<DecryptionShare> {
+        let params = Arc::new(BfvParameters::try_deserialize(&self.params)?);
+        let ct = Arc::new(Ciphertext::from_bytes(&self.ct, &params)?);
+        Ok(DecryptionShare::deserialize(&self.inner, &params, ct)?)
+    }
+}

--- a/packages/ciphernode/core/src/wrapped/mod.rs
+++ b/packages/ciphernode/core/src/wrapped/mod.rs
@@ -1,0 +1,13 @@
+mod ciphertext;
+mod decryption_share;
+mod plaintext;
+mod public_key;
+mod public_key_share;
+mod secret_key;
+
+pub use ciphertext::*;
+pub use decryption_share::*;
+pub use plaintext::*;
+pub use public_key::*;
+pub use public_key_share::*;
+pub use secret_key::*;

--- a/packages/ciphernode/core/src/wrapped/plaintext.rs
+++ b/packages/ciphernode/core/src/wrapped/plaintext.rs
@@ -1,0 +1,12 @@
+use fhe::bfv::Plaintext;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WrappedPlaintext {
+    pub inner: Plaintext,
+}
+
+impl WrappedPlaintext {
+    pub fn from_fhe_rs(inner: Plaintext /* params: Arc<BfvParameters> */) -> Self {
+        Self { inner }
+    }
+}

--- a/packages/ciphernode/core/src/wrapped/public_key.rs
+++ b/packages/ciphernode/core/src/wrapped/public_key.rs
@@ -1,0 +1,80 @@
+use fhe::bfv::{BfvParameters, PublicKey};
+use fhe_traits::{Deserialize, DeserializeParametrized, Serialize};
+use serde::Serializer;
+use std::{cmp::Ordering, hash::Hash, sync::Arc};
+
+/// Wrapped PublicKey. This is wrapped to provide an inflection point
+/// as we use this library elsewhere we only implement traits as we need them
+/// and avoid exposing underlying structures from fhe.rs
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WrappedPublicKey {
+    inner: PublicKey,
+    params: Arc<BfvParameters>,
+}
+
+impl WrappedPublicKey {
+    pub fn from_fhe_rs(inner: PublicKey, params: Arc<BfvParameters>) -> Self {
+        Self { inner, params }
+    }
+}
+
+impl fhe_traits::Serialize for WrappedPublicKey {
+    fn to_bytes(&self) -> Vec<u8> {
+        self.inner.to_bytes()
+    }
+}
+
+/// Deserialize from serde to WrappedPublicKey
+impl<'de> serde::Deserialize<'de> for WrappedPublicKey {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // Intermediate struct of bytes for deserialization
+        #[derive(serde::Deserialize)]
+        struct PublicKeyBytes {
+            par: Vec<u8>,
+            bytes: Vec<u8>,
+        }
+        let PublicKeyBytes { par, bytes } = PublicKeyBytes::deserialize(deserializer)?;
+        let params = Arc::new(BfvParameters::try_deserialize(&par).unwrap()); // TODO: fix errors
+        let inner = PublicKey::from_bytes(&bytes, &params).map_err(serde::de::Error::custom)?;
+        // TODO: how do we create an invariant that the deserialized params match the global params?
+        std::result::Result::Ok(WrappedPublicKey::from_fhe_rs(inner, params))
+    }
+}
+
+/// Serialize to serde bytes representation
+impl serde::Serialize for WrappedPublicKey {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let bytes = self.inner.to_bytes();
+        let par_bytes = self.params.to_bytes();
+        // Intermediate struct of bytes
+        let mut state = serializer.serialize_struct("PublicKey", 2)?;
+        state.serialize_field("par_bytes", &par_bytes)?;
+        state.serialize_field("bytes", &bytes)?;
+        state.end()
+    }
+}
+
+impl Hash for WrappedPublicKey {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.inner.to_bytes().hash(state)
+    }
+}
+
+impl Ord for WrappedPublicKey {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.inner.to_bytes().cmp(&other.inner.to_bytes())
+    }
+}
+
+impl PartialOrd for WrappedPublicKey {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}

--- a/packages/ciphernode/core/src/wrapped/public_key_share.rs
+++ b/packages/ciphernode/core/src/wrapped/public_key_share.rs
@@ -1,0 +1,106 @@
+use std::{cmp::Ordering, hash::Hash, sync::Arc};
+use fhe_traits::{Deserialize, Serialize};
+use fhe::{
+    bfv::BfvParameters,
+    mbfv::{CommonRandomPoly, PublicKeyShare},
+};
+use serde::Serializer;
+
+/// Wrapped PublicKeyShare. This is wrapped to provide an inflection point
+/// as we use this library elsewhere we only implement traits as we need them
+/// and avoid exposing underlying structures from fhe.rs
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WrappedPublicKeyShare {
+    inner: PublicKeyShare,
+    // We need to hold copies of the params and crp in order to effectively serialize and
+    // deserialize the wrapped type
+    params: Arc<BfvParameters>,
+    crp: CommonRandomPoly,
+}
+
+impl WrappedPublicKeyShare {
+    /// Public function to serialize specifically from the wrapped type including types that are
+    /// private from outside the crate
+    pub fn from_fhe_rs(
+        inner: PublicKeyShare,
+        params: Arc<BfvParameters>,
+        crp: CommonRandomPoly,
+    ) -> Self {
+        Self { inner, params, crp }
+    }
+
+    pub fn clone_inner(&self) -> PublicKeyShare {
+        self.inner.clone()
+    }
+}
+
+impl Ord for WrappedPublicKeyShare {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.inner.to_bytes().cmp(&other.inner.to_bytes())
+    }
+}
+
+impl PartialOrd for WrappedPublicKeyShare {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl From<WrappedPublicKeyShare> for Vec<u8> {
+    fn from(share: WrappedPublicKeyShare) -> Self {
+        share.inner.to_bytes()
+    }
+}
+
+impl Hash for WrappedPublicKeyShare {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.inner.to_bytes().hash(state)
+    }
+}
+
+/// Deserialize from serde to WrappedPublicKeyShare
+impl<'de> serde::Deserialize<'de> for WrappedPublicKeyShare {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // Intermediate struct of bytes for deserialization
+        #[derive(serde::Deserialize)]
+        struct PublicKeyShareBytes {
+            par_bytes: Vec<u8>,
+            crp_bytes: Vec<u8>,
+            bytes: Vec<u8>,
+        }
+        let PublicKeyShareBytes {
+            par_bytes,
+            crp_bytes,
+            bytes,
+        } = PublicKeyShareBytes::deserialize(deserializer)?;
+        let params = Arc::new(BfvParameters::try_deserialize(&par_bytes).unwrap());
+        let crp =
+            CommonRandomPoly::deserialize(&crp_bytes, &params).map_err(serde::de::Error::custom)?;
+        let inner = PublicKeyShare::deserialize(&bytes, &params, crp.clone())
+            .map_err(serde::de::Error::custom)?;
+        // TODO: how do we create an invariant that the deserialized params match the global params?
+        std::result::Result::Ok(WrappedPublicKeyShare::from_fhe_rs(inner, params, crp))
+    }
+}
+
+/// Serialize to serde bytes representation
+impl serde::Serialize for WrappedPublicKeyShare {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let bytes = self.inner.to_bytes();
+        let par_bytes = self.params.to_bytes();
+        let crp_bytes = self.crp.to_bytes();
+        // Intermediate struct of bytes
+        let mut state = serializer.serialize_struct("PublicKeyShare", 3)?;
+        state.serialize_field("par_bytes", &par_bytes)?;
+        state.serialize_field("crp_bytes", &crp_bytes)?;
+        state.serialize_field("bytes", &bytes)?;
+        state.end()
+    }
+}

--- a/packages/ciphernode/core/src/wrapped/secret_key.rs
+++ b/packages/ciphernode/core/src/wrapped/secret_key.rs
@@ -1,0 +1,45 @@
+use anyhow::*;
+use fhe::bfv::{BfvParameters, SecretKey};
+use fhe_traits::{Deserialize, Serialize};
+use std::sync::Arc;
+
+/// Wrapped SecretKey. This is wrapped to provide an inflection point
+/// as we use this library elsewhere we only implement traits as we need them
+/// and avoid exposing underlying structures from fhe.rs
+// We should favor consuming patterns and avoid cloning and copying this value around in memory.
+// Underlying key Zeroizes on drop
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WrappedSecretKey {
+    pub inner: SecretKey,
+    pub params: Arc<BfvParameters>,
+}
+
+impl WrappedSecretKey {
+    pub fn from_fhe_rs(inner: SecretKey, params: Arc<BfvParameters>) -> Self {
+        Self { inner, params }
+    }
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct SecretKeyData {
+    coeffs: Box<[i64]>,
+    par: Vec<u8>,
+}
+
+impl WrappedSecretKey {
+    pub fn unsafe_serialize(&self) -> Result<Vec<u8>> {
+        Ok(bincode::serialize(&SecretKeyData {
+            coeffs: self.inner.coeffs.clone(),
+            par: self.params.clone().to_bytes(),
+        })?)
+    }
+
+    pub fn deserialize(bytes: Vec<u8>) -> Result<WrappedSecretKey> {
+        let SecretKeyData { coeffs, par } = bincode::deserialize(&bytes)?;
+        let params = Arc::new(BfvParameters::try_deserialize(&par).unwrap());
+        Ok(WrappedSecretKey::from_fhe_rs(
+            SecretKey::new(coeffs.to_vec(), &params),
+            params,
+        ))
+    }
+}


### PR DESCRIPTION
Extracting wrapped structs out of Fhe Actor in order to clean up. 

Next phase will be to convert all Fhe output to either String or Vec<u8> based on architecture discussion. 

Ideally we just have a set of deserializer and serializer functions on the actual fhe.rs types.

We can then remove all wrapped::* stuff from the rest of the code. 

Currently we have a blocker on removing these because Fhe types do not serialize and deserialize independently often requiring special parameters added. 

Ideally they would serialize to bytes that can completely reconstruct the object and this would happen from within the type itself however certain data fields are not public so this cannot be done without changes to the upstream library. We should have a clear policy on how to proceed with this.
