### PR TITLE
Use Vec<u8> for FHE types

### DIFF
--- a/packages/ciphernode/core/src/ciphernode.rs
+++ b/packages/ciphernode/core/src/ciphernode.rs
@@ -114,16 +114,14 @@ async fn on_decryption_requested(
     let DecryptionRequested { e3_id, ciphertext } = event;
 
     // get secret key by id from data
-    let Some(sk_bytes) = data.send(Get(format!("{}/sk", e3_id).into())).await? else {
+    let Some(unsafe_secret) = data.send(Get(format!("{}/sk", e3_id).into())).await? else {
         return Err(anyhow::anyhow!("Secret key not stored for {}", e3_id));
     };
-
-    // let unsafe_secret = WrappedSecretKey::deserialize(sk_bytes)?;
 
     let decryption_share = fhe
         .send(DecryptCiphertext {
             ciphertext,
-            unsafe_secret: sk_bytes,
+            unsafe_secret,
         })
         .await??;
 

--- a/packages/ciphernode/core/src/ciphernode.rs
+++ b/packages/ciphernode/core/src/ciphernode.rs
@@ -3,7 +3,7 @@ use crate::{
     eventbus::EventBus,
     events::{ComputationRequested, EnclaveEvent, KeyshareCreated},
     fhe::{Fhe, GenerateKeyshare},
-    wrapped::WrappedSecretKey,
+    wrapped::SecretKeySerializer,
     DecryptCiphertext, DecryptionRequested, DecryptionshareCreated, Get, Subscribe,
 };
 use actix::prelude::*;

--- a/packages/ciphernode/core/src/committee_key.rs
+++ b/packages/ciphernode/core/src/committee_key.rs
@@ -1,7 +1,7 @@
 use crate::{
     eventbus::EventBus,
     events::{E3id, EnclaveEvent, KeyshareCreated, PublicKeyAggregated},
-    fhe::{Fhe, GetAggregatePublicKey}, ordered_set::OrderedSet, wrapped::{WrappedPublicKey, WrappedPublicKeyShare},
+    fhe::{Fhe, GetAggregatePublicKey}, ordered_set::OrderedSet, 
 };
 use actix::prelude::*;
 use anyhow::{anyhow, Result};
@@ -10,21 +10,21 @@ use anyhow::{anyhow, Result};
 pub enum CommitteeKeyState {
     Collecting {
         nodecount: usize,
-        keyshares: OrderedSet<WrappedPublicKeyShare>,
+        keyshares: OrderedSet<Vec<u8>>,
     },
     Computing {
-        keyshares: OrderedSet<WrappedPublicKeyShare>,
+        keyshares: OrderedSet<Vec<u8>>,
     },
     Complete {
-        public_key: WrappedPublicKey,
-        keyshares: OrderedSet<WrappedPublicKeyShare>,
+        public_key: Vec<u8>,
+        keyshares: OrderedSet<Vec<u8>>,
     },
 }
 
 #[derive(Message)]
 #[rtype(result = "anyhow::Result<()>")]
 struct ComputeAggregate {
-    pub keyshares: OrderedSet<WrappedPublicKeyShare>,
+    pub keyshares: OrderedSet<Vec<u8>>,
 }
 
 #[derive(Message)]
@@ -57,7 +57,7 @@ impl CommitteeKey {
         }
     }
 
-    pub fn add_keyshare(&mut self, keyshare: WrappedPublicKeyShare) -> Result<CommitteeKeyState> {
+    pub fn add_keyshare(&mut self, keyshare: Vec<u8>) -> Result<CommitteeKeyState> {
         let CommitteeKeyState::Collecting {
             nodecount,
             keyshares,
@@ -76,7 +76,7 @@ impl CommitteeKey {
         Ok(self.state.clone())
     }
 
-    pub fn set_pubkey(&mut self, pubkey: WrappedPublicKey) -> Result<CommitteeKeyState> {
+    pub fn set_pubkey(&mut self, pubkey: Vec<u8>) -> Result<CommitteeKeyState> {
         let CommitteeKeyState::Computing { keyshares } = &mut self.state else {
             return Ok(self.state.clone());
         };
@@ -129,7 +129,7 @@ impl Handler<ComputeAggregate> for CommitteeKey {
 
     fn handle(&mut self, msg: ComputeAggregate, _: &mut Self::Context) -> Self::Result {
         // Futures are awkward in Actix from what I can tell we should try and structure events so
-        // that futures that don't reuire access to self filre like the following...
+        // that futures that don't require access to self like the following...
         Box::pin(
             // Run the async future.
             self.fhe

--- a/packages/ciphernode/core/src/committee_key.rs
+++ b/packages/ciphernode/core/src/committee_key.rs
@@ -1,7 +1,8 @@
 use crate::{
     eventbus::EventBus,
     events::{E3id, EnclaveEvent, KeyshareCreated, PublicKeyAggregated},
-    fhe::{Fhe, GetAggregatePublicKey}, ordered_set::OrderedSet, 
+    fhe::{Fhe, GetAggregatePublicKey},
+    ordered_set::OrderedSet,
 };
 use actix::prelude::*;
 use anyhow::{anyhow, Result};
@@ -39,7 +40,7 @@ pub struct CommitteeKey {
 }
 
 /// Aggregate PublicKey for a committee of nodes. This actor listens for KeyshareCreated events
-/// around a particular e3_id and aggregates the public key based on this and once done broadcasts 
+/// around a particular e3_id and aggregates the public key based on this and once done broadcasts
 /// a EnclaveEvent::PublicKeyAggregated event on the event bus. Note events are hashed and
 /// identical events will not be triggered twice.
 /// It is expected to change this mechanism as we work through adversarial scenarios and write tests

--- a/packages/ciphernode/core/src/data.rs
+++ b/packages/ciphernode/core/src/data.rs
@@ -17,7 +17,6 @@ impl Insert {
     }
 }
 
-
 #[derive(Message, Clone, Debug, PartialEq, Eq, Hash)]
 #[rtype(result = "Option<Vec<u8>>")]
 pub struct Get(pub Vec<u8>);
@@ -59,7 +58,6 @@ impl Data {
 impl Handler<Insert> for Data {
     type Result = ();
     fn handle(&mut self, event: Insert, _: &mut Self::Context) {
-
         // insert data into sled
         self.db.insert(event.key(), event.value());
 

--- a/packages/ciphernode/core/src/enclave_contract.rs
+++ b/packages/ciphernode/core/src/enclave_contract.rs
@@ -1,4 +1,3 @@
-
 use actix::{Actor, Context};
 
 /// Manage an internal web3 instance and express protocol specific behaviour through the events it
@@ -9,8 +8,6 @@ use actix::{Actor, Context};
 /// Accept eventbus events and forward as appropriate contract calls as required
 pub struct EnclaveContract;
 
-impl Actor for EnclaveContract{
+impl Actor for EnclaveContract {
     type Context = Context<Self>;
 }
-
-

--- a/packages/ciphernode/core/src/events.rs
+++ b/packages/ciphernode/core/src/events.rs
@@ -215,7 +215,7 @@ impl EnclaveEvent {
 mod tests {
     use super::EnclaveEvent;
     use crate::{
-        events::extract_enclave_event_name, wrapped::WrappedPublicKeyShare, E3id, KeyshareCreated,
+        events::extract_enclave_event_name, wrapped::PublicKeyShareSerializer, E3id, KeyshareCreated,
     };
     use fhe::{
         bfv::{BfvParametersBuilder, SecretKey},
@@ -251,7 +251,7 @@ mod tests {
         let crp = CommonRandomPoly::new(&params, &mut rng)?;
         let sk_share = { SecretKey::random(&params, &mut rng) };
         let pk_share = { PublicKeyShare::new(&sk_share, crp.clone(), &mut rng)? };
-        let pubkey = WrappedPublicKeyShare::from_fhe_rs(pk_share, params.clone(), crp.clone())?;
+        let pubkey = PublicKeyShareSerializer::to_bytes(pk_share, params.clone(), crp.clone())?;
         let kse = EnclaveEvent::from(KeyshareCreated {
             e3_id: E3id::from(1001),
             pubkey,

--- a/packages/ciphernode/core/src/events.rs
+++ b/packages/ciphernode/core/src/events.rs
@@ -1,4 +1,3 @@
-use crate::wrapped::{WrappedCiphertext, WrappedDecryptionShare, WrappedPublicKey, WrappedPublicKeyShare};
 use actix::Message;
 use bincode;
 use serde::{Deserialize, Serialize};
@@ -157,21 +156,21 @@ impl fmt::Display for EnclaveEvent {
 #[derive(Message, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[rtype(result = "anyhow::Result<()>")]
 pub struct KeyshareCreated {
-    pub pubkey: WrappedPublicKeyShare,
+    pub pubkey: Vec<u8>,
     pub e3_id: E3id,
 }
 
 #[derive(Message, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[rtype(result = "anyhow::Result<()>")]
 pub struct DecryptionshareCreated {
-    pub decryption_share: WrappedDecryptionShare,
+    pub decryption_share: Vec<u8>,
     pub e3_id: E3id,
 }
 
 #[derive(Message, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[rtype(result = "()")]
 pub struct PublicKeyAggregated {
-    pub pubkey: WrappedPublicKey,
+    pub pubkey: Vec<u8>,
     pub e3_id: E3id,
 }
 
@@ -192,7 +191,7 @@ pub struct ComputationRequested {
 #[rtype(result = "()")]
 pub struct DecryptionRequested {
     pub e3_id: E3id,
-    pub ciphertext: WrappedCiphertext,
+    pub ciphertext: Vec<u8>,
 }
 
 fn extract_enclave_event_name(s: &str) -> &str {
@@ -254,7 +253,7 @@ mod tests {
         let crp = CommonRandomPoly::new(&params, &mut rng)?;
         let sk_share = { SecretKey::random(&params, &mut rng) };
         let pk_share = { PublicKeyShare::new(&sk_share, crp.clone(), &mut rng)? };
-        let pubkey = WrappedPublicKeyShare::from_fhe_rs(pk_share, params.clone(), crp.clone());
+        let pubkey = WrappedPublicKeyShare::from_fhe_rs(pk_share, params.clone(), crp.clone())?;
         let kse = EnclaveEvent::from(KeyshareCreated {
             e3_id: E3id::from(1001),
             pubkey,

--- a/packages/ciphernode/core/src/events.rs
+++ b/packages/ciphernode/core/src/events.rs
@@ -213,19 +213,17 @@ impl EnclaveEvent {
 
 #[cfg(test)]
 mod tests {
-
-    use std::error::Error;
-
+    use super::EnclaveEvent;
+    use crate::{
+        events::extract_enclave_event_name, wrapped::WrappedPublicKeyShare, E3id, KeyshareCreated,
+    };
     use fhe::{
         bfv::{BfvParametersBuilder, SecretKey},
         mbfv::{CommonRandomPoly, PublicKeyShare},
     };
     use rand::SeedableRng;
     use rand_chacha::ChaCha20Rng;
-
-    use crate::{events::extract_enclave_event_name, wrapped::WrappedPublicKeyShare, E3id, KeyshareCreated};
-
-    use super::EnclaveEvent;
+    use std::error::Error;
 
     #[test]
     fn test_extract_enum_name() {

--- a/packages/ciphernode/core/src/fhe.rs
+++ b/packages/ciphernode/core/src/fhe.rs
@@ -1,13 +1,14 @@
 use crate::{
     ordered_set::OrderedSet,
     wrapped::{
-        WrappedCiphertext, WrappedDecryptionShare, WrappedPlaintext, WrappedPublicKey, WrappedPublicKeyShare, WrappedSecretKey
+        WrappedCiphertext, WrappedDecryptionShare, WrappedPlaintext, WrappedPublicKey,
+        WrappedPublicKeyShare, WrappedSecretKey,
     },
 };
 use actix::{Actor, Context, Handler, Message};
 use anyhow::*;
 use fhe::{
-    bfv::{BfvParameters, BfvParametersBuilder, Plaintext, PublicKey, SecretKey},
+    bfv::{BfvParameters, BfvParametersBuilder, Ciphertext, Plaintext, PublicKey, SecretKey},
     mbfv::{AggregateIter, CommonRandomPoly, DecryptionShare, PublicKeyShare},
 };
 use rand::SeedableRng;
@@ -15,32 +16,28 @@ use rand_chacha::ChaCha20Rng;
 use std::{hash::Hash, sync::Arc};
 
 #[derive(Message, Clone, Debug, PartialEq, Eq, Hash)]
-#[rtype(result = "Result<(WrappedSecretKey, WrappedPublicKeyShare)>")]
-// TODO: Result<(Vec<u8>,Vec<u8>)>
+#[rtype(result = "Result<(Vec<u8>, Vec<u8>)>")]
 pub struct GenerateKeyshare {
     // responder_pk: Vec<u8>, // TODO: use this to encrypt the secret data
 }
 
 #[derive(Message, Clone, Debug, PartialEq, Eq)]
-#[rtype(result = "Result<(WrappedPublicKey)>")]
-// TODO: Result<Vec<u8>>
+#[rtype(result = "Result<(Vec<u8>)>")]
 pub struct GetAggregatePublicKey {
-    pub keyshares: OrderedSet<WrappedPublicKeyShare>,
+    pub keyshares: OrderedSet<Vec<u8>>,
 }
 
-#[derive(Message, Clone, Debug, PartialEq, Eq)]
-#[rtype(result = "Result<(WrappedPlaintext)>")]
-// TODO: Result<Vec<u8>>
-pub struct GetAggregatePlaintext {
-    pub decryptions: OrderedSet<WrappedDecryptionShare>,
-}
+// #[derive(Message, Clone, Debug, PartialEq, Eq)]
+// #[rtype(result = "Result<(WrappedPlaintext)>")]
+// pub struct GetAggregatePlaintext {
+//     pub decryptions: OrderedSet<WrappedDecryptionShare>,
+// }
 
 #[derive(Message, Clone, Debug, PartialEq, Eq)]
-#[rtype(result = "Result<(WrappedDecryptionShare)>")]
-// TODO: Result<Vec<u8>>
+#[rtype(result = "Result<(Vec<u8>)>")]
 pub struct DecryptCiphertext {
-    pub unsafe_secret: WrappedSecretKey,
-    pub ciphertext: WrappedCiphertext,
+    pub unsafe_secret: Vec<u8>,
+    pub ciphertext: Vec<u8>,
 }
 
 /// Fhe library adaptor. All FHE computations should happen through this actor.
@@ -79,60 +76,68 @@ impl Fhe {
 }
 
 impl Handler<GenerateKeyshare> for Fhe {
-    type Result = Result<(WrappedSecretKey, WrappedPublicKeyShare)>;
+    type Result = Result<(Vec<u8>, Vec<u8>)>;
     fn handle(&mut self, _event: GenerateKeyshare, _: &mut Self::Context) -> Self::Result {
         let sk_share = { SecretKey::random(&self.params, &mut self.rng) };
         let pk_share = { PublicKeyShare::new(&sk_share, self.crp.clone(), &mut self.rng)? };
         Ok((
-            WrappedSecretKey::from_fhe_rs(sk_share, self.params.clone()),
-            WrappedPublicKeyShare::from_fhe_rs(pk_share, self.params.clone(), self.crp.clone()),
+            WrappedSecretKey::from_fhe_rs(sk_share, self.params.clone())?,
+            WrappedPublicKeyShare::from_fhe_rs(pk_share, self.params.clone(), self.crp.clone())?,
         ))
     }
 }
 
 impl Handler<DecryptCiphertext> for Fhe {
-    type Result = Result<WrappedDecryptionShare>;
+    type Result = Result<Vec<u8>>;
     fn handle(&mut self, msg: DecryptCiphertext, _: &mut Self::Context) -> Self::Result {
         let DecryptCiphertext {
             unsafe_secret, // TODO: fix security issues with sending secrets between actors
             ciphertext,
         } = msg;
 
-        let ct = Arc::new(ciphertext.inner);
-        let inner = DecryptionShare::new(&unsafe_secret.inner, &ct, &mut self.rng).unwrap();
+        let secret_key = WrappedSecretKey::deserialize(unsafe_secret)?.inner;
+        let wct: WrappedCiphertext = bincode::deserialize(&ciphertext)?;
+        let ct: Arc<Ciphertext> = Arc::new(wct.inner);
+        let inner = DecryptionShare::new(&secret_key, &ct, &mut self.rng).unwrap();
 
         Ok(WrappedDecryptionShare::from_fhe_rs(
             inner,
-            ciphertext.params,
+            wct.params,
             ct.clone(),
-        ))
+        )?)
     }
 }
 
 impl Handler<GetAggregatePublicKey> for Fhe {
-    type Result = Result<WrappedPublicKey>;
+    type Result = Result<Vec<u8>>;
 
     fn handle(&mut self, msg: GetAggregatePublicKey, _: &mut Self::Context) -> Self::Result {
-        // Could implement Aggregate for Wrapped keys but that leaks traits
-        let public_key: PublicKey = msg.keyshares.iter().map(|k| k.clone_inner()).aggregate()?;
-        Ok(WrappedPublicKey::from_fhe_rs(
-            public_key,
-            self.params.clone(),
-        ))
-    }
-}
-
-impl Handler<GetAggregatePlaintext> for Fhe {
-    type Result = Result<WrappedPlaintext>;
-    fn handle(&mut self, msg: GetAggregatePlaintext, _: &mut Self::Context) -> Self::Result {
-        let plaintext: Plaintext = msg
-            .decryptions
+        let public_key: PublicKey = msg
+            .keyshares
             .iter()
-            .map(|k| k.clone().try_inner())
-            .collect::<Result<Vec<_>>>()? // NOTE: not optimal
+            .map(|k| WrappedPublicKeyShare::from_bytes(k))
+            .collect::<Result<Vec<_>>>()?
             .into_iter()
             .aggregate()?;
 
-        Ok(WrappedPlaintext::from_fhe_rs(plaintext))
+        Ok(WrappedPublicKey::from_fhe_rs(
+            public_key,
+            self.params.clone(),
+        )?)
     }
 }
+
+// impl Handler<GetAggregatePlaintext> for Fhe {
+//     type Result = Result<WrappedPlaintext>;
+//     fn handle(&mut self, msg: GetAggregatePlaintext, _: &mut Self::Context) -> Self::Result {
+//         let plaintext: Plaintext = msg
+//             .decryptions
+//             .iter()
+//             .map(|k| k.clone().try_inner())
+//             .collect::<Result<Vec<_>>>()? // NOTE: not optimal
+//             .into_iter()
+//             .aggregate()?;
+//
+//         Ok(WrappedPlaintext::from_fhe_rs(plaintext))
+//     }
+// }

--- a/packages/ciphernode/core/src/fhe.rs
+++ b/packages/ciphernode/core/src/fhe.rs
@@ -27,11 +27,11 @@ pub struct GetAggregatePublicKey {
     pub keyshares: OrderedSet<Vec<u8>>,
 }
 
-// #[derive(Message, Clone, Debug, PartialEq, Eq)]
-// #[rtype(result = "Result<(WrappedPlaintext)>")]
-// pub struct GetAggregatePlaintext {
-//     pub decryptions: OrderedSet<WrappedDecryptionShare>,
-// }
+#[derive(Message, Clone, Debug, PartialEq, Eq)]
+#[rtype(result = "Result<(WrappedPlaintext)>")]
+pub struct GetAggregatePlaintext {
+    pub decryptions: OrderedSet<Vec<u8>>,
+}
 
 #[derive(Message, Clone, Debug, PartialEq, Eq)]
 #[rtype(result = "Result<(Vec<u8>)>")]
@@ -127,6 +127,7 @@ impl Handler<GetAggregatePublicKey> for Fhe {
     }
 }
 
+// TODO: add this once we have decryption aggregation ready
 // impl Handler<GetAggregatePlaintext> for Fhe {
 //     type Result = Result<WrappedPlaintext>;
 //     fn handle(&mut self, msg: GetAggregatePlaintext, _: &mut Self::Context) -> Self::Result {

--- a/packages/ciphernode/core/src/lib.rs
+++ b/packages/ciphernode/core/src/lib.rs
@@ -60,12 +60,14 @@ mod tests {
     use crate::{
         ciphernode::Ciphernode,
         committee::CommitteeManager,
-        data::{Data, GetLog},
-        eventbus::{EventBus, GetHistory, Subscribe},
+        data::Data,
+        eventbus::{EventBus, GetHistory},
         events::{ComputationRequested, E3id, EnclaveEvent, KeyshareCreated, PublicKeyAggregated},
         fhe::Fhe,
         p2p::P2p,
-        wrapped::{WrappedCiphertext, WrappedDecryptionShare, WrappedPublicKey, WrappedPublicKeyShare},
+        wrapped::{
+            WrappedCiphertext, WrappedDecryptionShare, WrappedPublicKey, WrappedPublicKeyShare,
+        },
         DecryptionRequested, DecryptionshareCreated, ResetHistory,
     };
     use actix::prelude::*;
@@ -117,13 +119,13 @@ mod tests {
         params: Arc<BfvParameters>,
         crp: CommonRandomPoly,
         mut rng: ChaCha20Rng,
-    ) -> Result<(WrappedPublicKeyShare, ChaCha20Rng, SecretKey)> {
+    ) -> Result<(Vec<u8>, ChaCha20Rng, SecretKey)> {
         let sk = SecretKey::random(&params, &mut rng);
         let pk = WrappedPublicKeyShare::from_fhe_rs(
             PublicKeyShare::new(&sk, crp.clone(), &mut rng)?,
             params.clone(),
             crp,
-        );
+        )?;
         Ok((pk, rng, sk))
     }
 
@@ -192,7 +194,7 @@ mod tests {
 
         let pubkey: PublicKey = vec![p1.clone(), p2.clone(), p3.clone()]
             .iter()
-            .map(|k| k.clone_inner())
+            .map(|k| WrappedPublicKeyShare::from_bytes(k).unwrap())
             .aggregate()?;
 
         assert_eq!(history.len(), 5);
@@ -218,7 +220,7 @@ mod tests {
                     e3_id: e3_id.clone()
                 }),
                 EnclaveEvent::from(PublicKeyAggregated {
-                    pubkey: WrappedPublicKey::from_fhe_rs(pubkey.clone(), params.clone()),
+                    pubkey: WrappedPublicKey::from_fhe_rs(pubkey.clone(), params.clone())?,
                     e3_id: e3_id.clone()
                 })
             ]
@@ -235,7 +237,7 @@ mod tests {
         let ciphertext = pubkey.try_encrypt(&pt, &mut ChaCha20Rng::seed_from_u64(42))?;
 
         let event = EnclaveEvent::from(DecryptionRequested {
-            ciphertext: WrappedCiphertext::from_fhe_rs(ciphertext.clone(), params.clone()),
+            ciphertext: WrappedCiphertext::from_fhe_rs(ciphertext.clone(), params.clone())?,
             e3_id: e3_id.clone(),
         });
 
@@ -245,17 +247,17 @@ mod tests {
             DecryptionShare::new(&sk1, &arc_ct, &mut rng).unwrap(),
             params.clone(),
             arc_ct.clone(),
-        );
+        )?;
         let ds2 = WrappedDecryptionShare::from_fhe_rs(
             DecryptionShare::new(&sk2, &arc_ct, &mut rng).unwrap(),
             params.clone(),
             arc_ct.clone(),
-        );
+        )?;
         let ds3 = WrappedDecryptionShare::from_fhe_rs(
             DecryptionShare::new(&sk3, &arc_ct, &mut rng).unwrap(),
             params.clone(),
             arc_ct.clone(),
-        );
+        )?;
 
         // let ds1 = sk1
         bus.send(event.clone()).await?;

--- a/packages/ciphernode/core/src/lib.rs
+++ b/packages/ciphernode/core/src/lib.rs
@@ -66,7 +66,7 @@ mod tests {
         fhe::Fhe,
         p2p::P2p,
         wrapped::{
-            WrappedCiphertext, WrappedDecryptionShare, WrappedPublicKey, WrappedPublicKeyShare,
+            CiphertextSerializer, DecryptionShareSerializer, PublicKeySerializer, PublicKeyShareSerializer,
         },
         DecryptionRequested, DecryptionshareCreated, ResetHistory,
     };
@@ -121,7 +121,7 @@ mod tests {
         mut rng: ChaCha20Rng,
     ) -> Result<(Vec<u8>, ChaCha20Rng, SecretKey)> {
         let sk = SecretKey::random(&params, &mut rng);
-        let pk = WrappedPublicKeyShare::from_fhe_rs(
+        let pk = PublicKeyShareSerializer::to_bytes(
             PublicKeyShare::new(&sk, crp.clone(), &mut rng)?,
             params.clone(),
             crp,
@@ -194,7 +194,7 @@ mod tests {
 
         let pubkey: PublicKey = vec![p1.clone(), p2.clone(), p3.clone()]
             .iter()
-            .map(|k| WrappedPublicKeyShare::from_bytes(k).unwrap())
+            .map(|k| PublicKeyShareSerializer::from_bytes(k).unwrap())
             .aggregate()?;
 
         assert_eq!(history.len(), 5);
@@ -220,7 +220,7 @@ mod tests {
                     e3_id: e3_id.clone()
                 }),
                 EnclaveEvent::from(PublicKeyAggregated {
-                    pubkey: WrappedPublicKey::from_fhe_rs(pubkey.clone(), params.clone())?,
+                    pubkey: PublicKeySerializer::to_bytes(pubkey.clone(), params.clone())?,
                     e3_id: e3_id.clone()
                 })
             ]
@@ -237,23 +237,23 @@ mod tests {
         let ciphertext = pubkey.try_encrypt(&pt, &mut ChaCha20Rng::seed_from_u64(42))?;
 
         let event = EnclaveEvent::from(DecryptionRequested {
-            ciphertext: WrappedCiphertext::from_fhe_rs(ciphertext.clone(), params.clone())?,
+            ciphertext: CiphertextSerializer::to_bytes(ciphertext.clone(), params.clone())?,
             e3_id: e3_id.clone(),
         });
 
         let arc_ct = Arc::new(ciphertext);
 
-        let ds1 = WrappedDecryptionShare::from_fhe_rs(
+        let ds1 = DecryptionShareSerializer::to_bytes(
             DecryptionShare::new(&sk1, &arc_ct, &mut rng).unwrap(),
             params.clone(),
             arc_ct.clone(),
         )?;
-        let ds2 = WrappedDecryptionShare::from_fhe_rs(
+        let ds2 = DecryptionShareSerializer::to_bytes(
             DecryptionShare::new(&sk2, &arc_ct, &mut rng).unwrap(),
             params.clone(),
             arc_ct.clone(),
         )?;
-        let ds3 = WrappedDecryptionShare::from_fhe_rs(
+        let ds3 = DecryptionShareSerializer::to_bytes(
             DecryptionShare::new(&sk3, &arc_ct, &mut rng).unwrap(),
             params.clone(),
             arc_ct.clone(),

--- a/packages/ciphernode/core/src/wrapped/ciphertext.rs
+++ b/packages/ciphernode/core/src/wrapped/ciphertext.rs
@@ -1,33 +1,31 @@
+use anyhow::*;
 use fhe::bfv::{BfvParameters, Ciphertext};
 use fhe_traits::{Deserialize, DeserializeParametrized, Serialize};
 use serde::Serializer;
-use std::{hash::Hash, sync::Arc};
-use anyhow::*;
+use std::sync::Arc;
 
 /// Wrapped Ciphertext. This is wrapped to provide an inflection point
 /// as we use this library elsewhere we only implement traits as we need them
 /// and avoid exposing underlying structures from fhe.rs
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct WrappedCiphertext {
+pub struct CiphertextSerializer {
     pub inner: Ciphertext,
     pub params: Arc<BfvParameters>,
 }
 
-impl WrappedCiphertext {
-    pub fn from_fhe_rs(inner: Ciphertext, params: Arc<BfvParameters>) -> Result<Vec<u8>> {
+impl CiphertextSerializer {
+    pub fn to_bytes(inner: Ciphertext, params: Arc<BfvParameters>) -> Result<Vec<u8>> {
         let value = Self { inner, params };
         Ok(bincode::serialize(&value)?)
     }
-}
 
-impl Hash for WrappedCiphertext {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.inner.to_bytes().hash(state)
+    pub fn from_bytes(bytes:&[u8]) -> Result<Ciphertext>{
+        let wct: Self = bincode::deserialize(&bytes)?;
+        Ok(wct.inner)
     }
 }
 
-/// Deserialize from serde to WrappedPublicKey
-impl<'de> serde::Deserialize<'de> for WrappedCiphertext {
+/// Deserialize from serde to PublicKeySerializer
+impl<'de> serde::Deserialize<'de> for CiphertextSerializer {
     fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
@@ -41,10 +39,10 @@ impl<'de> serde::Deserialize<'de> for WrappedCiphertext {
         let DeserializedBytes { par, bytes } = DeserializedBytes::deserialize(deserializer)?;
         let params = Arc::new(BfvParameters::try_deserialize(&par).unwrap());
         let inner = Ciphertext::from_bytes(&bytes, &params).map_err(serde::de::Error::custom)?;
-        std::result::Result::Ok(Self {inner, params})
+        std::result::Result::Ok(Self { inner, params })
     }
 }
-impl serde::Serialize for WrappedCiphertext {
+impl serde::Serialize for CiphertextSerializer {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,

--- a/packages/ciphernode/core/src/wrapped/decryption_share.rs
+++ b/packages/ciphernode/core/src/wrapped/decryption_share.rs
@@ -20,16 +20,17 @@ impl WrappedDecryptionShare {
         inner: DecryptionShare,
         params: Arc<BfvParameters>,
         ct: Arc<Ciphertext>,
-    ) -> Self {
+    ) -> Result<Vec<u8>>{
         // Have to serialize immediately in order to clone etc.
         let inner_bytes = inner.to_bytes();
         let params_bytes = params.to_bytes();
         let ct_bytes = ct.to_bytes();
-        Self {
+        let value = Self {
             inner: inner_bytes,
             params: params_bytes,
             ct: ct_bytes,
-        }
+        };
+        Ok(bincode::serialize(&value)?)
     }
 
     pub fn try_inner(self) -> Result<DecryptionShare> {

--- a/packages/ciphernode/core/src/wrapped/decryption_share.rs
+++ b/packages/ciphernode/core/src/wrapped/decryption_share.rs
@@ -3,24 +3,22 @@ use fhe::{
     bfv::{BfvParameters, Ciphertext},
     mbfv::DecryptionShare,
 };
-use fhe_traits::{Deserialize, DeserializeParametrized, Serialize};
+use fhe_traits::Serialize;
 use std::sync::Arc;
 
-#[derive(
-    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
-)]
-pub struct WrappedDecryptionShare {
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct DecryptionShareSerializer {
     inner: Vec<u8>,
     params: Vec<u8>,
     ct: Vec<u8>,
 }
 
-impl WrappedDecryptionShare {
-    pub fn from_fhe_rs(
+impl DecryptionShareSerializer {
+    pub fn to_bytes(
         inner: DecryptionShare,
         params: Arc<BfvParameters>,
         ct: Arc<Ciphertext>,
-    ) -> Result<Vec<u8>>{
+    ) -> Result<Vec<u8>> {
         // Have to serialize immediately in order to clone etc.
         let inner_bytes = inner.to_bytes();
         let params_bytes = params.to_bytes();
@@ -31,11 +29,5 @@ impl WrappedDecryptionShare {
             ct: ct_bytes,
         };
         Ok(bincode::serialize(&value)?)
-    }
-
-    pub fn try_inner(self) -> Result<DecryptionShare> {
-        let params = Arc::new(BfvParameters::try_deserialize(&self.params)?);
-        let ct = Arc::new(Ciphertext::from_bytes(&self.ct, &params)?);
-        Ok(DecryptionShare::deserialize(&self.inner, &params, ct)?)
     }
 }

--- a/packages/ciphernode/core/src/wrapped/plaintext.rs
+++ b/packages/ciphernode/core/src/wrapped/plaintext.rs
@@ -7,6 +7,6 @@ pub struct WrappedPlaintext {
 
 impl WrappedPlaintext {
     pub fn from_fhe_rs(inner: Plaintext /* params: Arc<BfvParameters> */) -> Self {
-        Self { inner }
+        Self { inner }  
     }
 }

--- a/packages/ciphernode/core/src/wrapped/plaintext.rs
+++ b/packages/ciphernode/core/src/wrapped/plaintext.rs
@@ -1,12 +1,12 @@
 use fhe::bfv::Plaintext;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct WrappedPlaintext {
+pub struct PlaintextSerializer {
     pub inner: Plaintext,
 }
 
-impl WrappedPlaintext {
-    pub fn from_fhe_rs(inner: Plaintext /* params: Arc<BfvParameters> */) -> Self {
+impl PlaintextSerializer {
+    pub fn to_bytes(inner: Plaintext /* params: Arc<BfvParameters> */) -> Self {
         Self { inner }  
     }
 }

--- a/packages/ciphernode/core/src/wrapped/public_key.rs
+++ b/packages/ciphernode/core/src/wrapped/public_key.rs
@@ -1,8 +1,8 @@
+use anyhow::*;
 use fhe::bfv::{BfvParameters, PublicKey};
 use fhe_traits::{Deserialize, DeserializeParametrized, Serialize};
 use serde::Serializer;
 use std::{cmp::Ordering, hash::Hash, sync::Arc};
-
 /// Wrapped PublicKey. This is wrapped to provide an inflection point
 /// as we use this library elsewhere we only implement traits as we need them
 /// and avoid exposing underlying structures from fhe.rs
@@ -13,16 +13,22 @@ pub struct WrappedPublicKey {
 }
 
 impl WrappedPublicKey {
-    pub fn from_fhe_rs(inner: PublicKey, params: Arc<BfvParameters>) -> Self {
-        Self { inner, params }
+    pub fn from_fhe_rs(inner: PublicKey, params: Arc<BfvParameters>) -> Result<Vec<u8>> {
+        let value = Self { inner, params };
+        Ok(bincode::serialize(&value)?)
+    }
+
+    pub fn from_bytes(bytes:Vec<u8>) -> Result<PublicKey> {
+        let wpk:WrappedPublicKey = bincode::deserialize(&bytes)?;
+        Ok(wpk.inner)
     }
 }
 
-impl fhe_traits::Serialize for WrappedPublicKey {
-    fn to_bytes(&self) -> Vec<u8> {
-        self.inner.to_bytes()
-    }
-}
+// impl fhe_traits::Serialize for WrappedPublicKey {
+//     fn to_bytes(&self) -> Vec<u8> {
+//         self.inner.to_bytes()
+//     }
+// }
 
 /// Deserialize from serde to WrappedPublicKey
 impl<'de> serde::Deserialize<'de> for WrappedPublicKey {
@@ -40,7 +46,7 @@ impl<'de> serde::Deserialize<'de> for WrappedPublicKey {
         let params = Arc::new(BfvParameters::try_deserialize(&par).unwrap()); // TODO: fix errors
         let inner = PublicKey::from_bytes(&bytes, &params).map_err(serde::de::Error::custom)?;
         // TODO: how do we create an invariant that the deserialized params match the global params?
-        std::result::Result::Ok(WrappedPublicKey::from_fhe_rs(inner, params))
+        std::result::Result::Ok(Self { inner, params })
     }
 }
 
@@ -61,20 +67,20 @@ impl serde::Serialize for WrappedPublicKey {
     }
 }
 
-impl Hash for WrappedPublicKey {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.inner.to_bytes().hash(state)
-    }
-}
-
-impl Ord for WrappedPublicKey {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.inner.to_bytes().cmp(&other.inner.to_bytes())
-    }
-}
-
-impl PartialOrd for WrappedPublicKey {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
+// impl Hash for WrappedPublicKey {
+//     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+//         self.inner.to_bytes().hash(state)
+//     }
+// }
+//
+// impl Ord for WrappedPublicKey {
+//     fn cmp(&self, other: &Self) -> Ordering {
+//         self.inner.to_bytes().cmp(&other.inner.to_bytes())
+//     }
+// }
+//
+// impl PartialOrd for WrappedPublicKey {
+//     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+//         Some(self.cmp(other))
+//     }
+// }

--- a/packages/ciphernode/core/src/wrapped/public_key.rs
+++ b/packages/ciphernode/core/src/wrapped/public_key.rs
@@ -2,36 +2,30 @@ use anyhow::*;
 use fhe::bfv::{BfvParameters, PublicKey};
 use fhe_traits::{Deserialize, DeserializeParametrized, Serialize};
 use serde::Serializer;
-use std::{cmp::Ordering, hash::Hash, sync::Arc};
+use std::sync::Arc;
+
 /// Wrapped PublicKey. This is wrapped to provide an inflection point
 /// as we use this library elsewhere we only implement traits as we need them
 /// and avoid exposing underlying structures from fhe.rs
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct WrappedPublicKey {
+pub struct PublicKeySerializer {
     inner: PublicKey,
     params: Arc<BfvParameters>,
 }
 
-impl WrappedPublicKey {
-    pub fn from_fhe_rs(inner: PublicKey, params: Arc<BfvParameters>) -> Result<Vec<u8>> {
+impl PublicKeySerializer {
+    pub fn to_bytes(inner: PublicKey, params: Arc<BfvParameters>) -> Result<Vec<u8>> {
         let value = Self { inner, params };
         Ok(bincode::serialize(&value)?)
     }
 
-    pub fn from_bytes(bytes:Vec<u8>) -> Result<PublicKey> {
-        let wpk:WrappedPublicKey = bincode::deserialize(&bytes)?;
+    pub fn from_bytes(bytes: Vec<u8>) -> Result<PublicKey> {
+        let wpk: PublicKeySerializer = bincode::deserialize(&bytes)?;
         Ok(wpk.inner)
     }
 }
 
-// impl fhe_traits::Serialize for WrappedPublicKey {
-//     fn to_bytes(&self) -> Vec<u8> {
-//         self.inner.to_bytes()
-//     }
-// }
-
-/// Deserialize from serde to WrappedPublicKey
-impl<'de> serde::Deserialize<'de> for WrappedPublicKey {
+/// Deserialize from serde to PublicKeySerializer
+impl<'de> serde::Deserialize<'de> for PublicKeySerializer {
     fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
@@ -51,7 +45,7 @@ impl<'de> serde::Deserialize<'de> for WrappedPublicKey {
 }
 
 /// Serialize to serde bytes representation
-impl serde::Serialize for WrappedPublicKey {
+impl serde::Serialize for PublicKeySerializer {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -67,19 +61,19 @@ impl serde::Serialize for WrappedPublicKey {
     }
 }
 
-// impl Hash for WrappedPublicKey {
+// impl Hash for PublicKeySerializer {
 //     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
 //         self.inner.to_bytes().hash(state)
 //     }
 // }
 //
-// impl Ord for WrappedPublicKey {
+// impl Ord for PublicKeySerializer {
 //     fn cmp(&self, other: &Self) -> Ordering {
 //         self.inner.to_bytes().cmp(&other.inner.to_bytes())
 //     }
 // }
 //
-// impl PartialOrd for WrappedPublicKey {
+// impl PartialOrd for PublicKeySerializer {
 //     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
 //         Some(self.cmp(other))
 //     }

--- a/packages/ciphernode/core/src/wrapped/secret_key.rs
+++ b/packages/ciphernode/core/src/wrapped/secret_key.rs
@@ -15,8 +15,9 @@ pub struct WrappedSecretKey {
 }
 
 impl WrappedSecretKey {
-    pub fn from_fhe_rs(inner: SecretKey, params: Arc<BfvParameters>) -> Self {
-        Self { inner, params }
+    pub fn from_fhe_rs(inner: SecretKey, params: Arc<BfvParameters>) -> Result<Vec<u8>> {
+        let value = Self { inner, params };
+        Ok(value.unsafe_serialize()?)
     }
 }
 
@@ -37,9 +38,9 @@ impl WrappedSecretKey {
     pub fn deserialize(bytes: Vec<u8>) -> Result<WrappedSecretKey> {
         let SecretKeyData { coeffs, par } = bincode::deserialize(&bytes)?;
         let params = Arc::new(BfvParameters::try_deserialize(&par).unwrap());
-        Ok(WrappedSecretKey::from_fhe_rs(
-            SecretKey::new(coeffs.to_vec(), &params),
+        Ok(Self {
+            inner: SecretKey::new(coeffs.to_vec(), &params),
             params,
-        ))
+        })
     }
 }

--- a/packages/ciphernode/core/src/wrapped/secret_key.rs
+++ b/packages/ciphernode/core/src/wrapped/secret_key.rs
@@ -8,16 +8,19 @@ use std::sync::Arc;
 /// and avoid exposing underlying structures from fhe.rs
 // We should favor consuming patterns and avoid cloning and copying this value around in memory.
 // Underlying key Zeroizes on drop
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct WrappedSecretKey {
+pub struct SecretKeySerializer {
     pub inner: SecretKey,
     pub params: Arc<BfvParameters>,
 }
 
-impl WrappedSecretKey {
-    pub fn from_fhe_rs(inner: SecretKey, params: Arc<BfvParameters>) -> Result<Vec<u8>> {
+impl SecretKeySerializer {
+    pub fn to_bytes(inner: SecretKey, params: Arc<BfvParameters>) -> Result<Vec<u8>> {
         let value = Self { inner, params };
         Ok(value.unsafe_serialize()?)
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Result<SecretKey> {
+        Ok(Self::deserialize(bytes)?.inner)
     }
 }
 
@@ -27,7 +30,7 @@ struct SecretKeyData {
     par: Vec<u8>,
 }
 
-impl WrappedSecretKey {
+impl SecretKeySerializer {
     pub fn unsafe_serialize(&self) -> Result<Vec<u8>> {
         Ok(bincode::serialize(&SecretKeyData {
             coeffs: self.inner.coeffs.clone(),
@@ -35,7 +38,7 @@ impl WrappedSecretKey {
         })?)
     }
 
-    pub fn deserialize(bytes: Vec<u8>) -> Result<WrappedSecretKey> {
+    pub fn deserialize(bytes: &[u8]) -> Result<SecretKeySerializer> {
         let SecretKeyData { coeffs, par } = bincode::deserialize(&bytes)?;
         let params = Arc::new(BfvParameters::try_deserialize(&par).unwrap());
         Ok(Self {


### PR DESCRIPTION
Fixes: #31 

This 
- Converts all event key types to `Vec<u8>` limiting the blast radius of a FHE lib change. 
- Rename wrappers to Serializers.
