### PR TITLE
feat: add `e3Id` and `seed` to `validate()` calls to `IE3Program` and `IComputeProvider`

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ sequenceDiagram
     Users->>Enclave: request(parameters)
     Enclave->>E3Program: validate(e3ProgramParams)
     E3Program-->>Enclave: inputValidator
-    Enclave->>ComputeProvider: validate(emParams)
+    Enclave->>ComputeProvider: validate(computeProviderParams)
     ComputeProvider-->>Enclave: decryptionVerifier
     Enclave->>CiphernodeRegistry: requestCommittee(e3Id, filter, threshold)
     CiphernodeRegistry-->>Enclave: success

--- a/packages/evm/contracts/interfaces/IComputeProvider.sol
+++ b/packages/evm/contracts/interfaces/IComputeProvider.sol
@@ -7,6 +7,8 @@ interface IComputeProvider {
     /// @notice This function should be called by the Enclave contract to validate the compute provider parameters.
     /// @param params ABI encoded compute provider parameters.
     function validate(
+        uint256 e3Id,
+        uint256 seed,
         bytes calldata params
     ) external returns (IDecryptionVerifier decryptionVerifier);
 }

--- a/packages/evm/contracts/interfaces/IE3.sol
+++ b/packages/evm/contracts/interfaces/IE3.sol
@@ -20,7 +20,7 @@ import { IDecryptionVerifier } from "./IDecryptionVerifier.sol";
 /// @param ciphertextOutput Encrypted output data.
 /// @param plaintextOutput Decrypted output data.
 struct E3 {
-    bytes32 seed;
+    uint256 seed;
     uint32[2] threshold;
     uint256[2] startWindow;
     uint256 duration;

--- a/packages/evm/contracts/interfaces/IE3Program.sol
+++ b/packages/evm/contracts/interfaces/IE3Program.sol
@@ -5,9 +5,13 @@ import { IInputValidator } from "./IInputValidator.sol";
 
 interface IE3Program {
     /// @notice This function should be called by the Enclave contract to validate the computation parameters.
+    /// @param e3Id ID of the E3.
+    /// @param seed Seed for the computation.
     /// @param params ABI encoded computation parameters.
     /// @return inputValidator The input validator to be used for the computation.
     function validate(
+        uint256 e3Id,
+        uint256 seed,
         bytes calldata params
     ) external returns (IInputValidator inputValidator);
 

--- a/packages/evm/contracts/interfaces/IEnclave.sol
+++ b/packages/evm/contracts/interfaces/IEnclave.sol
@@ -98,7 +98,7 @@ interface IEnclave {
     /// @param e3Program Address of the E3 Program.
     /// @param e3ProgramParams ABI encoded computation parameters.
     /// @param computeProvider Address of the compute provider.
-    /// @param emParams ABI encoded compute provider parameters.
+    /// @param computeProviderParams ABI encoded compute provider parameters.
     /// @return e3Id ID of the E3.
     /// @return e3 The E3 struct.
     function request(
@@ -109,7 +109,7 @@ interface IEnclave {
         IE3Program e3Program,
         bytes memory e3ProgramParams,
         IComputeProvider computeProvider,
-        bytes memory emParams
+        bytes memory computeProviderParams
     ) external payable returns (uint256 e3Id, E3 memory e3);
 
     /// @notice This function should be called to activate an Encrypted Execution Environment (E3) once it has been

--- a/packages/evm/contracts/test/MockComputeProvider.sol
+++ b/packages/evm/contracts/test/MockComputeProvider.sol
@@ -10,6 +10,8 @@ contract MockComputeProvider is IComputeProvider {
     error invalidParams();
 
     function validate(
+        uint256,
+        uint256,
         bytes memory params
     ) external pure returns (IDecryptionVerifier decryptionVerifier) {
         require(params.length == 32, invalidParams());

--- a/packages/evm/contracts/test/MockE3Program.sol
+++ b/packages/evm/contracts/test/MockE3Program.sol
@@ -7,6 +7,8 @@ contract MockE3Program is IE3Program {
     error invalidParams(bytes params);
 
     function validate(
+        uint256,
+        uint256,
         bytes memory params
     ) external pure returns (IInputValidator inputValidator) {
         require(params.length == 32, "invalid params");


### PR DESCRIPTION
Closes #33

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced parameter naming for clarity in various interfaces and contracts.
	- Added new parameters (`e3Id` and `seed`) to validation functions for improved context and validation processes.

- **Bug Fixes**
	- Improved validation logic to ensure it aligns with the current computation context.

- **Documentation**
	- Updated documentation comments to reflect new parameters and their purposes across interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->