### PR TITLE
feat: store ciphernode in an incremental merkle tree

### DIFF
--- a/packages/evm/contracts/interfaces/ICiphernodeRegistry.sol
+++ b/packages/evm/contracts/interfaces/ICiphernodeRegistry.sol
@@ -22,10 +22,28 @@ interface ICiphernodeRegistry {
     event EnclaveSet(address indexed enclave);
 
     /// @notice This event MUST be emitted when a ciphernode is added to the registry.
-    event CiphernodeAdded(address indexed node);
+    /// @param node Address of the ciphernode.
+    /// @param index Index of the ciphernode in the registry.
+    /// @param numNodes Number of ciphernodes in the registry.
+    /// @param size Size of the registry.
+    event CiphernodeAdded(
+        address indexed node,
+        uint256 index,
+        uint256 numNodes,
+        uint256 size
+    );
 
     /// @notice This event MUST be emitted when a ciphernode is removed from the registry.
-    event CiphernodeRemoved(address indexed node);
+    /// @param node Address of the ciphernode.
+    /// @param index Index of the ciphernode in the registry.
+    /// @param numNodes Number of ciphernodes in the registry.
+    /// @param size Size of the registry.
+    event CiphernodeRemoved(
+        address indexed node,
+        uint256 index,
+        uint256 numNodes,
+        uint256 size
+    );
 
     function isCiphernodeEligible(address ciphernode) external returns (bool);
 

--- a/packages/evm/contracts/registry/CiphernodeRegistryOwnable.sol
+++ b/packages/evm/contracts/registry/CiphernodeRegistryOwnable.sol
@@ -26,6 +26,7 @@ contract CiphernodeRegistryOwnable is ICiphernodeRegistry, OwnableUpgradeable {
     LeanIMTData public ciphernodes;
 
     mapping(uint256 e3Id => IRegistryFilter filter) public requests;
+    mapping(uint256 e3Id => uint256 root) public roots;
     mapping(uint256 e3Id => bytes publicKey) public publicKeys;
 
     ////////////////////////////////////////////////////////////
@@ -84,6 +85,7 @@ contract CiphernodeRegistryOwnable is ICiphernodeRegistry, OwnableUpgradeable {
             CommitteeAlreadyRequested()
         );
         requests[e3Id] = IRegistryFilter(filter);
+        roots[e3Id] = root();
 
         IRegistryFilter(filter).requestCommittee(e3Id, threshold);
         emit CommitteeRequested(e3Id, filter, threshold);
@@ -161,5 +163,13 @@ contract CiphernodeRegistryOwnable is ICiphernodeRegistry, OwnableUpgradeable {
 
     function isEnabled(address node) public view returns (bool) {
         return ciphernodes._has(uint256(bytes32(bytes20(node))));
+    }
+
+    function root() public view returns (uint256) {
+        return (ciphernodes._root());
+    }
+
+    function rootAt(uint256 e3Id) public view returns (uint256) {
+        return roots[e3Id];
     }
 }


### PR DESCRIPTION
This PR:

1. adds some additional parameters to the `CiphernodeAdded()` and `CiphernodeRemoved()` events, to make it simpler for the node software to track the current state of the registry.
2. accumulates registered ciphernodes in an incremental merkle tree to efficiently enable some proving and sorition methods.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced events for added and removed ciphernodes, now providing additional context such as index, number of nodes, and size of the registry.
	- Introduced a new public function to check if a ciphernode exists within the registry.
	- Updated methods for adding and removing ciphernodes to improve dynamic management.

- **Bug Fixes**
	- Removed redundant tracking mechanism for ciphernode status, streamlining management functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->