### PR TITLE
Move Compute Provider validation and coordination to the E3Program contract

### DIFF
--- a/packages/evm/contracts/interfaces/IE3.sol
+++ b/packages/evm/contracts/interfaces/IE3.sol
@@ -28,7 +28,6 @@ struct E3 {
     IE3Program e3Program;
     bytes e3ProgramParams;
     IInputValidator inputValidator;
-    IComputeProvider computeProvider;
     IDecryptionVerifier decryptionVerifier;
     bytes committeePublicKey;
     bytes ciphertextOutput;

--- a/packages/evm/contracts/interfaces/IE3Program.sol
+++ b/packages/evm/contracts/interfaces/IE3Program.sol
@@ -2,18 +2,27 @@
 pragma solidity >=0.8.27;
 
 import { IInputValidator } from "./IInputValidator.sol";
+import { IDecryptionVerifier } from "./IDecryptionVerifier.sol";
 
 interface IE3Program {
     /// @notice This function should be called by the Enclave contract to validate the computation parameters.
     /// @param e3Id ID of the E3.
     /// @param seed Seed for the computation.
-    /// @param params ABI encoded computation parameters.
+    /// @param e3ProgramParams ABI encoded computation parameters.
+    /// @param computeProviderParams ABI encoded compute provider parameters.
     /// @return inputValidator The input validator to be used for the computation.
+    /// @return decryptionVerifier The decryption verifier to be used for the computation.
     function validate(
         uint256 e3Id,
         uint256 seed,
-        bytes calldata params
-    ) external returns (IInputValidator inputValidator);
+        bytes calldata e3ProgramParams,
+        bytes calldata computeProviderParams
+    )
+        external
+        returns (
+            IInputValidator inputValidator,
+            IDecryptionVerifier decryptionVerifier
+        );
 
     /// @notice This function should be called by the Enclave contract to verify the decrypted output of an E3.
     /// @param e3Id ID of the E3.

--- a/packages/evm/contracts/interfaces/IEnclave.sol
+++ b/packages/evm/contracts/interfaces/IEnclave.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.8.27;
 
-import { E3, IE3Program, IComputeProvider } from "./IE3.sol";
+import { E3, IE3Program } from "./IE3.sol";
 
 interface IEnclave {
     ////////////////////////////////////////////////////////////
@@ -15,13 +15,11 @@ interface IEnclave {
     /// @param e3 Details of the E3.
     /// @param filter Address of the pool of nodes from which the Cipher Node committee was selected.
     /// @param e3Program Address of the Computation module selected.
-    /// @param computeProvider  Address of the compute provider selected.
     event E3Requested(
         uint256 e3Id,
         E3 e3,
         address filter,
-        IE3Program indexed e3Program,
-        IComputeProvider indexed computeProvider
+        IE3Program indexed e3Program
     );
 
     /// @notice This event MUST be emitted when an Encrypted Execution Environment (E3) is successfully activated.
@@ -76,14 +74,6 @@ interface IEnclave {
     /// @param e3Program The address of the E3 Program.
     event E3ProgramDisabled(IE3Program e3Program);
 
-    /// @notice This event MUST be emitted any time an compute provider is enabled.
-    /// @param computeProvider The address of the compute provider.
-    event ComputeProviderEnabled(IComputeProvider computeProvider);
-
-    /// @notice This event MUST be emitted any time an compute provider is disabled.
-    /// @param computeProvider The address of the compute provider.
-    event ComputeProviderDisabled(IComputeProvider computeProvider);
-
     ////////////////////////////////////////////////////////////
     //                                                        //
     //                  Core Entrypoints                      //
@@ -97,7 +87,6 @@ interface IEnclave {
     /// @param duration The duration of the computation in seconds.
     /// @param e3Program Address of the E3 Program.
     /// @param e3ProgramParams ABI encoded computation parameters.
-    /// @param computeProvider Address of the compute provider.
     /// @param computeProviderParams ABI encoded compute provider parameters.
     /// @return e3Id ID of the E3.
     /// @return e3 The E3 struct.
@@ -108,7 +97,6 @@ interface IEnclave {
         uint256 duration,
         IE3Program e3Program,
         bytes memory e3ProgramParams,
-        IComputeProvider computeProvider,
         bytes memory computeProviderParams
     ) external payable returns (uint256 e3Id, E3 memory e3);
 

--- a/packages/evm/contracts/test/MockE3Program.sol
+++ b/packages/evm/contracts/test/MockE3Program.sol
@@ -1,20 +1,36 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.8.27;
 
-import { IE3Program, IInputValidator } from "../interfaces/IE3Program.sol";
+import {
+    IE3Program,
+    IInputValidator,
+    IDecryptionVerifier
+} from "../interfaces/IE3Program.sol";
 
 contract MockE3Program is IE3Program {
-    error invalidParams(bytes params);
+    error invalidParams(bytes e3ProgramParams, bytes computeProviderParams);
 
     function validate(
         uint256,
         uint256,
-        bytes memory params
-    ) external pure returns (IInputValidator inputValidator) {
-        require(params.length == 32, "invalid params");
+        bytes memory e3ProgramParams,
+        bytes memory computeProviderParams
+    )
+        external
+        pure
+        returns (
+            IInputValidator inputValidator,
+            IDecryptionVerifier decryptionVerifier
+        )
+    {
+        require(
+            e3ProgramParams.length == 32 && computeProviderParams.length == 32,
+            invalidParams(e3ProgramParams, computeProviderParams)
+        );
         // solhint-disable no-inline-assembly
         assembly {
-            inputValidator := mload(add(params, 32))
+            inputValidator := mload(add(e3ProgramParams, 32))
+            decryptionVerifier := mload(add(computeProviderParams, 32))
         }
     }
 

--- a/packages/evm/test/Enclave.spec.ts
+++ b/packages/evm/test/Enclave.spec.ts
@@ -42,7 +42,6 @@ describe("Enclave", function () {
     });
 
     await enclave.enableE3Program(await e3Program.getAddress());
-    await enclave.enableComputeProvider(await computeProvider.getAddress());
 
     return {
       owner,
@@ -68,7 +67,6 @@ describe("Enclave", function () {
           ["address"],
           [await inputValidator.getAddress()],
         ),
-        computeProvider: await computeProvider.getAddress(),
         computeProviderParams: abiCoder.encode(
           ["address"],
           [await decryptionVerifier.getAddress()],
@@ -196,7 +194,6 @@ describe("Enclave", function () {
         request.duration,
         request.e3Program,
         request.e3ProgramParams,
-        request.computeProvider,
         request.computeProviderParams,
         { value: 10 },
       );
@@ -209,7 +206,6 @@ describe("Enclave", function () {
       expect(e3.inputValidator).to.equal(
         abiCoder.decode(["address"], request.e3ProgramParams)[0],
       );
-      expect(e3.computeProvider).to.equal(request.computeProvider);
       expect(e3.decryptionVerifier).to.equal(
         abiCoder.decode(["address"], request.computeProviderParams)[0],
       );
@@ -309,98 +305,6 @@ describe("Enclave", function () {
     });
   });
 
-  describe("enableComputeProvider()", function () {
-    it("reverts if not called by owner", async function () {
-      const { notTheOwner, enclave } = await loadFixture(setup);
-      await expect(
-        enclave.connect(notTheOwner).enableComputeProvider(AddressTwo),
-      )
-        .to.be.revertedWithCustomError(enclave, "OwnableUnauthorizedAccount")
-        .withArgs(notTheOwner.address);
-    });
-    it("reverts if compute provider is already enabled", async function () {
-      const {
-        enclave,
-        mocks: { computeProvider },
-      } = await loadFixture(setup);
-      await expect(enclave.enableComputeProvider(computeProvider))
-        .to.be.revertedWithCustomError(enclave, "ModuleAlreadyEnabled")
-        .withArgs(computeProvider);
-    });
-    it("enables compute provider correctly", async function () {
-      const {
-        enclave,
-        mocks: { computeProvider },
-      } = await loadFixture(setup);
-      const enabled = await enclave.computeProviders(computeProvider);
-      expect(enabled).to.be.true;
-    });
-    it("returns true if compute provider is enabled successfully", async function () {
-      const { enclave } = await loadFixture(setup);
-      const result = await enclave.enableComputeProvider.staticCall(AddressTwo);
-
-      expect(result).to.be.true;
-    });
-    it("emits ComputeProviderEnabled event", async function () {
-      const { enclave } = await loadFixture(setup);
-      await expect(enclave.enableComputeProvider(AddressTwo))
-        .to.emit(enclave, "ComputeProviderEnabled")
-        .withArgs(AddressTwo);
-    });
-  });
-
-  describe("disableComputeProvider()", function () {
-    it("reverts if not called by owner", async function () {
-      const {
-        notTheOwner,
-        enclave,
-        mocks: { computeProvider },
-      } = await loadFixture(setup);
-
-      await expect(
-        enclave.connect(notTheOwner).disableComputeProvider(computeProvider),
-      )
-        .to.be.revertedWithCustomError(enclave, "OwnableUnauthorizedAccount")
-        .withArgs(notTheOwner);
-    });
-    it("reverts if compute provider is not enabled", async function () {
-      const { enclave } = await loadFixture(setup);
-      await expect(enclave.disableComputeProvider(AddressTwo))
-        .to.be.revertedWithCustomError(enclave, "ModuleNotEnabled")
-        .withArgs(AddressTwo);
-    });
-    it("disables compute provider correctly", async function () {
-      const {
-        enclave,
-        mocks: { computeProvider },
-      } = await loadFixture(setup);
-
-      expect(await enclave.computeProviders(computeProvider)).to.be.true;
-      await enclave.disableComputeProvider(computeProvider);
-      expect(await enclave.computeProviders(computeProvider)).to.be.false;
-    });
-    it("returns true if compute provider is disabled successfully", async function () {
-      const {
-        enclave,
-        mocks: { computeProvider },
-      } = await loadFixture(setup);
-      const result =
-        await enclave.disableComputeProvider.staticCall(computeProvider);
-
-      expect(result).to.be.true;
-    });
-    it("emits ComputeProviderDisabled event", async function () {
-      const {
-        enclave,
-        mocks: { computeProvider },
-      } = await loadFixture(setup);
-
-      await expect(enclave.disableComputeProvider(computeProvider))
-        .to.emit(enclave, "ComputeProviderDisabled")
-        .withArgs(computeProvider);
-    });
-  });
-
   describe("request()", function () {
     it("reverts if msg.value is 0", async function () {
       const { enclave, request } = await loadFixture(setup);
@@ -412,7 +316,6 @@ describe("Enclave", function () {
           request.duration,
           request.e3Program,
           request.e3ProgramParams,
-          request.computeProvider,
           request.computeProviderParams,
         ),
       ).to.be.revertedWithCustomError(enclave, "PaymentRequired");
@@ -427,7 +330,6 @@ describe("Enclave", function () {
           request.duration,
           request.e3Program,
           request.e3ProgramParams,
-          request.computeProvider,
           request.computeProviderParams,
           { value: 10 },
         ),
@@ -443,7 +345,6 @@ describe("Enclave", function () {
           request.duration,
           request.e3Program,
           request.e3ProgramParams,
-          request.computeProvider,
           request.computeProviderParams,
           { value: 10 },
         ),
@@ -459,7 +360,6 @@ describe("Enclave", function () {
           0,
           request.e3Program,
           request.e3ProgramParams,
-          request.computeProvider,
           request.computeProviderParams,
           { value: 10 },
         ),
@@ -475,7 +375,6 @@ describe("Enclave", function () {
           time.duration.days(31),
           request.e3Program,
           request.e3ProgramParams,
-          request.computeProvider,
           request.computeProviderParams,
           { value: 10 },
         ),
@@ -491,30 +390,11 @@ describe("Enclave", function () {
           request.duration,
           ethers.ZeroAddress,
           request.e3ProgramParams,
-          request.computeProvider,
           request.computeProviderParams,
           { value: 10 },
         ),
       )
         .to.be.revertedWithCustomError(enclave, "E3ProgramNotAllowed")
-        .withArgs(ethers.ZeroAddress);
-    });
-    it("reverts if compute provider is not enabled", async function () {
-      const { enclave, request } = await loadFixture(setup);
-      await expect(
-        enclave.request(
-          request.filter,
-          request.threshold,
-          request.startTime,
-          request.duration,
-          request.e3Program,
-          request.e3ProgramParams,
-          ethers.ZeroAddress,
-          request.computeProviderParams,
-          { value: 10 },
-        ),
-      )
-        .to.be.revertedWithCustomError(enclave, "ModuleNotEnabled")
         .withArgs(ethers.ZeroAddress);
     });
     it("reverts if input E3 Program does not return input validator address", async function () {
@@ -528,11 +408,10 @@ describe("Enclave", function () {
           request.duration,
           request.e3Program,
           ZeroHash,
-          request.computeProvider,
           request.computeProviderParams,
           { value: 10 },
         ),
-      ).to.be.revertedWithCustomError(enclave, "InvalidComputation");
+      ).to.be.revertedWithCustomError(enclave, "InvalidComputationRequest");
     });
     it("reverts if input compute provider does not return output verifier address", async function () {
       const { enclave, request } = await loadFixture(setup);
@@ -544,11 +423,10 @@ describe("Enclave", function () {
           request.duration,
           request.e3Program,
           request.e3ProgramParams,
-          request.computeProvider,
           ZeroHash,
           { value: 10 },
         ),
-      ).to.be.revertedWithCustomError(enclave, "InvalidComputeProviderSetup");
+      ).to.be.revertedWithCustomError(enclave, "InvalidComputationRequest");
     });
     it("reverts if committee selection fails", async function () {
       const { enclave, request } = await loadFixture(setup);
@@ -560,7 +438,6 @@ describe("Enclave", function () {
           request.duration,
           request.e3Program,
           request.e3ProgramParams,
-          request.computeProvider,
           request.computeProviderParams,
           { value: 10 },
         ),
@@ -575,7 +452,6 @@ describe("Enclave", function () {
         request.duration,
         request.e3Program,
         request.e3ProgramParams,
-        request.computeProvider,
         request.computeProviderParams,
         { value: 10 },
       );
@@ -587,7 +463,6 @@ describe("Enclave", function () {
       expect(e3.inputValidator).to.equal(
         abiCoder.decode(["address"], request.e3ProgramParams)[0],
       );
-      expect(e3.computeProvider).to.equal(request.computeProvider);
       expect(e3.decryptionVerifier).to.equal(
         abiCoder.decode(["address"], request.computeProviderParams)[0],
       );
@@ -604,7 +479,6 @@ describe("Enclave", function () {
         request.duration,
         request.e3Program,
         request.e3ProgramParams,
-        request.computeProvider,
         request.computeProviderParams,
         { value: 10 },
       );
@@ -612,13 +486,7 @@ describe("Enclave", function () {
 
       await expect(tx)
         .to.emit(enclave, "E3Requested")
-        .withArgs(
-          0,
-          e3,
-          request.filter,
-          request.e3Program,
-          request.computeProvider,
-        );
+        .withArgs(0, e3, request.filter, request.e3Program);
     });
   });
 
@@ -640,7 +508,6 @@ describe("Enclave", function () {
         request.duration,
         request.e3Program,
         request.e3ProgramParams,
-        request.computeProvider,
         request.computeProviderParams,
         { value: 10 },
       );
@@ -665,7 +532,6 @@ describe("Enclave", function () {
         request.duration,
         request.e3Program,
         request.e3ProgramParams,
-        request.computeProvider,
         request.computeProviderParams,
         { value: 10 },
       );
@@ -689,7 +555,6 @@ describe("Enclave", function () {
         request.duration,
         request.e3Program,
         request.e3ProgramParams,
-        request.computeProvider,
         request.computeProviderParams,
         { value: 10 },
       );
@@ -715,7 +580,6 @@ describe("Enclave", function () {
         request.duration,
         request.e3Program,
         request.e3ProgramParams,
-        request.computeProvider,
         request.computeProviderParams,
         { value: 10 },
       );
@@ -739,7 +603,6 @@ describe("Enclave", function () {
         request.duration,
         request.e3Program,
         request.e3ProgramParams,
-        request.computeProvider,
         request.computeProviderParams,
         { value: 10 },
       );
@@ -761,7 +624,6 @@ describe("Enclave", function () {
         request.duration,
         request.e3Program,
         request.e3ProgramParams,
-        request.computeProvider,
         request.computeProviderParams,
         { value: 10 },
       );
@@ -794,7 +656,6 @@ describe("Enclave", function () {
         request.duration,
         request.e3Program,
         request.e3ProgramParams,
-        request.computeProvider,
         request.computeProviderParams,
         { value: 10 },
       );
@@ -820,7 +681,6 @@ describe("Enclave", function () {
         request.duration,
         request.e3Program,
         request.e3ProgramParams,
-        request.computeProvider,
         request.computeProviderParams,
         { value: 10 },
       );
@@ -839,7 +699,6 @@ describe("Enclave", function () {
         request.duration,
         request.e3Program,
         request.e3ProgramParams,
-        request.computeProvider,
         request.computeProviderParams,
         { value: 10 },
       );
@@ -872,7 +731,6 @@ describe("Enclave", function () {
         request.duration,
         request.e3Program,
         request.e3ProgramParams,
-        request.computeProvider,
         request.computeProviderParams,
         { value: 10 },
       );
@@ -897,7 +755,6 @@ describe("Enclave", function () {
         request.duration,
         request.e3Program,
         request.e3ProgramParams,
-        request.computeProvider,
         request.computeProviderParams,
         { value: 10 },
       );
@@ -918,7 +775,6 @@ describe("Enclave", function () {
         request.duration,
         request.e3Program,
         request.e3ProgramParams,
-        request.computeProvider,
         request.computeProviderParams,
         { value: 10 },
       );
@@ -942,7 +798,6 @@ describe("Enclave", function () {
         request.duration,
         request.e3Program,
         request.e3ProgramParams,
-        request.computeProvider,
         request.computeProviderParams,
         { value: 10 },
       );
@@ -967,7 +822,6 @@ describe("Enclave", function () {
         request.duration,
         request.e3Program,
         request.e3ProgramParams,
-        request.computeProvider,
         request.computeProviderParams,
         { value: 10 },
       );
@@ -996,7 +850,6 @@ describe("Enclave", function () {
         request.duration,
         request.e3Program,
         request.e3ProgramParams,
-        request.computeProvider,
         request.computeProviderParams,
         { value: 10 },
       );
@@ -1032,7 +885,6 @@ describe("Enclave", function () {
         request.duration,
         request.e3Program,
         request.e3ProgramParams,
-        request.computeProvider,
         request.computeProviderParams,
         { value: 10 },
       );
@@ -1049,7 +901,6 @@ describe("Enclave", function () {
         request.duration,
         request.e3Program,
         request.e3ProgramParams,
-        request.computeProvider,
         request.computeProviderParams,
         { value: 10 },
       );
@@ -1075,7 +926,6 @@ describe("Enclave", function () {
         request.duration,
         request.e3Program,
         request.e3ProgramParams,
-        request.computeProvider,
         request.computeProviderParams,
         { value: 10 },
       );
@@ -1100,7 +950,6 @@ describe("Enclave", function () {
         request.duration,
         request.e3Program,
         request.e3ProgramParams,
-        request.computeProvider,
         request.computeProviderParams,
         { value: 10 },
       );
@@ -1121,7 +970,6 @@ describe("Enclave", function () {
         request.duration,
         request.e3Program,
         request.e3ProgramParams,
-        request.computeProvider,
         request.computeProviderParams,
         { value: 10 },
       );
@@ -1142,7 +990,6 @@ describe("Enclave", function () {
         request.duration,
         request.e3Program,
         request.e3ProgramParams,
-        request.computeProvider,
         request.computeProviderParams,
         { value: 10 },
       );
@@ -1163,7 +1010,6 @@ describe("Enclave", function () {
         request.duration,
         request.e3Program,
         request.e3ProgramParams,
-        request.computeProvider,
         request.computeProviderParams,
         { value: 10 },
       );
@@ -1195,7 +1041,6 @@ describe("Enclave", function () {
         request.duration,
         request.e3Program,
         request.e3ProgramParams,
-        request.computeProvider,
         request.computeProviderParams,
         { value: 10 },
       );
@@ -1214,7 +1059,6 @@ describe("Enclave", function () {
         request.duration,
         request.e3Program,
         request.e3ProgramParams,
-        request.computeProvider,
         request.computeProviderParams,
         { value: 10 },
       );
@@ -1234,7 +1078,6 @@ describe("Enclave", function () {
         request.duration,
         request.e3Program,
         request.e3ProgramParams,
-        request.computeProvider,
         request.computeProviderParams,
         { value: 10 },
       );
@@ -1260,7 +1103,6 @@ describe("Enclave", function () {
         request.duration,
         request.e3Program,
         request.e3ProgramParams,
-        request.computeProvider,
         request.computeProviderParams,
         { value: 10 },
       );
@@ -1282,7 +1124,6 @@ describe("Enclave", function () {
         request.duration,
         request.e3Program,
         request.e3ProgramParams,
-        request.computeProvider,
         request.computeProviderParams,
         { value: 10 },
       );
@@ -1305,7 +1146,6 @@ describe("Enclave", function () {
         request.duration,
         request.e3Program,
         request.e3ProgramParams,
-        request.computeProvider,
         request.computeProviderParams,
         { value: 10 },
       );
@@ -1327,7 +1167,6 @@ describe("Enclave", function () {
         request.duration,
         request.e3Program,
         request.e3ProgramParams,
-        request.computeProvider,
         request.computeProviderParams,
         { value: 10 },
       );


### PR DESCRIPTION
This PR moves Compute Provider validation and coordination to the E3Program contract, allowing each E3Program to explicitly specify if and how it interacts with various compute providers.