### PR TITLE
CommitteeManager -> CiphernodeSupervisor

### DIFF
--- a/packages/ciphernode/core/src/ciphernode_supervisor.rs
+++ b/packages/ciphernode/core/src/ciphernode_supervisor.rs
@@ -18,7 +18,7 @@ pub struct Die;
 struct CommitteeMeta {
     nodecount: usize,
 }
-pub struct CommitteeManager {
+pub struct CiphernodeSupervisor {
     bus: Addr<EventBus>,
     fhe: Addr<Fhe>,
 
@@ -27,11 +27,11 @@ pub struct CommitteeManager {
     meta: HashMap<E3id, CommitteeMeta>,
 }
 
-impl Actor for CommitteeManager {
+impl Actor for CiphernodeSupervisor {
     type Context = Context<Self>;
 }
 
-impl CommitteeManager {
+impl CiphernodeSupervisor {
     pub fn new(bus: Addr<EventBus>, fhe: Addr<Fhe>) -> Self {
         Self {
             bus,
@@ -43,7 +43,7 @@ impl CommitteeManager {
     }
 
     pub fn attach(bus: Addr<EventBus>, fhe: Addr<Fhe>) -> Addr<Self> {
-        let addr = CommitteeManager::new(bus.clone(), fhe).start();
+        let addr = CiphernodeSupervisor::new(bus.clone(), fhe).start();
         bus.do_send(Subscribe::new(
             "CommitteeRequested",
             addr.clone().recipient(),
@@ -65,7 +65,7 @@ impl CommitteeManager {
     }
 }
 
-impl Handler<EnclaveEvent> for CommitteeManager {
+impl Handler<EnclaveEvent> for CiphernodeSupervisor {
     type Result = ();
 
     fn handle(&mut self, event: EnclaveEvent, _ctx: &mut Self::Context) -> Self::Result {

--- a/packages/ciphernode/core/src/lib.rs
+++ b/packages/ciphernode/core/src/lib.rs
@@ -3,7 +3,7 @@
 // #![warn(missing_docs, unused_imports)]
 
 mod ciphernode;
-mod committee;
+mod ciphernode_supervisor;
 mod publickey_aggregator;
 mod data;
 mod plaintext_aggregator;
@@ -19,7 +19,7 @@ mod serializers;
 // TODO: this is too permissive
 pub use actix::prelude::*;
 pub use ciphernode::*;
-pub use committee::*;
+pub use ciphernode_supervisor::*;
 pub use publickey_aggregator::*;
 pub use data::*;
 pub use eventbus::*;
@@ -30,7 +30,7 @@ pub use p2p::*;
 
 pub use actix::prelude::*;
 pub use ciphernode::*;
-pub use committee::*;
+pub use ciphernode_supervisor::*;
 pub use publickey_aggregator::*;
 pub use data::*;
 pub use eventbus::*;
@@ -60,7 +60,7 @@ pub use p2p::*;
 mod tests {
     use crate::{
         ciphernode::Ciphernode,
-        committee::CommitteeManager,
+        ciphernode_supervisor::CiphernodeSupervisor,
         data::Data,
         eventbus::{EventBus, GetHistory},
         events::{CommitteeRequested, E3id, EnclaveEvent, KeyshareCreated, PublicKeyAggregated},
@@ -98,7 +98,7 @@ mod tests {
         let node = Ciphernode::attach(bus.clone(), fhe.clone(), data.clone()).await;
 
         // setup the committee manager to generate the comittee public keys
-        CommitteeManager::attach(bus.clone(), fhe.clone());
+        CiphernodeSupervisor::attach(bus.clone(), fhe.clone());
         (node, data)
     }
 

--- a/packages/ciphernode/enclave_node/src/bin/aggregator.rs
+++ b/packages/ciphernode/enclave_node/src/bin/aggregator.rs
@@ -1,5 +1,5 @@
 use enclave_core::Actor;
-use enclave_core::CommitteeManager;
+use enclave_core::CiphernodeSupervisor;
 use enclave_core::EventBus;
 use enclave_core::Fhe;
 use enclave_core::P2p;
@@ -11,7 +11,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let fhe = Fhe::try_default()?.start();
     let bus = EventBus::new(true).start();
     SimpleLogger::attach(bus.clone());
-    CommitteeManager::attach(bus.clone(), fhe.clone());
+    CiphernodeSupervisor::attach(bus.clone(), fhe.clone());
     let (_, h) = P2p::spawn_libp2p(bus.clone())?;
     println!("Aggregator");
     let _ = tokio::join!(h);

--- a/packages/ciphernode/enclave_node/src/bin/ciphernode.rs
+++ b/packages/ciphernode/enclave_node/src/bin/ciphernode.rs
@@ -1,6 +1,6 @@
 use enclave_core::Actor;
 use enclave_core::Ciphernode;
-use enclave_core::CommitteeManager;
+use enclave_core::CiphernodeSupervisor;
 use enclave_core::Data;
 use enclave_core::EventBus;
 use enclave_core::Fhe;
@@ -15,7 +15,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let data = Data::new(true).start(); // TODO: Use a sled backed Data Actor
     SimpleLogger::attach(bus.clone());
     Ciphernode::attach(bus.clone(), fhe.clone(), data.clone());
-    CommitteeManager::attach(bus.clone(), fhe.clone());
+    CiphernodeSupervisor::attach(bus.clone(), fhe.clone());
     let (_, h) = P2p::spawn_libp2p(bus.clone())?;
     println!("Ciphernode");
     let _ = tokio::join!(h);


### PR DESCRIPTION
Renaming to ciphernode supervisor in accordance with the [figma design](https://www.figma.com/board/KIC3zKXC6gQiIbHTYnDCAp/Enclave-Architecture?node-id=0-1&t=v5v7ZtBnhQRxN1B8-1)