### PR TITLE
Added CiphernodeSelector Actor and connect Ciphernode to CiphernodeSelected Event

### DIFF
--- a/packages/ciphernode/core/src/ciphernode_selector.rs
+++ b/packages/ciphernode/core/src/ciphernode_selector.rs
@@ -1,0 +1,46 @@
+use actix::prelude::*;
+
+use crate::{CiphernodeSelected, CommitteeRequested, EnclaveEvent, EventBus, Subscribe};
+
+pub struct CiphernodeSelector {
+    bus: Addr<EventBus>,
+}
+
+impl Actor for CiphernodeSelector {
+    type Context = Context<Self>;
+}
+
+impl CiphernodeSelector {
+    pub fn new(bus: Addr<EventBus>) -> Self {
+        Self { bus }
+    }
+
+    pub fn attach(bus: Addr<EventBus>) -> Addr<Self> {
+        let addr = CiphernodeSelector::new(bus.clone()).start();
+
+        bus.do_send(Subscribe::new(
+            "CommitteeRequested",
+            addr.clone().recipient(),
+        ));
+
+        addr
+    }
+}
+
+impl Handler<EnclaveEvent> for CiphernodeSelector {
+    type Result = ();
+
+    fn handle(&mut self, event: EnclaveEvent, ctx: &mut Self::Context) -> Self::Result {
+        match event {
+            EnclaveEvent::CommitteeRequested { data, .. } => {
+                // TODO: ask Sortition module whether registered node has been selected
+                self.bus.do_send(EnclaveEvent::from(CiphernodeSelected {
+                    e3_id: data.e3_id,
+                    nodecount: data.nodecount,
+                    threshold: data.threshold,
+                }))
+            }
+            _ => (),
+        }
+    }
+}

--- a/packages/ciphernode/core/src/ciphernode_supervisor.rs
+++ b/packages/ciphernode/core/src/ciphernode_supervisor.rs
@@ -1,10 +1,13 @@
-use std::collections::HashMap;
-
-use actix::{Actor, Addr, Context, Handler, Message};
-
 use crate::{
-    eventbus::EventBus, events::{E3id, EnclaveEvent}, fhe::Fhe, plaintext_aggregator::PlaintextAggregator, publickey_aggregator::{self, PublicKeyAggregator}, Subscribe
+    eventbus::EventBus,
+    events::{E3id, EnclaveEvent},
+    fhe::Fhe,
+    plaintext_aggregator::PlaintextAggregator,
+    publickey_aggregator::PublicKeyAggregator,
+    Subscribe,
 };
+use actix::prelude::*;
+use std::collections::HashMap;
 
 #[derive(Message)]
 #[rtype(result = "()")]
@@ -55,10 +58,7 @@ impl CiphernodeSupervisor {
             "DecryptionshareCreated",
             addr.clone().into(),
         ));
-        bus.do_send(Subscribe::new(
-            "PlaintextAggregated",
-            addr.clone().into(),
-        ));
+        bus.do_send(Subscribe::new("PlaintextAggregated", addr.clone().into()));
         addr
     }
 }
@@ -84,7 +84,8 @@ impl Handler<EnclaveEvent> for CiphernodeSupervisor {
                         nodecount: data.nodecount.clone(),
                     },
                 );
-                self.publickey_aggregators.insert(data.e3_id, publickey_aggregator);
+                self.publickey_aggregators
+                    .insert(data.e3_id, publickey_aggregator);
             }
             EnclaveEvent::KeyshareCreated { data, .. } => {
                 if let Some(key) = self.publickey_aggregators.get(&data.e3_id) {
@@ -114,7 +115,8 @@ impl Handler<EnclaveEvent> for CiphernodeSupervisor {
                 )
                 .start();
 
-                self.plaintext_aggregators.insert(data.e3_id, plaintext_aggregator);
+                self.plaintext_aggregators
+                    .insert(data.e3_id, plaintext_aggregator);
             }
             EnclaveEvent::DecryptionshareCreated { data, .. } => {
                 if let Some(decryption) = self.plaintext_aggregators.get(&data.e3_id) {
@@ -128,7 +130,8 @@ impl Handler<EnclaveEvent> for CiphernodeSupervisor {
 
                 addr.do_send(Die);
                 self.plaintext_aggregators.remove(&data.e3_id);
-            }
+            },
+            _ => ()
         }
     }
 }

--- a/packages/ciphernode/enclave_node/src/bin/aggregator.rs
+++ b/packages/ciphernode/enclave_node/src/bin/aggregator.rs
@@ -6,6 +6,7 @@ use enclave_core::P2p;
 use enclave_core::SimpleLogger;
 use std::error::Error;
 
+/// Note this is untestable so it may break as we change our API
 #[actix_rt::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     let fhe = Fhe::try_default()?.start();

--- a/packages/ciphernode/enclave_node/src/bin/ciphernode-noag.rs
+++ b/packages/ciphernode/enclave_node/src/bin/ciphernode-noag.rs
@@ -1,5 +1,6 @@
 use enclave_core::Actor;
 use enclave_core::Ciphernode;
+use enclave_core::CiphernodeSelector;
 use enclave_core::Data;
 use enclave_core::EventBus;
 use enclave_core::Fhe;
@@ -7,11 +8,13 @@ use enclave_core::P2p;
 use enclave_core::SimpleLogger;
 use std::error::Error;
 
+/// Note this is untestable so it may break as we change our API
 #[actix_rt::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     let fhe = Fhe::try_default()?.start();
     let bus = EventBus::new(true).start();
     let data = Data::new(true).start(); // TODO: Use a sled backed Data Actor
+    CiphernodeSelector::attach(bus.clone());
     SimpleLogger::attach(bus.clone());
     Ciphernode::attach(bus.clone(), fhe.clone(), data.clone());
     let (_, h) = P2p::spawn_libp2p(bus.clone())?;

--- a/packages/ciphernode/enclave_node/src/bin/ciphernode.rs
+++ b/packages/ciphernode/enclave_node/src/bin/ciphernode.rs
@@ -1,5 +1,6 @@
 use enclave_core::Actor;
 use enclave_core::Ciphernode;
+use enclave_core::CiphernodeSelector;
 use enclave_core::CiphernodeSupervisor;
 use enclave_core::Data;
 use enclave_core::EventBus;
@@ -8,12 +9,14 @@ use enclave_core::P2p;
 use enclave_core::SimpleLogger;
 use std::error::Error;
 
+/// Note this is untestable so it may break as we change our API
 #[actix_rt::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     let fhe = Fhe::try_default()?.start();
     let bus = EventBus::new(true).start();
     let data = Data::new(true).start(); // TODO: Use a sled backed Data Actor
     SimpleLogger::attach(bus.clone());
+    CiphernodeSelector::attach(bus.clone());
     Ciphernode::attach(bus.clone(), fhe.clone(), data.clone());
     CiphernodeSupervisor::attach(bus.clone(), fhe.clone());
     let (_, h) = P2p::spawn_libp2p(bus.clone())?;

--- a/packages/ciphernode/enclave_node/src/bin/cmd.rs
+++ b/packages/ciphernode/enclave_node/src/bin/cmd.rs
@@ -11,6 +11,7 @@ use tokio::{
     io::{self, AsyncBufReadExt, BufReader},
 };
 
+/// Note this is untestable so it may break as we change our API
 #[actix_rt::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     let bus = EventBus::new(true).start();


### PR DESCRIPTION
This divorces Ciphernode from the CommitteeRequested event in favor of the CiphernodeSelected event.

We are doing this so that the CiphernodeSelector can be aware of the ciphernode ID and as the Sortition module if the ciphernode is selected and can broadcast the event locally. 

This way we avoid coupling. 


Also added notes to untested (demo) parts of the codebase as they cannot be assumed to be correct.