### PR TITLE
Filter local events

### DIFF
--- a/packages/ciphernode/core/src/events.rs
+++ b/packages/ciphernode/core/src/events.rs
@@ -97,6 +97,13 @@ impl EnclaveEvent {
     pub fn get_id(&self) -> EventId {
         self.clone().into()
     }
+
+    pub fn is_local_only(&self) -> bool {
+        match self {
+            EnclaveEvent::CiphernodeSelected { .. } => true,
+            _ => false,
+        }
+    }
 }
 
 impl From<EnclaveEvent> for EventId {

--- a/packages/ciphernode/core/src/lib.rs
+++ b/packages/ciphernode/core/src/lib.rs
@@ -327,7 +327,6 @@ mod tests {
             sortition_seed: 123,
         });
 
-        // This is a local event which should not be broadcast to the network
         let local_evt_3 = EnclaveEvent::from(CiphernodeSelected {
             e3_id: E3id::new("1235"),
             nodecount: 3,
@@ -336,7 +335,7 @@ mod tests {
 
         bus.do_send(evt_1.clone());
         bus.do_send(evt_2.clone());
-        bus.do_send(local_evt_3.clone());
+        bus.do_send(local_evt_3.clone()); // This is a local event which should not be broadcast to the network
 
         sleep(Duration::from_millis(1)).await; // need to push to next tick
 
@@ -351,7 +350,8 @@ mod tests {
 
         assert_eq!(
             history,
-            vec![evt_1, evt_2, local_evt_3],
+            vec![evt_1, evt_2, local_evt_3], // all local events that have been broadcast but no
+                                             // events from the loopback
             "P2p must not retransmit forwarded event to event bus"
         );
 


### PR DESCRIPTION
This filters local events from within the P2P module. 

So far the only local event to filter is the CiphernodeSelected but we should expect the evm events not to be gossipped