### PR TITLE
Hardhat task for adding / removing a ciphernode from the registry

### DIFF
--- a/packages/evm/README.md
+++ b/packages/evm/README.md
@@ -10,3 +10,17 @@ This will add the deployment information to the `./deployments` directory.
 
 Be sure to configure your desired network in `hardhat.config.ts` before
 deploying.
+
+## Registering a Ciphernode
+
+To add a ciphernode to the registry, run
+
+```
+yarn ciphernode:add --network [network] --ciphernode-address [address]
+```
+
+To remove a ciphernode, run
+
+```
+yarn ciphernode:remove --network [network] --ciphernode-address [address]
+```

--- a/packages/evm/hardhat.config.ts
+++ b/packages/evm/hardhat.config.ts
@@ -6,7 +6,7 @@ import { vars } from "hardhat/config";
 import type { NetworkUserConfig } from "hardhat/types";
 
 import "./tasks/accounts";
-import "./tasks/enclave";
+import "./tasks/ciphernode";
 
 dotenv.config();
 

--- a/packages/evm/package.json
+++ b/packages/evm/package.json
@@ -73,6 +73,8 @@
     "compile": "cross-env TS_NODE_TRANSPILE_ONLY=true hardhat compile",
     "coverage": "hardhat coverage --solcoverjs ./.solcover.js --temp artifacts --testfiles \"test/**/*.ts\" && yarn typechain",
     "deploy": "hardhat deploy",
+    "ciphernode:add": "hardhat ciphernode:add",
+    "ciphernode:remove": "hardhat ciphernode:remove",
     "lint": "yarn lint:sol && yarn lint:ts && yarn prettier:check",
     "lint:sol": "solhint --max-warnings 0 \"contracts/**/*.sol\"",
     "lint:ts": "eslint --ignore-path ./.eslintignore --ext .js,.ts .",

--- a/packages/evm/tasks/ciphernode.ts
+++ b/packages/evm/tasks/ciphernode.ts
@@ -1,0 +1,38 @@
+import { task } from "hardhat/config";
+import type { TaskArguments } from "hardhat/types";
+
+task("ciphernode:add", "Register a ciphernode to the registry")
+  .addParam("ciphernodeAddress", "address of ciphernode to register")
+  .setAction(async function (taskArguments: TaskArguments, hre) {
+    const registry = await hre.deployments.get("CyphernodeRegistryOwnable");
+
+    const registryContract = await hre.ethers.getContractAt(
+      "CyphernodeRegistryOwnable",
+      registry.address,
+    );
+
+    const tx = await registryContract.addCyphernode(
+      taskArguments.ciphernodeAddress,
+    );
+    await tx.wait();
+
+    console.log(`Ciphernode ${taskArguments.ciphernodeAddress} registered`);
+  });
+
+task("ciphernode:remove", "Remove a ciphernode from the registry")
+  .addParam("ciphernodeAddress", "address of ciphernode to remove")
+  .setAction(async function (taskArguments: TaskArguments, hre) {
+    const registry = await hre.deployments.get("CyphernodeRegistryOwnable");
+
+    const registryContract = await hre.ethers.getContractAt(
+      "CyphernodeRegistryOwnable",
+      registry.address,
+    );
+
+    const tx = await registryContract.removeCyphernode(
+      taskArguments.ciphernodeAddress,
+    );
+    await tx.wait();
+
+    console.log(`Ciphernode ${taskArguments.ciphernodeAddress} removed`);
+  });


### PR DESCRIPTION
To add a ciphernode to the registry, run

```
yarn ciphernode:add --network [network] --ciphernode-address [address]
```

To remove a ciphernode, run

```
yarn ciphernode:remove --network [network] --ciphernode-address [address]