### PR TITLE
Refactor registries to be more modular

### DIFF
--- a/packages/ciphernode/Cargo.lock
+++ b/packages/ciphernode/Cargo.lock
@@ -1126,6 +1126,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1889,6 +1938,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2333,12 +2428,15 @@ dependencies = [
  "alloy-primitives 0.6.4",
  "async-std",
  "bfv",
+ "clap",
  "enclave-core",
  "eth",
  "fhe",
  "fhe-traits",
  "fhe-util",
  "p2p",
+ "rand",
+ "rand_chacha",
  "sortition",
  "tokio",
 ]
@@ -3292,6 +3390,12 @@ name = "ipnet"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
@@ -5768,6 +5872,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "strum"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6362,6 +6472,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "valuable"

--- a/packages/ciphernode/core/src/ciphernode_registry.rs
+++ b/packages/ciphernode/core/src/ciphernode_registry.rs
@@ -1,0 +1,100 @@
+// TODO: spawn and supervise child actors
+use crate::{Ciphernode, Data, E3id, EnclaveEvent, EventBus, Fhe, InitializeWithEnclaveEvent};
+use actix::prelude::*;
+use alloy_primitives::Address;
+use std::collections::HashMap;
+
+pub struct CiphernodeRegistry {
+    bus: Addr<EventBus>,
+    data: Addr<Data>,
+    address: Address,
+    ciphernodes: HashMap<E3id, Addr<Ciphernode>>,
+    buffers: HashMap<E3id, Vec<EnclaveEvent>>,
+}
+
+impl CiphernodeRegistry {
+    pub fn new(bus: Addr<EventBus>, data: Addr<Data>, address: Address) -> Self {
+        Self {
+            bus,
+            data,
+            address,
+            ciphernodes: HashMap::new(),
+            buffers: HashMap::new(),
+        }
+    }
+
+    pub fn attach(bus: Addr<EventBus>, data: Addr<Data>, address: Address) -> Addr<Self> {
+        CiphernodeRegistry::new(bus, data, address).start()
+    }
+}
+
+impl Actor for CiphernodeRegistry {
+    type Context = Context<Self>;
+}
+
+impl Handler<InitializeWithEnclaveEvent> for CiphernodeRegistry {
+    type Result = ();
+    fn handle(&mut self, msg: InitializeWithEnclaveEvent, _: &mut Self::Context) -> Self::Result {
+        let InitializeWithEnclaveEvent { fhe, event, .. } = msg;
+        let EnclaveEvent::CommitteeRequested { data, .. } = event else {
+            return;
+        };
+
+        let ciphernode_factory = self.ciphernode_factory(fhe.clone());
+        store(&data.e3_id, &mut self.ciphernodes, ciphernode_factory);
+    }
+}
+
+impl Handler<EnclaveEvent> for CiphernodeRegistry {
+    type Result = ();
+
+    fn handle(&mut self, msg: EnclaveEvent, _ctx: &mut Self::Context) -> Self::Result {
+        let Some(e3_id) = msg.get_e3_id() else {
+            return;
+        };
+        self.forward_message(&e3_id, msg);
+    }
+}
+
+impl CiphernodeRegistry {
+    fn ciphernode_factory(&self, fhe: Addr<Fhe>) -> impl FnOnce() -> Addr<Ciphernode> {
+        let data = self.data.clone();
+        let bus = self.bus.clone();
+        let address = self.address;
+        move || Ciphernode::new(bus, fhe, data, address).start()
+    }
+
+    fn store_msg(&mut self, e3_id: E3id, msg: EnclaveEvent) {
+        self.buffers.entry(e3_id).or_default().push(msg);
+    }
+
+    fn take_msgs(&mut self, e3_id: E3id) -> Vec<EnclaveEvent> {
+        self.buffers
+            .get_mut(&e3_id)
+            .map(std::mem::take)
+            .unwrap_or_default()
+    }
+
+    fn forward_message(&mut self, e3_id: &E3id, msg: EnclaveEvent) {
+        // Buffer events for each thing that has not been created
+        if let Some(act) = self.ciphernodes.clone().get(e3_id) {
+            let msgs = self.take_msgs(e3_id.clone());
+            let recipient = act.clone().recipient();
+            recipient.do_send(msg.clone());
+            for m in msgs {
+                recipient.do_send(m);
+            }
+        } else {
+            self.store_msg(e3_id.clone(), msg.clone());
+        }
+    }
+}
+
+// Store on a hashmap a Addr<T> from the factory F
+fn store<T, F>(e3_id: &E3id, map: &mut HashMap<E3id, Addr<T>>, creator: F) -> Addr<T>
+where
+    T: Actor<Context = Context<T>>,
+    F: FnOnce() -> Addr<T>,
+{
+    map.entry(e3_id.clone()).or_insert_with(creator).clone()
+}

--- a/packages/ciphernode/core/src/ciphernode_registry.rs
+++ b/packages/ciphernode/core/src/ciphernode_registry.rs
@@ -39,9 +39,10 @@ impl Handler<InitializeWithEnclaveEvent> for CiphernodeRegistry {
         let EnclaveEvent::CommitteeRequested { data, .. } = event else {
             return;
         };
-
         let ciphernode_factory = self.ciphernode_factory(fhe.clone());
-        store(&data.e3_id, &mut self.ciphernodes, ciphernode_factory);
+        self.ciphernodes
+            .entry(data.e3_id.clone())
+            .or_insert_with(ciphernode_factory);
     }
 }
 
@@ -88,13 +89,4 @@ impl CiphernodeRegistry {
             self.store_msg(e3_id.clone(), msg.clone());
         }
     }
-}
-
-// Store on a hashmap a Addr<T> from the factory F
-fn store<T, F>(e3_id: &E3id, map: &mut HashMap<E3id, Addr<T>>, creator: F) -> Addr<T>
-where
-    T: Actor<Context = Context<T>>,
-    F: FnOnce() -> Addr<T>,
-{
-    map.entry(e3_id.clone()).or_insert_with(creator).clone()
 }

--- a/packages/ciphernode/core/src/main_aggregator.rs
+++ b/packages/ciphernode/core/src/main_aggregator.rs
@@ -1,0 +1,57 @@
+use std::sync::{Arc, Mutex};
+
+use crate::{EventBus, P2p, PlaintextRegistry, PublicKeyRegistry, Registry, Sortition};
+use actix::{Actor, Addr, Context};
+use rand::SeedableRng;
+use rand_chacha::rand_core::OsRng;
+use tokio::task::JoinHandle;
+
+/// Main Ciphernode Actor
+/// Suprvises all children
+// TODO: add supervision logic
+pub struct MainAggregator {
+    bus: Addr<EventBus>,
+    sortition: Addr<Sortition>,
+    registry: Addr<Registry>,
+    p2p: Addr<P2p>,
+}
+
+impl MainAggregator {
+    pub fn new(
+        bus: Addr<EventBus>,
+        sortition: Addr<Sortition>,
+        registry: Addr<Registry>,
+        p2p: Addr<P2p>,
+    ) -> Self {
+        Self {
+            bus,
+            sortition,
+            registry,
+            p2p,
+        }
+    }
+
+    pub async fn attach() -> (Addr<Self>, JoinHandle<()>) {
+        let rng = Arc::new(Mutex::new(
+            rand_chacha::ChaCha20Rng::from_rng(OsRng).expect("Failed to create RNG"),
+        ));
+        let bus = EventBus::new(true).start();
+        let sortition = Sortition::attach(bus.clone());
+        let registry = Registry::attach(
+            bus.clone(),
+            rng,
+            Some(PublicKeyRegistry::attach(bus.clone(), sortition.clone())),
+            Some(PlaintextRegistry::attach(bus.clone(), sortition.clone())),
+            None,
+        )
+        .await;
+        let (p2p_addr, join_handle) =
+            P2p::spawn_libp2p(bus.clone()).expect("Failed to setup libp2p");
+        let main_addr = MainAggregator::new(bus, sortition, registry, p2p_addr).start();
+        (main_addr, join_handle)
+    }
+}
+
+impl Actor for MainAggregator {
+    type Context = Context<Self>;
+}

--- a/packages/ciphernode/core/src/main_ciphernode.rs
+++ b/packages/ciphernode/core/src/main_ciphernode.rs
@@ -1,0 +1,71 @@
+use std::sync::{Arc, Mutex};
+
+use crate::{CiphernodeRegistry, CiphernodeSelector, Data, EventBus, P2p, Registry, Sortition};
+use actix::{Actor, Addr, Context};
+use alloy_primitives::Address;
+use rand::SeedableRng;
+use rand_chacha::rand_core::OsRng;
+use tokio::task::JoinHandle;
+
+/// Main Ciphernode Actor
+/// Suprvises all children
+// TODO: add supervision logic
+pub struct MainCiphernode {
+    addr: Address,
+    bus: Addr<EventBus>,
+    data: Addr<Data>,
+    sortition: Addr<Sortition>,
+    selector: Addr<CiphernodeSelector>,
+    registry: Addr<Registry>,
+    p2p: Addr<P2p>,
+}
+
+impl MainCiphernode {
+    pub fn new(
+        addr: Address,
+        bus: Addr<EventBus>,
+        data: Addr<Data>,
+        sortition: Addr<Sortition>,
+        selector: Addr<CiphernodeSelector>,
+        registry: Addr<Registry>,
+        p2p: Addr<P2p>,
+    ) -> Self {
+        Self {
+            addr,
+            bus,
+            data,
+            sortition,
+            selector,
+            registry,
+            p2p,
+        }
+    }
+
+    pub async fn attach(address: Address) -> (Addr<Self>, JoinHandle<()>) {
+        let rng = Arc::new(Mutex::new(
+            rand_chacha::ChaCha20Rng::from_rng(OsRng).expect("Failed to create RNG"),
+        ));
+        let bus = EventBus::new(true).start();
+        let data = Data::new(true).start(); // TODO: Use a sled backed Data Actor
+        let sortition = Sortition::attach(bus.clone());
+        let selector = CiphernodeSelector::attach(bus.clone(), sortition.clone(), address);
+        let registry =  Registry::attach(
+            bus.clone(),
+            rng,
+            None,
+            None,
+            Some(CiphernodeRegistry::attach(bus.clone(), data.clone(), address)),
+        )
+        .await;
+        let (p2p_addr, join_handle) =
+            P2p::spawn_libp2p(bus.clone()).expect("Failed to setup libp2p");
+        let main_addr =
+            MainCiphernode::new(address, bus, data, sortition, selector, registry, p2p_addr)
+                .start();
+        (main_addr, join_handle)
+    }
+}
+
+impl Actor for MainCiphernode {
+    type Context = Context<Self>;
+}

--- a/packages/ciphernode/core/src/plaintext_registry.rs
+++ b/packages/ciphernode/core/src/plaintext_registry.rs
@@ -1,0 +1,101 @@
+// TODO: spawn and supervise child actors
+use crate::{
+    CommitteeMeta, E3id, EnclaveEvent, EventBus, Fhe, InitializeWithEnclaveEvent,
+    PlaintextAggregator, Sortition,
+};
+use actix::prelude::*;
+use std::collections::HashMap;
+
+pub struct PlaintextRegistry {
+    bus: Addr<EventBus>,
+    sortition: Addr<Sortition>,
+    buffers: HashMap<E3id, Vec<EnclaveEvent>>,
+    plaintexts: HashMap<E3id, Addr<PlaintextAggregator>>,
+}
+
+impl PlaintextRegistry {
+    pub fn new(bus: Addr<EventBus>, sortition: Addr<Sortition>) -> Self {
+        Self {
+            bus,
+            sortition,
+            plaintexts: HashMap::new(),
+            buffers: HashMap::new(),
+        }
+    }
+
+    pub fn attach(bus: Addr<EventBus>, sortition: Addr<Sortition>) -> Addr<Self> {
+        PlaintextRegistry::new(bus.clone(), sortition).start()
+    }
+}
+
+impl Actor for PlaintextRegistry {
+    type Context = Context<Self>;
+}
+
+impl Handler<InitializeWithEnclaveEvent> for PlaintextRegistry {
+    type Result = ();
+    fn handle(&mut self, msg: InitializeWithEnclaveEvent, _: &mut Self::Context) -> Self::Result {
+        let InitializeWithEnclaveEvent { fhe, meta, event } = msg;
+        let EnclaveEvent::CiphertextOutputPublished { data, .. } = event else {
+            return;
+        };
+
+        let plaintext_factory =
+            self.plaintext_factory(data.e3_id.clone(), meta.clone(), fhe.clone());
+
+        self.plaintexts
+            .entry(data.e3_id)
+            .or_insert_with(plaintext_factory);
+    }
+}
+
+impl Handler<EnclaveEvent> for PlaintextRegistry {
+    type Result = ();
+
+    fn handle(&mut self, msg: EnclaveEvent, _ctx: &mut Self::Context) -> Self::Result {
+        let Some(e3_id) = msg.get_e3_id() else {
+            return;
+        };
+        self.forward_message(&e3_id, msg);
+    }
+}
+
+impl PlaintextRegistry {
+    fn plaintext_factory(
+        &self,
+        e3_id: E3id,
+        meta: CommitteeMeta,
+        fhe: Addr<Fhe>,
+    ) -> impl FnOnce() -> Addr<PlaintextAggregator> {
+        let bus = self.bus.clone();
+        let sortition = self.sortition.clone();
+        let nodecount = meta.nodecount;
+        let seed = meta.seed;
+        move || PlaintextAggregator::new(fhe, bus, sortition, e3_id, nodecount, seed).start()
+    }
+
+    fn store_msg(&mut self, e3_id: E3id, msg: EnclaveEvent) {
+        self.buffers.entry(e3_id).or_default().push(msg);
+    }
+
+    fn take_msgs(&mut self, e3_id: E3id) -> Vec<EnclaveEvent> {
+        self.buffers
+            .get_mut(&e3_id)
+            .map(std::mem::take)
+            .unwrap_or_default()
+    }
+
+    fn forward_message(&mut self, e3_id: &E3id, msg: EnclaveEvent) {
+        // Buffer events for each thing that has not been created
+        if let Some(act) = self.plaintexts.clone().get(e3_id) {
+            let msgs = self.take_msgs(e3_id.clone());
+            let recipient = act.clone().recipient();
+            recipient.do_send(msg.clone());
+            for m in msgs {
+                recipient.do_send(m);
+            }
+        } else {
+            self.store_msg(e3_id.clone(), msg.clone());
+        }
+    }
+}

--- a/packages/ciphernode/core/src/publickey_registry.rs
+++ b/packages/ciphernode/core/src/publickey_registry.rs
@@ -1,0 +1,102 @@
+// TODO: spawn and supervise child actors
+use crate::{
+    E3id, EnclaveEvent, EventBus, Fhe, InitializeWithEnclaveEvent, PublicKeyAggregator, Sortition,
+};
+use actix::prelude::*;
+use std::collections::HashMap;
+
+pub struct PublicKeyRegistry {
+    bus: Addr<EventBus>,
+    sortition: Addr<Sortition>,
+    buffers: HashMap<E3id, Vec<EnclaveEvent>>,
+    public_keys: HashMap<E3id, Addr<PublicKeyAggregator>>,
+}
+
+impl PublicKeyRegistry {
+    pub fn new(bus: Addr<EventBus>, sortition: Addr<Sortition>) -> Self {
+        Self {
+            bus,
+            sortition,
+            public_keys: HashMap::new(),
+            buffers: HashMap::new(),
+        }
+    }
+
+    pub fn attach(bus: Addr<EventBus>, sortition: Addr<Sortition>) -> Addr<Self> {
+        PublicKeyRegistry::new(bus.clone(), sortition).start()
+    }
+}
+
+impl Actor for PublicKeyRegistry {
+    type Context = Context<Self>;
+}
+
+impl Handler<InitializeWithEnclaveEvent> for PublicKeyRegistry {
+    type Result = ();
+    fn handle(&mut self, msg: InitializeWithEnclaveEvent, _: &mut Self::Context) -> Self::Result {
+        let InitializeWithEnclaveEvent { fhe, event, .. } = msg;
+        let EnclaveEvent::CommitteeRequested { data, .. } = event else {
+            return;
+        };
+
+        let public_key_factory = self.public_key_factory(
+            fhe.clone(),
+            data.e3_id.clone(),
+            data.nodecount,
+            data.sortition_seed,
+        );
+        self.public_keys
+            .entry(data.e3_id)
+            .or_insert_with(public_key_factory);
+    }
+}
+
+impl Handler<EnclaveEvent> for PublicKeyRegistry {
+    type Result = ();
+
+    fn handle(&mut self, msg: EnclaveEvent, _ctx: &mut Self::Context) -> Self::Result {
+        let Some(e3_id) = msg.get_e3_id() else {
+            return;
+        };
+        self.forward_message(&e3_id, msg);
+    }
+}
+
+impl PublicKeyRegistry {
+    fn public_key_factory(
+        &self,
+        fhe: Addr<Fhe>,
+        e3_id: E3id,
+        nodecount: usize,
+        seed: u64,
+    ) -> impl FnOnce() -> Addr<PublicKeyAggregator> {
+        let bus = self.bus.clone();
+        let sortition = self.sortition.clone();
+        move || PublicKeyAggregator::new(fhe, bus, sortition, e3_id, nodecount, seed).start()
+    }
+
+    fn store_msg(&mut self, e3_id: E3id, msg: EnclaveEvent) {
+        self.buffers.entry(e3_id).or_default().push(msg);
+    }
+
+    fn take_msgs(&mut self, e3_id: E3id) -> Vec<EnclaveEvent> {
+        self.buffers
+            .get_mut(&e3_id)
+            .map(std::mem::take)
+            .unwrap_or_default()
+    }
+
+    fn forward_message(&mut self, e3_id: &E3id, msg: EnclaveEvent) {
+        // Buffer events for each thing that has not been created
+        if let Some(act) = self.public_keys.clone().get(e3_id) {
+            let msgs = self.take_msgs(e3_id.clone());
+            let recipient = act.clone().recipient();
+            recipient.do_send(msg.clone());
+            for m in msgs {
+                recipient.do_send(m);
+            }
+        } else {
+            self.store_msg(e3_id.clone(), msg.clone());
+        }
+    }
+}

--- a/packages/ciphernode/core/src/registry.rs
+++ b/packages/ciphernode/core/src/registry.rs
@@ -1,14 +1,9 @@
 // TODO: spawn and supervise child actors
-// TODO: vertically modularize this so there is a registry for each function that get rolled up into one based
-// on config
 use crate::{
-    Ciphernode, CiphernodeRegistry, CommitteeRequested, Data, E3id, EnclaveEvent, EventBus, Fhe,
-    PlaintextAggregator, PlaintextRegistry, PublicKeyAggregator, PublicKeyRegistry, Sortition,
-    Subscribe,
+    CiphernodeRegistry, CommitteeRequested, E3id, EnclaveEvent, EventBus, Fhe, PlaintextRegistry,
+    PublicKeyRegistry, Subscribe,
 };
 use actix::prelude::*;
-use alloy_primitives::Address;
-use fhe::mbfv::PublicKeySwitchShare;
 use rand_chacha::ChaCha20Rng;
 use std::{
     collections::HashMap,
@@ -36,7 +31,6 @@ pub struct CommitteeMeta {
 }
 
 pub struct Registry {
-    bus: Addr<EventBus>,
     fhes: HashMap<E3id, Addr<Fhe>>,
     meta: HashMap<E3id, CommitteeMeta>,
     public_key: Option<Addr<PublicKeyRegistry>>,
@@ -47,14 +41,12 @@ pub struct Registry {
 
 impl Registry {
     pub fn new(
-        bus: Addr<EventBus>,
         rng: Arc<Mutex<ChaCha20Rng>>,
         public_key: Option<Addr<PublicKeyRegistry>>,
         plaintext: Option<Addr<PlaintextRegistry>>,
         ciphernode: Option<Addr<CiphernodeRegistry>>,
     ) -> Self {
         Self {
-            bus,
             rng,
             public_key,
             plaintext,
@@ -72,7 +64,7 @@ impl Registry {
         plaintext: Option<Addr<PlaintextRegistry>>,
         ciphernode: Option<Addr<CiphernodeRegistry>>,
     ) -> Addr<Self> {
-        let addr = Registry::new(bus.clone(), rng, public_key, plaintext, ciphernode).start();
+        let addr = Registry::new(rng, public_key, plaintext, ciphernode).start();
         bus.send(Subscribe::new("*", addr.clone().into()))
             .await
             .unwrap();

--- a/packages/ciphernode/core/src/registry.rs
+++ b/packages/ciphernode/core/src/registry.rs
@@ -64,6 +64,7 @@ impl Registry {
         }
     }
 
+    // TODO: use a builder pattern to manage the Option<Registry>
     pub async fn attach(
         bus: Addr<EventBus>,
         rng: Arc<Mutex<ChaCha20Rng>>,

--- a/packages/ciphernode/core/src/registry.rs
+++ b/packages/ciphernode/core/src/registry.rs
@@ -2,55 +2,63 @@
 // TODO: vertically modularize this so there is a registry for each function that get rolled up into one based
 // on config
 use crate::{
-    Ciphernode, CommitteeRequested, Data, E3id, EnclaveEvent, EventBus, Fhe, PlaintextAggregator,
-    PublicKeyAggregator, Sortition, Subscribe,
+    Ciphernode, CiphernodeRegistry, CommitteeRequested, Data, E3id, EnclaveEvent, EventBus, Fhe,
+    PlaintextAggregator, PlaintextRegistry, PublicKeyAggregator, PublicKeyRegistry, Sortition,
+    Subscribe,
 };
 use actix::prelude::*;
 use alloy_primitives::Address;
+use fhe::mbfv::PublicKeySwitchShare;
 use rand_chacha::ChaCha20Rng;
 use std::{
     collections::HashMap,
     sync::{Arc, Mutex},
 };
 
-#[derive(Clone)]
-struct CommitteeMeta {
-    nodecount: usize,
-    seed: u64,
+#[derive(Message, Clone, Debug, PartialEq, Eq)]
+#[rtype(result = "()")]
+pub struct InitializeWithEnclaveEvent {
+    pub fhe: Addr<Fhe>,
+    pub meta: CommitteeMeta,
+    pub event: EnclaveEvent,
+}
+
+impl InitializeWithEnclaveEvent {
+    pub fn new(fhe: Addr<Fhe>, meta: CommitteeMeta, event: EnclaveEvent) -> Self {
+        Self { fhe, meta, event }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CommitteeMeta {
+    pub nodecount: usize,
+    pub seed: u64,
 }
 
 pub struct Registry {
     bus: Addr<EventBus>,
-    ciphernodes: HashMap<E3id, Addr<Ciphernode>>,
-    data: Addr<Data>,
-    sortition: Addr<Sortition>,
-    address: Address,
     fhes: HashMap<E3id, Addr<Fhe>>,
-    plaintexts: HashMap<E3id, Addr<PlaintextAggregator>>,
-    buffers: HashMap<E3id, HashMap<String, Vec<EnclaveEvent>>>,
     meta: HashMap<E3id, CommitteeMeta>,
-    public_keys: HashMap<E3id, Addr<PublicKeyAggregator>>,
+    public_key: Option<Addr<PublicKeyRegistry>>,
+    plaintext: Option<Addr<PlaintextRegistry>>,
+    ciphernode: Option<Addr<CiphernodeRegistry>>,
     rng: Arc<Mutex<ChaCha20Rng>>,
 }
 
 impl Registry {
     pub fn new(
         bus: Addr<EventBus>,
-        data: Addr<Data>,
-        sortition: Addr<Sortition>,
         rng: Arc<Mutex<ChaCha20Rng>>,
-        address: Address,
+        public_key: Option<Addr<PublicKeyRegistry>>,
+        plaintext: Option<Addr<PlaintextRegistry>>,
+        ciphernode: Option<Addr<CiphernodeRegistry>>,
     ) -> Self {
         Self {
             bus,
-            data,
-            sortition,
             rng,
-            address,
-            ciphernodes: HashMap::new(),
-            plaintexts: HashMap::new(),
-            public_keys: HashMap::new(),
-            buffers: HashMap::new(),
+            public_key,
+            plaintext,
+            ciphernode,
             meta: HashMap::new(),
             fhes: HashMap::new(),
         }
@@ -58,12 +66,12 @@ impl Registry {
 
     pub async fn attach(
         bus: Addr<EventBus>,
-        data: Addr<Data>,
-        sortition: Addr<Sortition>,
         rng: Arc<Mutex<ChaCha20Rng>>,
-        address: Address,
+        public_key: Option<Addr<PublicKeyRegistry>>,
+        plaintext: Option<Addr<PlaintextRegistry>>,
+        ciphernode: Option<Addr<CiphernodeRegistry>>,
     ) -> Addr<Self> {
-        let addr = Registry::new(bus.clone(), data, sortition, rng, address).start();
+        let addr = Registry::new(bus.clone(), rng, public_key, plaintext, ciphernode).start();
         bus.send(Subscribe::new("*", addr.clone().into()))
             .await
             .unwrap();
@@ -90,47 +98,56 @@ impl Handler<EnclaveEvent> for Registry {
                     moduli,
                     plaintext_modulus,
                     crp,
-                    sortition_seed,
                     ..
                 } = data;
 
                 let fhe_factory = self.fhe_factory(moduli, degree, plaintext_modulus, crp);
-                let fhe = store(&e3_id, &mut self.fhes, fhe_factory);
+                let fhe = self.fhes.entry(e3_id.clone()).or_insert_with(fhe_factory);
                 let meta = CommitteeMeta {
                     nodecount: data.nodecount,
                     seed: data.sortition_seed,
                 };
-
                 self.meta.entry(e3_id.clone()).or_insert(meta.clone());
 
-                let public_key_factory = self.public_key_factory(
-                    e3_id.clone(),
-                    meta.clone(),
-                    fhe.clone(),
-                    sortition_seed,
-                );
-                store(&e3_id, &mut self.public_keys, public_key_factory);
+                if let Some(addr) = self.public_key.clone() {
+                    addr.do_send(InitializeWithEnclaveEvent {
+                        event: msg.clone(),
+                        fhe: fhe.clone(),
+                        meta: meta.clone(),
+                    })
+                }
 
-                let ciphernode_factory = self.ciphernode_factory(fhe.clone());
-                store(&e3_id, &mut self.ciphernodes, ciphernode_factory);
+                if let Some(addr) = self.ciphernode.clone() {
+                    addr.do_send(InitializeWithEnclaveEvent {
+                        event: msg.clone(),
+                        fhe: fhe.clone(),
+                        meta: meta.clone(),
+                    })
+                }
             }
-            EnclaveEvent::CiphertextOutputPublished { .. } => {
-                let Some(fhe) = self.fhes.get(&e3_id) else {
+            EnclaveEvent::CiphertextOutputPublished { data, .. } => {
+                let Some(plaintext) = self.plaintext.clone() else {
                     return;
                 };
 
-                let Some(meta) = self.meta.get(&e3_id) else {
+                let Some(fhe) = self.fhes.get(&data.e3_id) else {
                     return;
                 };
 
-                let plaintext_factory =
-                    self.plaintext_factory(e3_id.clone(), meta.clone(), fhe.clone());
-                store(&e3_id, &mut self.plaintexts, plaintext_factory);
+                let Some(meta) = self.meta.get(&data.e3_id) else {
+                    return;
+                };
+
+                plaintext.do_send(InitializeWithEnclaveEvent {
+                    event: msg.clone(),
+                    fhe: fhe.clone(),
+                    meta: meta.clone(),
+                })
             }
             _ => (),
         };
 
-        self.forward_message(&e3_id, msg);
+        self.forward_message(msg);
     }
 }
 
@@ -150,100 +167,17 @@ impl Registry {
         }
     }
 
-    fn public_key_factory(
-        &self,
-        e3_id: E3id,
-        meta: CommitteeMeta,
-        fhe: Addr<Fhe>,
-        seed: u64,
-    ) -> impl FnOnce() -> Addr<PublicKeyAggregator> {
-        let bus = self.bus.clone();
-        let nodecount = meta.nodecount;
-        let sortition = self.sortition.clone();
-        move || PublicKeyAggregator::new(fhe, bus, sortition, e3_id, nodecount, seed).start()
-    }
-
-    fn ciphernode_factory(&self, fhe: Addr<Fhe>) -> impl FnOnce() -> Addr<Ciphernode> {
-        let data = self.data.clone();
-        let bus = self.bus.clone();
-        let address = self.address;
-        move || Ciphernode::new(bus, fhe, data, address).start()
-    }
-
-    fn plaintext_factory(
-        &self,
-        e3_id: E3id,
-        meta: CommitteeMeta,
-        fhe: Addr<Fhe>,
-    ) -> impl FnOnce() -> Addr<PlaintextAggregator> {
-        let bus = self.bus.clone();
-        let sortition = self.sortition.clone();
-        let nodecount = meta.nodecount;
-        let seed = meta.seed;
-        move || PlaintextAggregator::new(fhe, bus, sortition, e3_id, nodecount, seed).start()
-    }
-
-    fn store_msg(&mut self, e3_id: E3id, msg: EnclaveEvent, key: &str) {
-        self.buffers
-            .entry(e3_id)
-            .or_default()
-            .entry(key.to_owned())
-            .or_default()
-            .push(msg);
-    }
-
-    fn take_msgs(&mut self, e3_id: E3id, key: &str) -> Vec<EnclaveEvent> {
-        self.buffers
-            .get_mut(&e3_id)
-            .and_then(|inner_map| inner_map.get_mut(key))
-            .map(std::mem::take)
-            .unwrap_or_default()
-    }
-
-    fn forward_message(&mut self, e3_id: &E3id, msg: EnclaveEvent) {
-        // Buffer events for each thing that has not been created
-        // TODO: Needs tidying up as this is verbose and repeats
-        // TODO: use an enum for the buffer keys
-        if let Some(act) = self.public_keys.clone().get(e3_id) {
-            let msgs = self.take_msgs(e3_id.clone(), "public_keys");
-            let recipient = act.clone().recipient();
-            recipient.do_send(msg.clone());
-            for m in msgs {
-                recipient.do_send(m);
-            }
-        } else {
-            self.store_msg(e3_id.clone(), msg.clone(), "public_keys");
+    fn forward_message(&mut self, msg: EnclaveEvent) {
+        if let Some(addr) = self.ciphernode.clone() {
+            addr.do_send(msg.clone())
         }
 
-        if let Some(act) = self.plaintexts.clone().get(e3_id) {
-            let msgs = self.take_msgs(e3_id.clone(), "plaintexts");
-            let recipient = act.clone().recipient();
-            recipient.do_send(msg.clone());
-            for m in msgs {
-                recipient.do_send(m);
-            }
-        } else {
-            self.store_msg(e3_id.clone(), msg.clone(), "plaintexts");
+        if let Some(addr) = self.public_key.clone() {
+            addr.do_send(msg.clone())
         }
 
-        if let Some(act) = self.ciphernodes.clone().get(e3_id) {
-            let msgs = self.take_msgs(e3_id.clone(), "ciphernodes");
-            let recipient = act.clone().recipient();
-            recipient.do_send(msg.clone());
-            for m in msgs {
-                recipient.do_send(m);
-            }
-        } else {
-            self.store_msg(e3_id.clone(), msg.clone(), "ciphernodes");
+        if let Some(addr) = self.plaintext.clone() {
+            addr.do_send(msg.clone())
         }
     }
-}
-
-// Store on a hashmap a Addr<T> from the factory F
-fn store<T, F>(e3_id: &E3id, map: &mut HashMap<E3id, Addr<T>>, creator: F) -> Addr<T>
-where
-    T: Actor<Context = Context<T>>,
-    F: FnOnce() -> Addr<T>,
-{
-    map.entry(e3_id.clone()).or_insert_with(creator).clone()
 }

--- a/packages/ciphernode/enclave_node/Cargo.toml
+++ b/packages/ciphernode/enclave_node/Cargo.toml
@@ -22,3 +22,6 @@ actix-rt = "2.10.0"
 alloy-primitives = { version = "0.6", default-features = false, features = ["rlp", "serde", "std"] }
 
 alloy = { version = "0.2.1", features = ["full"] }
+clap = { version = "4.5.17", features = ["derive"] }
+rand_chacha = "0.3.1"
+rand = "0.8.5"

--- a/packages/ciphernode/enclave_node/src/bin/aggregator.rs
+++ b/packages/ciphernode/enclave_node/src/bin/aggregator.rs
@@ -1,0 +1,17 @@
+use alloy_primitives::Address;
+use clap::Parser;
+use enclave_core::MainAggregator;
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    #[arg(short, long)]
+    address: String,
+}
+
+#[actix_rt::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let (_, handle) = MainAggregator::attach().await;
+    let _ = tokio::join!(handle);
+    Ok(())
+}

--- a/packages/ciphernode/enclave_node/src/bin/node.rs
+++ b/packages/ciphernode/enclave_node/src/bin/node.rs
@@ -1,0 +1,19 @@
+use alloy_primitives::Address;
+use clap::Parser;
+use enclave_core::MainCiphernode;
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    #[arg(short, long)]
+    address: String,
+}
+
+#[actix_rt::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = Args::parse();
+    let address = Address::parse_checksummed(&args.address, None).expect("Invalid address");
+    let (_, handle) = MainCiphernode::attach(address).await;
+    let _ = tokio::join!(handle);
+    Ok(())
+}


### PR DESCRIPTION
The Registry (Orchestrator?) is kind of the entry point to the main functionality of the cipher node. 

It wraps other sub modules in a dynamic way and manages bootstrapping and lifecycle. 


Currently functionality can be configured like this:
```rust
Registry::attach(
    bus.clone(),
    rng,
    Some(PublicKeyRegistry::attach(bus.clone(), sortition.clone())),
    Some(PlaintextRegistry::attach(bus.clone(), sortition.clone())),
    Some(CiphernodeRegistry::attach(bus.clone(), data, addr)),
)
.await; 
```

I can see us re-writing this to be a builder pattern which might be more erganomic but not in this PR

```rust
Orchestrator::create(&bus, rng)
  .public_key(PublicKeyOrchestrator::create(&bus, &sortition)
  .plaintext(PlaintextOrchestrator::create(&bus, &sortition))
  .ciphernode(CiphernodeOrchestrator::create(&bus, &data, &addr))
  .build().await
```

Not sure what to call these exactly. Registry is okay but I think it is misleading because we have the ciphernode registry and this is really just a coordinator or orchestrator.