### PR TITLE
Auryn/unit-tests

### DIFF
--- a/packages/evm/contracts/Enclave.sol
+++ b/packages/evm/contracts/Enclave.sol
@@ -176,7 +176,7 @@ contract Enclave is IEnclave, OwnableUpgradeable {
             CommitteeSelectionFailed()
         );
 
-        emit E3Requested(e3Id, e3s[e3Id], filter, e3Program);
+        emit E3Requested(e3Id, e3, filter, e3Program);
     }
 
     function activate(uint256 e3Id) external returns (bool success) {

--- a/packages/evm/contracts/registry/CiphernodeRegistryOwnable.sol
+++ b/packages/evm/contracts/registry/CiphernodeRegistryOwnable.sol
@@ -120,15 +120,9 @@ contract CiphernodeRegistryOwnable is ICiphernodeRegistry, OwnableUpgradeable {
         uint256[] calldata siblingNodes
     ) external onlyOwner {
         uint160 ciphernode = uint160(node);
-        ciphernodes._remove(ciphernode, siblingNodes);
         uint256 index = ciphernodes._indexOf(ciphernode);
+        ciphernodes._remove(ciphernode, siblingNodes);
         numCiphernodes--;
-        emit CiphernodeAdded(
-            node,
-            ciphernodes._indexOf(ciphernode),
-            numCiphernodes,
-            ciphernodes.size
-        );
         emit CiphernodeRemoved(node, index, numCiphernodes, ciphernodes.size);
     }
 
@@ -174,5 +168,9 @@ contract CiphernodeRegistryOwnable is ICiphernodeRegistry, OwnableUpgradeable {
 
     function getFilter(uint256 e3Id) public view returns (IRegistryFilter) {
         return filters[e3Id];
+    }
+
+    function treeSize() public view returns (uint256) {
+        return ciphernodes.size;
     }
 }

--- a/packages/evm/contracts/registry/CiphernodeRegistryOwnable.sol
+++ b/packages/evm/contracts/registry/CiphernodeRegistryOwnable.sol
@@ -103,17 +103,6 @@ contract CiphernodeRegistryOwnable is ICiphernodeRegistry, OwnableUpgradeable {
         emit CommitteePublished(e3Id, publicKey);
     }
 
-    ////////////////////////////////////////////////////////////
-    //                                                        //
-    //                   Set Functions                        //
-    //                                                        //
-    ////////////////////////////////////////////////////////////
-
-    function setEnclave(address _enclave) public onlyOwner {
-        enclave = _enclave;
-        emit EnclaveSet(_enclave);
-    }
-
     function addCiphernode(address node) external onlyOwner {
         uint160 ciphernode = uint160(node);
         ciphernodes._insert(ciphernode);
@@ -130,7 +119,7 @@ contract CiphernodeRegistryOwnable is ICiphernodeRegistry, OwnableUpgradeable {
         address node,
         uint256[] calldata siblingNodes
     ) external onlyOwner {
-        uint256 ciphernode = uint256(bytes32(bytes20(node)));
+        uint160 ciphernode = uint160(node);
         ciphernodes._remove(ciphernode, siblingNodes);
         uint256 index = ciphernodes._indexOf(ciphernode);
         numCiphernodes--;
@@ -143,8 +132,15 @@ contract CiphernodeRegistryOwnable is ICiphernodeRegistry, OwnableUpgradeable {
         emit CiphernodeRemoved(node, index, numCiphernodes, ciphernodes.size);
     }
 
-    function isCiphernodeEligible(address node) external view returns (bool) {
-        return isEnabled(node);
+    ////////////////////////////////////////////////////////////
+    //                                                        //
+    //                   Set Functions                        //
+    //                                                        //
+    ////////////////////////////////////////////////////////////
+
+    function setEnclave(address _enclave) public onlyOwner {
+        enclave = _enclave;
+        emit EnclaveSet(_enclave);
     }
 
     ////////////////////////////////////////////////////////////
@@ -160,8 +156,12 @@ contract CiphernodeRegistryOwnable is ICiphernodeRegistry, OwnableUpgradeable {
         require(publicKey.length > 0, CommitteeNotPublished());
     }
 
+    function isCiphernodeEligible(address node) external view returns (bool) {
+        return isEnabled(node);
+    }
+
     function isEnabled(address node) public view returns (bool) {
-        return ciphernodes._has(uint256(bytes32(bytes20(node))));
+        return ciphernodes._has(uint160(node));
     }
 
     function root() public view returns (uint256) {

--- a/packages/evm/contracts/registry/NaiveRegistryFilter.sol
+++ b/packages/evm/contracts/registry/NaiveRegistryFilter.sol
@@ -106,4 +106,16 @@ contract NaiveRegistryFilter is IRegistryFilter, OwnableUpgradeable {
     function setRegistry(address _registry) public onlyOwner {
         registry = _registry;
     }
+
+    ////////////////////////////////////////////////////////////
+    //                                                        //
+    //                   Get Functions                        //
+    //                                                        //
+    ////////////////////////////////////////////////////////////
+
+    function getCommittee(
+        uint256 e3Id
+    ) external view returns (Committee memory) {
+        return committees[e3Id];
+    }
 }

--- a/packages/evm/test/CyphernodeRegistry/CiphernodeRegistryOwnable.spec.ts
+++ b/packages/evm/test/CyphernodeRegistry/CiphernodeRegistryOwnable.spec.ts
@@ -55,7 +55,7 @@ describe("CiphernodeRegistryOwnable", function () {
       const poseidonFactory = await ethers.getContractFactory("PoseidonT3");
       const poseidonDeployment = await poseidonFactory.deploy();
       const [deployer] = await ethers.getSigners();
-      let ciphernodeRegistryFactory = await ethers.getContractFactory(
+      const ciphernodeRegistryFactory = await ethers.getContractFactory(
         "CiphernodeRegistryOwnable",
         {
           libraries: {
@@ -63,7 +63,7 @@ describe("CiphernodeRegistryOwnable", function () {
           },
         },
       );
-      let ciphernodeRegistry = await ciphernodeRegistryFactory.deploy(
+      const ciphernodeRegistry = await ciphernodeRegistryFactory.deploy(
         deployer.address,
         AddressTwo,
       );
@@ -191,7 +191,7 @@ describe("CiphernodeRegistryOwnable", function () {
         request.filter,
         request.threshold,
       );
-      expect(
+      await expect(
         await filter.publishCommittee(
           request.e3Id,
           [AddressOne, AddressTwo],
@@ -225,10 +225,16 @@ describe("CiphernodeRegistryOwnable", function () {
     });
     it("emits a CiphernodeAdded event", async function () {
       const { registry } = await loadFixture(setup);
+      const treeSize = await registry.treeSize();
       const numCiphernodes = await registry.numCiphernodes();
-      expect(await registry.addCiphernode(AddressThree))
+      await expect(await registry.addCiphernode(AddressThree))
         .to.emit(registry, "CiphernodeAdded")
-        .withArgs(AddressThree, numCiphernodes + BigInt(1));
+        .withArgs(
+          AddressThree,
+          treeSize,
+          numCiphernodes + BigInt(1),
+          treeSize + BigInt(1),
+        );
     });
   });
 
@@ -285,7 +291,7 @@ describe("CiphernodeRegistryOwnable", function () {
     });
     it("emits an EnclaveSet event", async function () {
       const { registry } = await loadFixture(setup);
-      expect(await registry.setEnclave(AddressThree))
+      await expect(await registry.setEnclave(AddressThree))
         .to.emit(registry, "EnclaveSet")
         .withArgs(AddressThree);
     });

--- a/packages/evm/test/CyphernodeRegistry/CyphernodeRegistryOwnable.spec.ts
+++ b/packages/evm/test/CyphernodeRegistry/CyphernodeRegistryOwnable.spec.ts
@@ -1,19 +1,13 @@
-import {
-  loadFixture,
-  mine,
-  time,
-} from "@nomicfoundation/hardhat-network-helpers";
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
 import { LeanIMT } from "@zk-kit/lean-imt";
 import { expect } from "chai";
-import { ZeroHash } from "ethers";
-import { ethers, network } from "hardhat";
+import { ethers } from "hardhat";
 import { poseidon2 } from "poseidon-lite";
 
 import { deployCiphernodeRegistryOwnableFixture } from "../fixtures/CiphernodeRegistryOwnable.fixture";
 import { naiveRegistryFilterFixture } from "../fixtures/NaiveRegistryFilter.fixture";
 import { PoseidonT3Fixture } from "../fixtures/PoseidonT3.fixture";
 
-const abiCoder = ethers.AbiCoder.defaultAbiCoder();
 const AddressOne = "0x0000000000000000000000000000000000000001";
 const AddressTwo = "0x0000000000000000000000000000000000000002";
 const AddressThree = "0x0000000000000000000000000000000000000003";

--- a/packages/evm/test/CyphernodeRegistry/CyphernodeRegistryOwnable.spec.ts
+++ b/packages/evm/test/CyphernodeRegistry/CyphernodeRegistryOwnable.spec.ts
@@ -1,0 +1,150 @@
+import {
+  loadFixture,
+  mine,
+  time,
+} from "@nomicfoundation/hardhat-network-helpers";
+import { LeanIMT } from "@zk-kit/lean-imt";
+import { expect } from "chai";
+import { ZeroHash } from "ethers";
+import { ethers } from "hardhat";
+import { poseidon2 } from "poseidon-lite";
+
+import { deployCiphernodeRegistryOwnableFixture } from "../fixtures/CiphernodeRegistryOwnable.fixture";
+import { naiveRegistryFilterFixture } from "../fixtures/NaiveRegistryFilter.fixture";
+import { PoseidonT3Fixture } from "../fixtures/PoseidonT3.fixture";
+
+const abiCoder = ethers.AbiCoder.defaultAbiCoder();
+const AddressOne = "0x0000000000000000000000000000000000000001";
+const AddressTwo = "0x0000000000000000000000000000000000000002";
+const addressThree = "0x0000000000000000000000000000000000000003";
+
+// Hash function used to compute the tree nodes.
+const hash = (a: bigint, b: bigint) => poseidon2([a, b]);
+
+describe.only("CiphernodeRegistryOwnable", function () {
+  async function setup() {
+    const [owner, notTheOwner] = await ethers.getSigners();
+
+    const poseidon = await PoseidonT3Fixture();
+    const registry = await deployCiphernodeRegistryOwnableFixture(
+      owner.address,
+      owner.address,
+      await poseidon.getAddress(),
+    );
+    const filter = await naiveRegistryFilterFixture(
+      owner.address,
+      await registry.getAddress(),
+    );
+    await registry.addCiphernode(AddressOne);
+    await registry.addCiphernode(AddressTwo);
+
+    return {
+      owner,
+      notTheOwner,
+      registry,
+      filter,
+      request: {
+        e3Id: 1,
+        filter: await filter.getAddress(),
+        threshold: [2, 2] as [number, number],
+      },
+    };
+  }
+
+  describe("constructor / initialize()", function () {
+    it("correctly sets `_owner` and `enclave` ", async function () {
+      const poseidonFactory = await ethers.getContractFactory("PoseidonT3");
+      const poseidonDeployment = await poseidonFactory.deploy();
+      const [deployer] = await ethers.getSigners();
+      let ciphernodeRegistryFactory = await ethers.getContractFactory(
+        "CiphernodeRegistryOwnable",
+        {
+          libraries: {
+            PoseidonT3: await poseidonDeployment.getAddress(),
+          },
+        },
+      );
+      let ciphernodeRegistry = await ciphernodeRegistryFactory.deploy(
+        deployer.address,
+        AddressTwo,
+      );
+      expect(await ciphernodeRegistry.owner()).to.equal(deployer.address);
+      expect(await ciphernodeRegistry.enclave()).to.equal(AddressTwo);
+    });
+  });
+
+  describe("requestCommittee()", function () {
+    it("reverts if committee has already been requested for given e3Id", async function () {
+      const { registry, request } = await loadFixture(setup);
+      await registry.requestCommittee(
+        request.e3Id,
+        request.filter,
+        request.threshold,
+      );
+      await expect(
+        registry.requestCommittee(
+          request.e3Id,
+          request.filter,
+          request.threshold,
+        ),
+      ).to.be.revertedWithCustomError(registry, "CommitteeAlreadyRequested");
+    });
+    it("stores the registry filter for the given e3Id");
+    it("stores the root of the ciphernode registry at the time of the request");
+    it("requests a committee from the given filter");
+    it("emits a CommitteeRequested event");
+    it("reverts if filter.requestCommittee() fails");
+    it("returns true if the request is successful");
+  });
+
+  describe("publishCommittee()", function () {
+    it("reverts if the caller is not the filter for the given e3Id");
+    it("stores the public key of the committee");
+    it("emits a CommitteePublished event");
+  });
+
+  describe("addCiphernode()", function () {
+    it("reverts if the caller is not the owner");
+    it("adds the ciphernode to the registry");
+    it("increments numCiphernodes");
+    it("emits a CiphernodeAdded event");
+  });
+
+  describe("removeCiphernode()", function () {
+    it("reverts if the caller is not the owner");
+    it("removes the ciphernode from the registry");
+    it("decrements numCiphernodes");
+    it("emits a CiphernodeRemoved event");
+  });
+
+  describe("setEnclave()", function () {
+    it("reverts if the caller is not the owner");
+    it("sets the enclave address");
+    it("emits an EnclaveSet event");
+  });
+
+  describe("committeePublicKey()", function () {
+    it("returns the public key of the committee for the given e3Id");
+    it("reverts if the committee has not been published");
+  });
+
+  describe("isCiphernodeEligible()", function () {
+    it("returns true if the ciphernode is in the registry");
+    it("returns false if the ciphernode is not in the registry");
+  });
+
+  describe("isEnabled()", function () {
+    it("returns true if the ciphernode is currently enabled");
+    it("returns false if the ciphernode is not currently enabled");
+  });
+
+  describe("root()", function () {
+    it("returns the root of the ciphernode registry merkle tree");
+  });
+
+  describe("rootAt()", function () {
+    it(
+      "returns the root of the ciphernode registry merkle tree at the given e3Id",
+    );
+  });
+});

--- a/packages/evm/test/CyphernodeRegistry/CyphernodeRegistryOwnable.spec.ts
+++ b/packages/evm/test/CyphernodeRegistry/CyphernodeRegistryOwnable.spec.ts
@@ -205,10 +205,32 @@ describe.only("CiphernodeRegistryOwnable", function () {
   });
 
   describe("addCiphernode()", function () {
-    it("reverts if the caller is not the owner");
-    it("adds the ciphernode to the registry");
-    it("increments numCiphernodes");
-    it("emits a CiphernodeAdded event");
+    it("reverts if the caller is not the owner", async function () {
+      const { registry, notTheOwner } = await loadFixture(setup);
+      await expect(registry.connect(notTheOwner).addCiphernode(addressThree))
+        .to.be.revertedWithCustomError(registry, "OwnableUnauthorizedAccount")
+        .withArgs(notTheOwner.address);
+    });
+    it("adds the ciphernode to the registry", async function () {
+      const { registry } = await loadFixture(setup);
+      expect(await registry.addCiphernode(addressThree));
+      expect(await registry.isCiphernodeEligible(addressThree)).to.be.true;
+    });
+    it("increments numCiphernodes", async function () {
+      const { registry } = await loadFixture(setup);
+      const numCiphernodes = await registry.numCiphernodes();
+      expect(await registry.addCiphernode(addressThree));
+      expect(await registry.numCiphernodes()).to.equal(
+        numCiphernodes + BigInt(1),
+      );
+    });
+    it("emits a CiphernodeAdded event", async function () {
+      const { registry } = await loadFixture(setup);
+      const numCiphernodes = await registry.numCiphernodes();
+      expect(await registry.addCiphernode(addressThree))
+        .to.emit(registry, "CiphernodeAdded")
+        .withArgs(addressThree, numCiphernodes + BigInt(1));
+    });
   });
 
   describe("removeCiphernode()", function () {

--- a/packages/evm/test/CyphernodeRegistry/CyphernodeRegistryOwnable.spec.ts
+++ b/packages/evm/test/CyphernodeRegistry/CyphernodeRegistryOwnable.spec.ts
@@ -15,7 +15,7 @@ const AddressThree = "0x0000000000000000000000000000000000000003";
 // Hash function used to compute the tree nodes.
 const hash = (a: bigint, b: bigint) => poseidon2([a, b]);
 
-describe.only("CiphernodeRegistryOwnable", function () {
+describe("CiphernodeRegistryOwnable", function () {
   async function setup() {
     const [owner, notTheOwner] = await ethers.getSigners();
 

--- a/packages/evm/test/CyphernodeRegistry/NaiveRegistryFilter.spec.ts
+++ b/packages/evm/test/CyphernodeRegistry/NaiveRegistryFilter.spec.ts
@@ -15,7 +15,7 @@ const AddressThree = "0x0000000000000000000000000000000000000003";
 // Hash function used to compute the tree nodes.
 const hash = (a: bigint, b: bigint) => poseidon2([a, b]);
 
-describe.only("NaiveRegistryFilter", function () {
+describe("NaiveRegistryFilter", function () {
   async function setup() {
     const [owner, notTheOwner] = await ethers.getSigners();
 
@@ -52,18 +52,18 @@ describe.only("NaiveRegistryFilter", function () {
 
   describe("constructor / initialize()", function () {
     it("should set the owner", async function () {
-      const { owner, filter } = await setup();
+      const { owner, filter } = await loadFixture(setup);
       expect(await filter.owner()).to.equal(owner.address);
     });
     it("should set the registry", async function () {
-      const { registry, filter } = await setup();
+      const { registry, filter } = await loadFixture(setup);
       expect(await filter.registry()).to.equal(await registry.getAddress());
     });
   });
 
   describe("requestCommittee()", function () {
     it("should revert if the caller is not the registry", async function () {
-      const { notTheOwner, filter, request } = await setup();
+      const { notTheOwner, filter, request } = await loadFixture(setup);
       await expect(
         filter
           .connect(notTheOwner)
@@ -71,7 +71,7 @@ describe.only("NaiveRegistryFilter", function () {
       ).to.be.revertedWithCustomError(filter, "OnlyRegistry");
     });
     it("should revert if a committee has already been requested for the given e3Id", async function () {
-      const { filter, request, owner } = await setup();
+      const { filter, request, owner } = await loadFixture(setup);
       await filter.setRegistry(owner.address);
       await filter.requestCommittee(request.e3Id, request.threshold);
       await expect(
@@ -79,14 +79,14 @@ describe.only("NaiveRegistryFilter", function () {
       ).to.be.revertedWithCustomError(filter, "CommitteeAlreadyExists");
     });
     it("should set the threshold for the requested committee", async function () {
-      const { filter, owner, request } = await setup();
+      const { filter, owner, request } = await loadFixture(setup);
       await filter.setRegistry(owner.address);
       await filter.requestCommittee(request.e3Id, request.threshold);
       const committee = await filter.getCommittee(request.e3Id);
       expect(committee.threshold).to.deep.equal(request.threshold);
     });
     it("should return true when a committee is requested", async function () {
-      const { filter, owner, request } = await setup();
+      const { filter, owner, request } = await loadFixture(setup);
       await filter.setRegistry(owner.address);
       const result = await filter.requestCommittee.staticCall(
         request.e3Id,
@@ -98,7 +98,7 @@ describe.only("NaiveRegistryFilter", function () {
 
   describe("publishCommittee()", function () {
     it("should revert if the caller is not owner", async function () {
-      const { filter, notTheOwner, request } = await setup();
+      const { filter, notTheOwner, request } = await loadFixture(setup);
       await expect(
         filter
           .connect(notTheOwner)
@@ -110,7 +110,7 @@ describe.only("NaiveRegistryFilter", function () {
       ).to.be.revertedWithCustomError(filter, "OwnableUnauthorizedAccount");
     });
     it("should revert if committee already published", async function () {
-      const { filter, registry, request } = await setup();
+      const { filter, registry, request } = await loadFixture(setup);
       expect(
         await registry.requestCommittee(
           request.e3Id,
@@ -132,7 +132,7 @@ describe.only("NaiveRegistryFilter", function () {
       ).to.be.revertedWithCustomError(filter, "CommitteeAlreadyPublished");
     });
     it("should store the node addresses of the committee", async function () {
-      const { filter, registry, request } = await setup();
+      const { filter, registry, request } = await loadFixture(setup);
       expect(
         await registry.requestCommittee(
           request.e3Id,
@@ -149,7 +149,7 @@ describe.only("NaiveRegistryFilter", function () {
       expect(committee.nodes).to.deep.equal([AddressOne, AddressTwo]);
     });
     it("should store the public key of the committee", async function () {
-      const { filter, registry, request } = await setup();
+      const { filter, registry, request } = await loadFixture(setup);
       expect(
         await registry.requestCommittee(
           request.e3Id,
@@ -166,7 +166,7 @@ describe.only("NaiveRegistryFilter", function () {
       expect(committee.publicKey).to.equal(AddressThree);
     });
     it("should publish the correct node addresses of the committee for the given e3Id", async function () {
-      const { filter, registry, request } = await setup();
+      const { filter, registry, request } = await loadFixture(setup);
       expect(
         await registry.requestCommittee(
           request.e3Id,
@@ -183,7 +183,7 @@ describe.only("NaiveRegistryFilter", function () {
       expect(committee.nodes).to.deep.equal([AddressOne, AddressTwo]);
     });
     it("should publish the public key of the committee for the given e3Id", async function () {
-      const { filter, registry, request } = await setup();
+      const { filter, registry, request } = await loadFixture(setup);
       expect(
         await registry.requestCommittee(
           request.e3Id,
@@ -203,13 +203,13 @@ describe.only("NaiveRegistryFilter", function () {
 
   describe("setRegistry()", function () {
     it("should revert if the caller is not the owner", async function () {
-      const { filter, notTheOwner } = await setup();
+      const { filter, notTheOwner } = await loadFixture(setup);
       await expect(filter.connect(notTheOwner).setRegistry(notTheOwner.address))
         .to.be.revertedWithCustomError(filter, "OwnableUnauthorizedAccount")
         .withArgs(notTheOwner.address);
     });
     it("should set the registry", async function () {
-      const { filter, owner, registry } = await setup();
+      const { filter, owner } = await loadFixture(setup);
       await filter.setRegistry(owner.address);
       expect(await filter.registry()).to.equal(owner.address);
     });
@@ -217,7 +217,7 @@ describe.only("NaiveRegistryFilter", function () {
 
   describe("getCommittee()", function () {
     it("should return the committee for the given e3Id", async function () {
-      const { filter, owner, registry, request } = await setup();
+      const { filter, registry, request } = await loadFixture(setup);
       expect(
         await registry.requestCommittee(
           request.e3Id,

--- a/packages/evm/test/CyphernodeRegistry/NaiveRegistryFilter.spec.ts
+++ b/packages/evm/test/CyphernodeRegistry/NaiveRegistryFilter.spec.ts
@@ -1,0 +1,241 @@
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { LeanIMT } from "@zk-kit/lean-imt";
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { poseidon2 } from "poseidon-lite";
+
+import { deployCiphernodeRegistryOwnableFixture } from "../fixtures/CiphernodeRegistryOwnable.fixture";
+import { naiveRegistryFilterFixture } from "../fixtures/NaiveRegistryFilter.fixture";
+import { PoseidonT3Fixture } from "../fixtures/PoseidonT3.fixture";
+
+const AddressOne = "0x0000000000000000000000000000000000000001";
+const AddressTwo = "0x0000000000000000000000000000000000000002";
+const AddressThree = "0x0000000000000000000000000000000000000003";
+
+// Hash function used to compute the tree nodes.
+const hash = (a: bigint, b: bigint) => poseidon2([a, b]);
+
+describe.only("NaiveRegistryFilter", function () {
+  async function setup() {
+    const [owner, notTheOwner] = await ethers.getSigners();
+
+    const poseidon = await PoseidonT3Fixture();
+    const registry = await deployCiphernodeRegistryOwnableFixture(
+      owner.address,
+      owner.address,
+      await poseidon.getAddress(),
+    );
+    const filter = await naiveRegistryFilterFixture(
+      owner.address,
+      await registry.getAddress(),
+    );
+
+    const tree = new LeanIMT(hash);
+    await registry.addCiphernode(AddressOne);
+    tree.insert(BigInt(AddressOne));
+    await registry.addCiphernode(AddressTwo);
+    tree.insert(BigInt(AddressTwo));
+
+    return {
+      owner,
+      notTheOwner,
+      registry,
+      filter,
+      tree,
+      request: {
+        e3Id: 1,
+        filter: await filter.getAddress(),
+        threshold: [2, 2] as [number, number],
+      },
+    };
+  }
+
+  describe("constructor / initialize()", function () {
+    it("should set the owner", async function () {
+      const { owner, filter } = await setup();
+      expect(await filter.owner()).to.equal(owner.address);
+    });
+    it("should set the registry", async function () {
+      const { registry, filter } = await setup();
+      expect(await filter.registry()).to.equal(await registry.getAddress());
+    });
+  });
+
+  describe("requestCommittee()", function () {
+    it("should revert if the caller is not the registry", async function () {
+      const { notTheOwner, filter, request } = await setup();
+      await expect(
+        filter
+          .connect(notTheOwner)
+          .requestCommittee(request.e3Id, request.threshold),
+      ).to.be.revertedWithCustomError(filter, "OnlyRegistry");
+    });
+    it("should revert if a committee has already been requested for the given e3Id", async function () {
+      const { filter, request, owner } = await setup();
+      await filter.setRegistry(owner.address);
+      await filter.requestCommittee(request.e3Id, request.threshold);
+      await expect(
+        filter.requestCommittee(request.e3Id, request.threshold),
+      ).to.be.revertedWithCustomError(filter, "CommitteeAlreadyExists");
+    });
+    it("should set the threshold for the requested committee", async function () {
+      const { filter, owner, request } = await setup();
+      await filter.setRegistry(owner.address);
+      await filter.requestCommittee(request.e3Id, request.threshold);
+      const committee = await filter.getCommittee(request.e3Id);
+      expect(committee.threshold).to.deep.equal(request.threshold);
+    });
+    it("should return true when a committee is requested", async function () {
+      const { filter, owner, request } = await setup();
+      await filter.setRegistry(owner.address);
+      const result = await filter.requestCommittee.staticCall(
+        request.e3Id,
+        request.threshold,
+      );
+      expect(result).to.equal(true);
+    });
+  });
+
+  describe("publishCommittee()", function () {
+    it("should revert if the caller is not owner", async function () {
+      const { filter, notTheOwner, request } = await setup();
+      await expect(
+        filter
+          .connect(notTheOwner)
+          .publishCommittee(
+            request.e3Id,
+            [AddressOne, AddressTwo],
+            AddressThree,
+          ),
+      ).to.be.revertedWithCustomError(filter, "OwnableUnauthorizedAccount");
+    });
+    it("should revert if committee already published", async function () {
+      const { filter, registry, request } = await setup();
+      expect(
+        await registry.requestCommittee(
+          request.e3Id,
+          request.filter,
+          request.threshold,
+        ),
+      );
+      await filter.publishCommittee(
+        request.e3Id,
+        [AddressOne, AddressTwo],
+        AddressThree,
+      );
+      await expect(
+        filter.publishCommittee(
+          request.e3Id,
+          [AddressOne, AddressTwo],
+          AddressThree,
+        ),
+      ).to.be.revertedWithCustomError(filter, "CommitteeAlreadyPublished");
+    });
+    it("should store the node addresses of the committee", async function () {
+      const { filter, registry, request } = await setup();
+      expect(
+        await registry.requestCommittee(
+          request.e3Id,
+          request.filter,
+          request.threshold,
+        ),
+      );
+      await filter.publishCommittee(
+        request.e3Id,
+        [AddressOne, AddressTwo],
+        AddressThree,
+      );
+      const committee = await filter.getCommittee(request.e3Id);
+      expect(committee.nodes).to.deep.equal([AddressOne, AddressTwo]);
+    });
+    it("should store the public key of the committee", async function () {
+      const { filter, registry, request } = await setup();
+      expect(
+        await registry.requestCommittee(
+          request.e3Id,
+          request.filter,
+          request.threshold,
+        ),
+      );
+      await filter.publishCommittee(
+        request.e3Id,
+        [AddressOne, AddressTwo],
+        AddressThree,
+      );
+      const committee = await filter.getCommittee(request.e3Id);
+      expect(committee.publicKey).to.equal(AddressThree);
+    });
+    it("should publish the correct node addresses of the committee for the given e3Id", async function () {
+      const { filter, registry, request } = await setup();
+      expect(
+        await registry.requestCommittee(
+          request.e3Id,
+          request.filter,
+          request.threshold,
+        ),
+      );
+      await filter.publishCommittee(
+        request.e3Id,
+        [AddressOne, AddressTwo],
+        AddressThree,
+      );
+      const committee = await filter.getCommittee(request.e3Id);
+      expect(committee.nodes).to.deep.equal([AddressOne, AddressTwo]);
+    });
+    it("should publish the public key of the committee for the given e3Id", async function () {
+      const { filter, registry, request } = await setup();
+      expect(
+        await registry.requestCommittee(
+          request.e3Id,
+          request.filter,
+          request.threshold,
+        ),
+      );
+      await filter.publishCommittee(
+        request.e3Id,
+        [AddressOne, AddressTwo],
+        AddressThree,
+      );
+      const committee = await filter.getCommittee(request.e3Id);
+      expect(committee.publicKey).to.equal(AddressThree);
+    });
+  });
+
+  describe("setRegistry()", function () {
+    it("should revert if the caller is not the owner", async function () {
+      const { filter, notTheOwner } = await setup();
+      await expect(filter.connect(notTheOwner).setRegistry(notTheOwner.address))
+        .to.be.revertedWithCustomError(filter, "OwnableUnauthorizedAccount")
+        .withArgs(notTheOwner.address);
+    });
+    it("should set the registry", async function () {
+      const { filter, owner, registry } = await setup();
+      await filter.setRegistry(owner.address);
+      expect(await filter.registry()).to.equal(owner.address);
+    });
+  });
+
+  describe("getCommittee()", function () {
+    it("should return the committee for the given e3Id", async function () {
+      const { filter, owner, registry, request } = await setup();
+      expect(
+        await registry.requestCommittee(
+          request.e3Id,
+          request.filter,
+          request.threshold,
+        ),
+      );
+      expect(
+        await filter.publishCommittee(
+          request.e3Id,
+          [AddressOne, AddressTwo],
+          AddressThree,
+        ),
+      );
+      const committee = await filter.getCommittee(request.e3Id);
+      expect(committee.threshold).to.deep.equal(request.threshold);
+      expect(committee.nodes).to.deep.equal([AddressOne, AddressTwo]);
+      expect(committee.publicKey).to.equal(AddressThree);
+    });
+  });
+});

--- a/packages/evm/test/fixtures/CiphernodeRegistryOwnable.fixture.ts
+++ b/packages/evm/test/fixtures/CiphernodeRegistryOwnable.fixture.ts
@@ -1,0 +1,24 @@
+import { ethers } from "hardhat";
+
+import { CiphernodeRegistryOwnable__factory } from "../../types";
+
+export async function deployCiphernodeRegistryOwnableFixture(
+  owner: string,
+  enclave: string,
+  poseidonT3: string,
+  name?: string,
+) {
+  const [signer] = await ethers.getSigners();
+  const deployment = await (
+    await ethers.getContractFactory(name || "CiphernodeRegistryOwnable", {
+      libraries: {
+        PoseidonT3: poseidonT3,
+      },
+    })
+  ).deploy(owner, enclave);
+
+  return CiphernodeRegistryOwnable__factory.connect(
+    await deployment.getAddress(),
+    signer,
+  );
+}

--- a/packages/evm/test/fixtures/Enclave.fixture.ts
+++ b/packages/evm/test/fixtures/Enclave.fixture.ts
@@ -1,4 +1,3 @@
-import { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
 import { ethers } from "hardhat";
 
 import { Enclave__factory } from "../../types/factories/contracts/Enclave__factory";

--- a/packages/evm/test/fixtures/Enclave.fixture.ts
+++ b/packages/evm/test/fixtures/Enclave.fixture.ts
@@ -3,25 +3,20 @@ import { ethers } from "hardhat";
 
 import { Enclave__factory } from "../../types/factories/contracts/Enclave__factory";
 
-export async function deployEnclaveFixture({
-  owner,
-  registry,
-  maxDuration = 60 * 60 * 24 * 30,
-}: {
-  owner: SignerWithAddress;
-  registry: string;
-  maxDuration?: number;
-}) {
-  const poseidonFactory = await ethers.getContractFactory("PoseidonT3");
-  const poseidonDeployment = await poseidonFactory.deploy();
-
+export async function deployEnclaveFixture(
+  owner: string,
+  registry: string,
+  poseidonT3: string,
+  maxDuration?: number,
+) {
+  const [signer] = await ethers.getSigners();
   const deployment = await (
     await ethers.getContractFactory("Enclave", {
       libraries: {
-        PoseidonT3: await poseidonDeployment.getAddress(),
+        PoseidonT3: poseidonT3,
       },
     })
-  ).deploy(owner, registry, maxDuration);
+  ).deploy(owner, registry, maxDuration || 60 * 60 * 24 * 30);
 
-  return Enclave__factory.connect(await deployment.getAddress(), owner);
+  return Enclave__factory.connect(await deployment.getAddress(), signer);
 }

--- a/packages/evm/test/fixtures/NaiveRegistryFilter.fixture.ts
+++ b/packages/evm/test/fixtures/NaiveRegistryFilter.fixture.ts
@@ -14,6 +14,6 @@ export async function naiveRegistryFilterFixture(
 
   return NaiveRegistryFilter__factory.connect(
     await deployment.getAddress(),
-    signer.provider,
+    signer,
   );
 }

--- a/packages/evm/test/fixtures/NaiveRegistryFilter.fixture.ts
+++ b/packages/evm/test/fixtures/NaiveRegistryFilter.fixture.ts
@@ -1,0 +1,19 @@
+import { ethers } from "hardhat";
+
+import { NaiveRegistryFilter__factory } from "../../types";
+
+export async function naiveRegistryFilterFixture(
+  owner: string,
+  registry: string,
+  name?: string,
+) {
+  const [signer] = await ethers.getSigners();
+  const deployment = await (
+    await ethers.getContractFactory(name || "NaiveRegistryFilter")
+  ).deploy(owner, registry);
+
+  return NaiveRegistryFilter__factory.connect(
+    await deployment.getAddress(),
+    signer.provider,
+  );
+}

--- a/packages/evm/test/fixtures/PoseidonT3.fixture.ts
+++ b/packages/evm/test/fixtures/PoseidonT3.fixture.ts
@@ -1,0 +1,15 @@
+import { ethers } from "hardhat";
+
+import { PoseidonT3__factory } from "../../types";
+
+export async function PoseidonT3Fixture(name?: string) {
+  const [signer] = await ethers.getSigners();
+  const deployment = await (
+    await ethers.getContractFactory(name || "PoseidonT3")
+  ).deploy();
+
+  return PoseidonT3__factory.connect(
+    await deployment.getAddress(),
+    signer.provider,
+  );
+}


### PR DESCRIPTION
This PR adds a suite of unit tests for `CiphernodeRegistryOwnable` and `NaiveRegistryFilter`.