### PR TITLE
feat: explicitly enable encryption schemes

### DIFF
--- a/packages/evm/contracts/interfaces/IE3.sol
+++ b/packages/evm/contracts/interfaces/IE3.sol
@@ -24,6 +24,7 @@ struct E3 {
     uint256[2] startWindow;
     uint256 duration;
     uint256 expiration;
+    bytes32 encryptionSchemeId;
     IE3Program e3Program;
     bytes e3ProgramParams;
     IInputValidator inputValidator;

--- a/packages/evm/contracts/interfaces/IE3Program.sol
+++ b/packages/evm/contracts/interfaces/IE3Program.sol
@@ -10,6 +10,7 @@ interface IE3Program {
     /// @param seed Seed for the computation.
     /// @param e3ProgramParams ABI encoded computation parameters.
     /// @param computeProviderParams ABI encoded compute provider parameters.
+    /// @return encryptionSchemeId ID of the encryption scheme to be used for the computation.
     /// @return inputValidator The input validator to be used for the computation.
     /// @return decryptionVerifier The decryption verifier to be used for the computation.
     function validate(
@@ -20,6 +21,7 @@ interface IE3Program {
     )
         external
         returns (
+            bytes32 encryptionSchemeId,
             IInputValidator inputValidator,
             IDecryptionVerifier decryptionVerifier
         );

--- a/packages/evm/contracts/interfaces/IEnclave.sol
+++ b/packages/evm/contracts/interfaces/IEnclave.sol
@@ -66,6 +66,14 @@ interface IEnclave {
     /// @param ciphernodeRegistry The address of the CiphernodeRegistry contract.
     event CiphernodeRegistrySet(address ciphernodeRegistry);
 
+    /// @notice The event MUST be emitted any time an encryption scheme is enabled.
+    /// @param encryptionSchemeId The ID of the encryption scheme that was enabled.
+    event EncryptionSchemeEnabled(bytes32 encryptionSchemeId);
+
+    /// @notice This event MUST be emitted any time an encryption scheme is disabled.
+    /// @param encryptionSchemeId The ID of the encryption scheme that was disabled.
+    event EncryptionSchemeDisabled(bytes32 encryptionSchemeId);
+
     /// @notice This event MUST be emitted any time a E3 Program is enabled.
     /// @param e3Program The address of the E3 Program.
     event E3ProgramEnabled(IE3Program e3Program);

--- a/packages/evm/contracts/registry/CiphernodeRegistryOwnable.sol
+++ b/packages/evm/contracts/registry/CiphernodeRegistryOwnable.sol
@@ -65,7 +65,7 @@ contract CiphernodeRegistryOwnable is ICiphernodeRegistry, OwnableUpgradeable {
     function initialize(address _owner, address _enclave) public initializer {
         __Ownable_init(msg.sender);
         setEnclave(_enclave);
-        transferOwnership(_owner);
+        if (_owner != owner()) transferOwnership(_owner);
     }
 
     ////////////////////////////////////////////////////////////

--- a/packages/evm/contracts/registry/NaiveRegistryFilter.sol
+++ b/packages/evm/contracts/registry/NaiveRegistryFilter.sol
@@ -60,7 +60,7 @@ contract NaiveRegistryFilter is IRegistryFilter, OwnableUpgradeable {
     function initialize(address _owner, address _registry) public initializer {
         __Ownable_init(msg.sender);
         setRegistry(_registry);
-        transferOwnership(_owner);
+        if (_owner != owner()) transferOwnership(_owner);
     }
 
     ////////////////////////////////////////////////////////////

--- a/packages/evm/contracts/test/MockE3Program.sol
+++ b/packages/evm/contracts/test/MockE3Program.sol
@@ -19,6 +19,7 @@ contract MockE3Program is IE3Program {
         external
         pure
         returns (
+            bytes32 encryptionSchemeId,
             IInputValidator inputValidator,
             IDecryptionVerifier decryptionVerifier
         )
@@ -32,6 +33,7 @@ contract MockE3Program is IE3Program {
             inputValidator := mload(add(e3ProgramParams, 32))
             decryptionVerifier := mload(add(computeProviderParams, 32))
         }
+        encryptionSchemeId = 0x0000000000000000000000000000000000000000000000000000000000000001;
     }
 
     function verify(

--- a/packages/evm/contracts/test/MockRegistryFilter.sol
+++ b/packages/evm/contracts/test/MockRegistryFilter.sol
@@ -67,7 +67,7 @@ contract MockNaiveRegistryFilter is IRegistryFilter, OwnableUpgradeable {
     function initialize(address _owner, address _registry) public initializer {
         __Ownable_init(msg.sender);
         setRegistry(_registry);
-        transferOwnership(_owner);
+        if (_owner != owner()) transferOwnership(_owner);
     }
 
     ////////////////////////////////////////////////////////////


### PR DESCRIPTION
This PR adds `enabledEncryptionSchemes` mapping to `Enclave.sol` along with `encryptionSchemeId` to the `E3` struct. This should make it easier for ciphernodes to identify which encryption scheme is being requested and to decode the FHE params from the `E3ProgrogramParams`.

Alternatively, we could split the FHE program params and FHE params into separate parameters. However, this seems like it might be overkill.