### PR TITLE
hash given outputs and pass output hash to corresponding verifiers

### DIFF
--- a/packages/evm/contracts/Enclave.sol
+++ b/packages/evm/contracts/Enclave.sol
@@ -228,7 +228,8 @@ contract Enclave is IEnclave, OwnableUpgradeable {
 
     function publishCiphertextOutput(
         uint256 e3Id,
-        bytes memory data
+        bytes memory ciphertextOutput,
+        bytes memory proof
     ) external returns (bool success) {
         E3 memory e3 = getE3(e3Id);
         // Note: if we make 0 a no expiration, this has to be refactored
@@ -240,38 +241,43 @@ contract Enclave is IEnclave, OwnableUpgradeable {
         // TODO: should the output verifier be able to change its mind?
         //i.e. should we be able to call this multiple times?
         require(
-            e3.ciphertextOutput.length == 0,
+            e3.ciphertextOutput == bytes32(0),
             CiphertextOutputAlreadyPublished(e3Id)
         );
-        bytes memory output;
-        (output, success) = e3.e3Program.verify(e3Id, data);
-        require(success, InvalidOutput(output));
-        e3s[e3Id].ciphertextOutput = output;
+        bytes32 ciphertextOutputHash = keccak256(ciphertextOutput);
+        (success) = e3.e3Program.verify(e3Id, ciphertextOutputHash, proof);
+        require(success, InvalidOutput(ciphertextOutput));
+        e3s[e3Id].ciphertextOutput = ciphertextOutputHash;
 
-        emit CiphertextOutputPublished(e3Id, output);
+        emit CiphertextOutputPublished(e3Id, ciphertextOutput);
     }
 
     function publishPlaintextOutput(
         uint256 e3Id,
-        bytes memory data
+        bytes memory plaintextOutput,
+        bytes memory proof
     ) external returns (bool success) {
         E3 memory e3 = getE3(e3Id);
         // Note: if we make 0 a no expiration, this has to be refactored
         require(e3.expiration > 0, E3NotActivated(e3Id));
         require(
-            e3.ciphertextOutput.length > 0,
+            e3.ciphertextOutput != bytes32(0),
             CiphertextOutputNotPublished(e3Id)
         );
         require(
-            e3.plaintextOutput.length == 0,
+            e3.plaintextOutput == bytes32(0),
             PlaintextOutputAlreadyPublished(e3Id)
         );
-        bytes memory output;
-        (output, success) = e3.decryptionVerifier.verify(e3Id, data);
-        require(success, InvalidOutput(output));
-        e3s[e3Id].plaintextOutput = output;
+        bytes32 plaintextOutputHash = keccak256(plaintextOutput);
+        (success) = e3.decryptionVerifier.verify(
+            e3Id,
+            plaintextOutputHash,
+            proof
+        );
+        require(success, InvalidOutput(plaintextOutput));
+        e3s[e3Id].plaintextOutput = plaintextOutputHash;
 
-        emit PlaintextOutputPublished(e3Id, output);
+        emit PlaintextOutputPublished(e3Id, plaintextOutput);
     }
 
     ////////////////////////////////////////////////////////////

--- a/packages/evm/contracts/interfaces/IDecryptionVerifier.sol
+++ b/packages/evm/contracts/interfaces/IDecryptionVerifier.sol
@@ -5,10 +5,12 @@ interface IDecryptionVerifier {
     /// @notice This function should be called by the Enclave contract to verify the
     /// decryption of output of a computation.
     /// @param e3Id ID of the E3.
-    /// @param data ABI encoded output data to be verified.
-    /// @return output Plaintext output of the given computation.
+    /// @param plaintextOutputHash The keccak256 hash of the plaintext output to be verified.
+    /// @param proof ABI encoded proof of the given output hash.
+    /// @return success Whether or not the plaintextOutputHash was successfully verified.
     function verify(
         uint256 e3Id,
-        bytes memory data
-    ) external view returns (bytes memory output, bool success);
+        bytes32 plaintextOutputHash,
+        bytes memory proof
+    ) external view returns (bool success);
 }

--- a/packages/evm/contracts/interfaces/IE3.sol
+++ b/packages/evm/contracts/interfaces/IE3.sol
@@ -29,6 +29,6 @@ struct E3 {
     IInputValidator inputValidator;
     IDecryptionVerifier decryptionVerifier;
     bytes committeePublicKey;
-    bytes ciphertextOutput;
-    bytes plaintextOutput;
+    bytes32 ciphertextOutput;
+    bytes32 plaintextOutput;
 }

--- a/packages/evm/contracts/interfaces/IE3Program.sol
+++ b/packages/evm/contracts/interfaces/IE3Program.sol
@@ -26,11 +26,12 @@ interface IE3Program {
 
     /// @notice This function should be called by the Enclave contract to verify the decrypted output of an E3.
     /// @param e3Id ID of the E3.
-    /// @param outputData ABI encoded output data to be verified.
-    /// @return output The output data to be published.
+    /// @param ciphertextOutputHash The keccak256 hash of output data to be verified.
+    /// @param proof ABI encoded data to verify the ciphertextOutputHash.
     /// @return success Whether the output data is valid.
     function verify(
         uint256 e3Id,
-        bytes memory outputData
-    ) external returns (bytes memory output, bool success);
+        bytes32 ciphertextOutputHash,
+        bytes memory proof
+    ) external returns (bool success);
 }

--- a/packages/evm/contracts/interfaces/IEnclave.sol
+++ b/packages/evm/contracts/interfaces/IEnclave.sol
@@ -122,22 +122,25 @@ interface IEnclave {
     /// @notice This function should be called to publish output data for an Encrypted Execution Environment (E3).
     /// @dev This function MUST emit the CiphertextOutputPublished event.
     /// @param e3Id ID of the E3.
-    /// @param data ABI encoded output data to verify.
+    /// @param ciphertextOutput ABI encoded output data to verify.
+    /// @param proof ABI encoded data to verify the ciphertextOutput.
     /// @return success True if the output was successfully published.
     function publishCiphertextOutput(
         uint256 e3Id,
-        bytes memory data
+        bytes memory ciphertextOutput,
+        bytes memory proof
     ) external returns (bool success);
 
     /// @notice This function publishes the plaintext output of an Encrypted Execution Environment (E3).
     /// @dev This function MUST revert if the output has not been published.
     /// @dev This function MUST emit the PlaintextOutputPublished event.
     /// @param e3Id ID of the E3.
-    /// @param data ABI encoded output data to decrypt.
-    /// @return success True if the output was successfully decrypted.
+    /// @param plaintextOutput ABI encoded plaintext output.
+    /// @param proof ABI encoded data to verify the plaintextOutput.
     function publishPlaintextOutput(
         uint256 e3Id,
-        bytes memory data
+        bytes memory plaintextOutput,
+        bytes memory proof
     ) external returns (bool success);
 
     ////////////////////////////////////////////////////////////

--- a/packages/evm/contracts/test/MockDecryptionVerifier.sol
+++ b/packages/evm/contracts/test/MockDecryptionVerifier.sol
@@ -6,10 +6,11 @@ import { IDecryptionVerifier } from "../interfaces/IDecryptionVerifier.sol";
 contract MockDecryptionVerifier is IDecryptionVerifier {
     function verify(
         uint256,
+        bytes32,
         bytes memory data
-    ) external pure returns (bytes memory output, bool success) {
-        output = data;
+    ) external pure returns (bool success) {
+        data;
 
-        if (output.length > 0) success = true;
+        if (data.length > 0) success = true;
     }
 }

--- a/packages/evm/contracts/test/MockE3Program.sol
+++ b/packages/evm/contracts/test/MockE3Program.sol
@@ -36,9 +36,10 @@ contract MockE3Program is IE3Program {
 
     function verify(
         uint256,
+        bytes32,
         bytes memory data
-    ) external pure returns (bytes memory output, bool success) {
-        output = data;
-        if (output.length > 0) success = true;
+    ) external pure returns (bool success) {
+        data;
+        if (data.length > 0) success = true;
     }
 }


### PR DESCRIPTION
This PR separates outputs and proofs into separate params, passing just the hash of the output and the proof into verify functions.