### PR TITLE
add file input for proof

### DIFF
--- a/packages/evm/tasks/enclave.ts
+++ b/packages/evm/tasks/enclave.ts
@@ -250,7 +250,8 @@ task("e3:publishCiphertext", "Publish ciphertext output for an E3 program")
   .addParam("e3Id", "Id of the E3 program")
   .addOptionalParam("data", "data to publish")
   .addOptionalParam("dataFile", "file containing data to publish")
-  .addParam("proof", "proof to publish")
+  .addOptionalParam("proof", "proof to publish")
+  .addOptionalParam("proofFile", "file containing proof to publish")
   .setAction(async function (taskArguments: TaskArguments, hre) {
     const enclave = await hre.deployments.get("Enclave");
 
@@ -266,10 +267,17 @@ task("e3:publishCiphertext", "Publish ciphertext output for an E3 program")
       data = file.toString();
     }
 
+    let proof = taskArguments.proof;
+
+    if (taskArguments.proofFile) {
+      const file = fs.readFileSync(taskArguments.proofFile);
+      proof = file.toString();
+    }
+
     const tx = await enclaveContract.publishCiphertextOutput(
       taskArguments.e3Id,
       data,
-      taskArguments.proof,
+      proof,
     );
 
     console.log("Publishing ciphertext... ", tx.hash);
@@ -282,7 +290,8 @@ task("e3:publishPlaintext", "Publish plaintext output for an E3 program")
   .addParam("e3Id", "Id of the E3 program")
   .addOptionalParam("data", "data to publish")
   .addOptionalParam("dataFile", "file containing data to publish")
-  .addParam("proof", "proof to publish")
+  .addOptionalParam("proof", "proof to publish")
+  .addOptionalParam("proofFile", "file containing proof to publish")
   .setAction(async function (taskArguments: TaskArguments, hre) {
     const enclave = await hre.deployments.get("Enclave");
 
@@ -298,10 +307,17 @@ task("e3:publishPlaintext", "Publish plaintext output for an E3 program")
       data = file.toString();
     }
 
+    let proof = taskArguments.proof;
+
+    if (taskArguments.proofFile) {
+      const file = fs.readFileSync(taskArguments.proofFile);
+      proof = file.toString();
+    }
+
     const tx = await enclaveContract.publishPlaintextOutput(
       taskArguments.e3Id,
       data,
-      taskArguments.proof,
+      proof,
     );
 
     console.log("Publishing ciphertext... ", tx.hash);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced flexibility in the `e3:publishCiphertext` and `e3:publishPlaintext` tasks by making the `proof` parameter optional.
	- Introduced a new optional `proofFile` parameter to allow users to specify a file containing the proof.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->