### PR TITLE
Remove address from encoding

### DIFF
--- a/packages/ciphernode/core/src/evm_enclave.rs
+++ b/packages/ciphernode/core/src/evm_enclave.rs
@@ -6,8 +6,7 @@ use crate::{
 };
 use actix::Addr;
 use alloy::{
-    hex,
-    primitives::{Address, Bytes},
+    primitives::{Address},
     sol,
     sol_types::SolValue,
 };
@@ -50,12 +49,8 @@ impl TryFrom<&E3Requested> for events::E3Requested {
     type Error = anyhow::Error;
     fn try_from(value: &E3Requested) -> Result<Self, Self::Error> {
         let program_params = value.e3.e3ProgramParams.to_vec();
-        println!("received: {}", hex::encode(&program_params));
-
-        let decoded =
-            decode_e3_params(&program_params).context("Failed to ABI decode program_params")?;
         Ok(events::E3Requested {
-            params: decoded.0.into(),
+            params: program_params.into(),
             threshold_m: value.e3.threshold[0] as usize,
             seed: value.e3.seed.into(),
             e3_id: value.e3Id.to_string().into(),
@@ -110,37 +105,3 @@ pub async fn connect_evm_enclave(bus: Addr<EventBus>, rpc_url: &str, contract_ad
     println!("Evm is listening to {}", contract_address);
 }
 
-pub fn decode_e3_params(bytes: &[u8]) -> Result<(Vec<u8>, String)> {
-    let decoded: (Bytes, Address) = SolValue::abi_decode_params(bytes, true)?;
-    Ok((decoded.0.into(), decoded.1.to_string()))
-}
-
-pub fn encode_e3_params(params: &[u8], input_validator: Address) -> Vec<u8> {
-    (params, input_validator).abi_encode_params()
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::encode_bfv_params;
-
-    use super::{decode_e3_params, encode_e3_params};
-    use alloy::{hex, primitives::address};
-    use anyhow::*;
-    use fhe::bfv::BfvParameters;
-    use fhe_traits::Deserialize;
-
-    #[test]
-    fn test_evm_decode() -> Result<()> {
-        let params_encoded = encode_bfv_params(vec![0x3FFFFFFF000001], 2048, 1032193);
-
-        let add = address!("8A791620dd6260079BF849Dc5567aDC3F2FdC318");
-        let encoded = hex::encode(&encode_e3_params(&params_encoded, add));
-        assert_eq!(encoded, "00000000000000000000000000000000000000000000000000000000000000400000000000000000000000008a791620dd6260079bf849dc5567adc3f2fdc31800000000000000000000000000000000000000000000000000000000000000130880101208818080f8ffffff1f1881803f200a00000000000000000000000000");
-        let input: Vec<u8> = hex::decode(&encoded)?;
-        let (de_params, de_address) = decode_e3_params(&input)?;
-        let params_assemble = BfvParameters::try_deserialize(&de_params)?;
-        assert_eq!(params_assemble.degree(), 2048);
-        assert_eq!(de_address, "0x8A791620dd6260079BF849Dc5567aDC3F2FdC318");
-        Ok(())
-    }
-}

--- a/packages/ciphernode/core/src/lib.rs
+++ b/packages/ciphernode/core/src/lib.rs
@@ -34,7 +34,6 @@ pub use data::*;
 pub use e3_request::*;
 pub use eventbus::*;
 pub use events::*;
-pub use evm_enclave::{decode_e3_params, encode_e3_params};
 pub use fhe::*;
 pub use keyshare::*;
 pub use logger::*;

--- a/packages/ciphernode/enclave_node/src/bin/pack_e3_params.rs
+++ b/packages/ciphernode/enclave_node/src/bin/pack_e3_params.rs
@@ -1,6 +1,5 @@
-use alloy::{hex::FromHex, primitives::{address, Address}};
 use clap::{command, Parser};
-use enclave_core::{encode_bfv_params, encode_e3_params};
+use enclave_core::encode_bfv_params;
 use std::{error::Error, num::ParseIntError, process};
 
 fn parse_hex(arg: &str) -> Result<u64, ParseIntError> {
@@ -19,12 +18,6 @@ struct Args {
 
     #[arg(short, long = "plaintext-modulus")]
     plaintext_modulus: u64,
-
-    #[arg(short, long = "no-crp", help = "Skip the CRP generation")]
-    no_crp: bool,
-
-    #[arg(short, long = "input-validator", help = "The input validator address")]
-    input_validator: String
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -36,8 +29,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     }
 
     let encoded = encode_bfv_params(args.moduli, args.degree, args.plaintext_modulus);
-    let abi_encoded = encode_e3_params(&encoded,Address::from_hex(args.input_validator)?);
-    for byte in abi_encoded {
+
+    for byte in encoded {
         print!("{:02x}", byte);
     }
 

--- a/packages/evm/contracts/test/MockE3Program.sol
+++ b/packages/evm/contracts/test/MockE3Program.sol
@@ -6,7 +6,7 @@ import { IE3Program, IInputValidator } from "../interfaces/IE3Program.sol";
 contract MockE3Program is IE3Program {
     error invalidParams(bytes e3ProgramParams, bytes computeProviderParams);
 
-    IInputValidator storageInputValidator;
+    IInputValidator private storageInputValidator;
 
     constructor(IInputValidator _inputValidator) {
         storageInputValidator = _inputValidator;

--- a/packages/evm/contracts/test/MockE3Program.sol
+++ b/packages/evm/contracts/test/MockE3Program.sol
@@ -6,6 +6,16 @@ import { IE3Program, IInputValidator } from "../interfaces/IE3Program.sol";
 contract MockE3Program is IE3Program {
     error invalidParams(bytes e3ProgramParams, bytes computeProviderParams);
 
+    IInputValidator storageInputValidator;
+
+    constructor(IInputValidator _inputValidator) {
+        storageInputValidator = _inputValidator;
+    }
+
+    function setInputValidator(IInputValidator _inputValidator) external {
+        storageInputValidator = _inputValidator;
+    }
+
     function validate(
         uint256,
         uint256,
@@ -13,17 +23,14 @@ contract MockE3Program is IE3Program {
         bytes memory computeProviderParams
     )
         external
-        pure
+        view
         returns (bytes32 encryptionSchemeId, IInputValidator inputValidator)
     {
         require(
             computeProviderParams.length == 32,
             invalidParams(e3ProgramParams, computeProviderParams)
         );
-        (, inputValidator) = abi.decode(
-            e3ProgramParams,
-            (bytes, IInputValidator)
-        );
+        inputValidator = storageInputValidator;
         encryptionSchemeId = 0x0000000000000000000000000000000000000000000000000000000000000001;
     }
 

--- a/packages/evm/deploy/mocks.ts
+++ b/packages/evm/deploy/mocks.ts
@@ -5,12 +5,6 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployer } = await hre.getNamedAccounts();
   const { deploy } = hre.deployments;
 
-  await deploy("MockE3Program", {
-    from: deployer,
-    args: [],
-    log: true,
-  });
-
   await deploy("MockComputeProvider", {
     from: deployer,
     args: [],
@@ -23,9 +17,15 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     log: true,
   });
 
-  await deploy("MockInputValidator", {
+  const mockInputValidator = await deploy("MockInputValidator", {
     from: deployer,
     args: [],
+    log: true,
+  });
+
+  await deploy("MockE3Program", {
+    from: deployer,
+    args: [mockInputValidator.address],
     log: true,
   });
 

--- a/packages/evm/test/Enclave.spec.ts
+++ b/packages/evm/test/Enclave.spec.ts
@@ -35,7 +35,7 @@ const proof = "0x1337";
 // Hash function used to compute the tree nodes.
 const hash = (a: bigint, b: bigint) => poseidon2([a, b]);
 
-describe("Enclave", function() {
+describe("Enclave", function () {
   async function setup() {
     const [owner, notTheOwner] = await ethers.getSigners();
 
@@ -90,43 +90,43 @@ describe("Enclave", function() {
     };
   }
 
-  describe("constructor / initialize()", function() {
-    it("correctly sets owner", async function() {
+  describe("constructor / initialize()", function () {
+    it("correctly sets owner", async function () {
       const { owner, enclave } = await loadFixture(setup);
       expect(await enclave.owner()).to.equal(owner.address);
     });
 
-    it("correctly sets ciphernodeRegistry address", async function() {
+    it("correctly sets ciphernodeRegistry address", async function () {
       const { mocks, enclave } = await loadFixture(setup);
       expect(await enclave.ciphernodeRegistry()).to.equal(
         await mocks.registry.getAddress(),
       );
     });
 
-    it("correctly sets max duration", async function() {
+    it("correctly sets max duration", async function () {
       const { enclave } = await loadFixture(setup);
       expect(await enclave.maxDuration()).to.equal(60 * 60 * 24 * 30);
     });
   });
 
-  describe("setMaxDuration()", function() {
-    it("reverts if not called by owner", async function() {
+  describe("setMaxDuration()", function () {
+    it("reverts if not called by owner", async function () {
       const { enclave, notTheOwner } = await loadFixture(setup);
       await expect(enclave.connect(notTheOwner).setMaxDuration(1))
         .to.be.revertedWithCustomError(enclave, "OwnableUnauthorizedAccount")
         .withArgs(notTheOwner);
     });
-    it("set max duration correctly", async function() {
+    it("set max duration correctly", async function () {
       const { enclave } = await loadFixture(setup);
       await enclave.setMaxDuration(1);
       expect(await enclave.maxDuration()).to.equal(1);
     });
-    it("returns true if max duration is set successfully", async function() {
+    it("returns true if max duration is set successfully", async function () {
       const { enclave } = await loadFixture(setup);
       const result = await enclave.setMaxDuration.staticCall(1);
       expect(result).to.be.true;
     });
-    it("emits MaxDurationSet event", async function() {
+    it("emits MaxDurationSet event", async function () {
       const { enclave } = await loadFixture(setup);
       await expect(enclave.setMaxDuration(1))
         .to.emit(enclave, "MaxDurationSet")
@@ -134,8 +134,8 @@ describe("Enclave", function() {
     });
   });
 
-  describe("setCiphernodeRegistry()", function() {
-    it("reverts if not called by owner", async function() {
+  describe("setCiphernodeRegistry()", function () {
+    it("reverts if not called by owner", async function () {
       const { enclave, notTheOwner } = await loadFixture(setup);
 
       await expect(
@@ -144,13 +144,13 @@ describe("Enclave", function() {
         .to.be.revertedWithCustomError(enclave, "OwnableUnauthorizedAccount")
         .withArgs(notTheOwner);
     });
-    it("reverts if given address(0)", async function() {
+    it("reverts if given address(0)", async function () {
       const { enclave } = await loadFixture(setup);
       await expect(enclave.setCiphernodeRegistry(ethers.ZeroAddress))
         .to.be.revertedWithCustomError(enclave, "InvalidCiphernodeRegistry")
         .withArgs(ethers.ZeroAddress);
     });
-    it("reverts if given address is the same as the current ciphernodeRegistry", async function() {
+    it("reverts if given address is the same as the current ciphernodeRegistry", async function () {
       const {
         enclave,
         mocks: { registry },
@@ -159,20 +159,20 @@ describe("Enclave", function() {
         .to.be.revertedWithCustomError(enclave, "InvalidCiphernodeRegistry")
         .withArgs(registry);
     });
-    it("sets ciphernodeRegistry correctly", async function() {
+    it("sets ciphernodeRegistry correctly", async function () {
       const { enclave } = await loadFixture(setup);
 
       expect(await enclave.ciphernodeRegistry()).to.not.equal(AddressTwo);
       await enclave.setCiphernodeRegistry(AddressTwo);
       expect(await enclave.ciphernodeRegistry()).to.equal(AddressTwo);
     });
-    it("returns true if ciphernodeRegistry is set successfully", async function() {
+    it("returns true if ciphernodeRegistry is set successfully", async function () {
       const { enclave } = await loadFixture(setup);
 
       const result = await enclave.setCiphernodeRegistry.staticCall(AddressTwo);
       expect(result).to.be.true;
     });
-    it("emits CiphernodeRegistrySet event", async function() {
+    it("emits CiphernodeRegistrySet event", async function () {
       const { enclave } = await loadFixture(setup);
 
       await expect(enclave.setCiphernodeRegistry(AddressTwo))
@@ -181,15 +181,15 @@ describe("Enclave", function() {
     });
   });
 
-  describe("getE3()", function() {
-    it("reverts if E3 does not exist", async function() {
+  describe("getE3()", function () {
+    it("reverts if E3 does not exist", async function () {
       const { enclave } = await loadFixture(setup);
 
       await expect(enclave.getE3(1))
         .to.be.revertedWithCustomError(enclave, "E3DoesNotExist")
         .withArgs(1);
     });
-    it("returns correct E3 details", async function() {
+    it("returns correct E3 details", async function () {
       const { enclave, mocks, request } = await loadFixture(setup);
       await enclave.request(
         request.filter,
@@ -219,14 +219,14 @@ describe("Enclave", function() {
     });
   });
 
-  describe("getDecryptionVerifier()", function() {
-    it("returns true if encryption scheme is enabled", async function() {
+  describe("getDecryptionVerifier()", function () {
+    it("returns true if encryption scheme is enabled", async function () {
       const { enclave, mocks } = await loadFixture(setup);
       expect(await enclave.getDecryptionVerifier(encryptionSchemeId)).to.equal(
         await mocks.decryptionVerifier.getAddress(),
       );
     });
-    it("returns false if encryption scheme is not enabled", async function() {
+    it("returns false if encryption scheme is not enabled", async function () {
       const { enclave } = await loadFixture(setup);
       expect(
         await enclave.getDecryptionVerifier(newEncryptionSchemeId),
@@ -234,8 +234,8 @@ describe("Enclave", function() {
     });
   });
 
-  describe("setDecryptionVerifier()", function() {
-    it("reverts if caller is not owner", async function() {
+  describe("setDecryptionVerifier()", function () {
+    it("reverts if caller is not owner", async function () {
       const { enclave, notTheOwner, mocks } = await loadFixture(setup);
 
       await expect(
@@ -249,7 +249,7 @@ describe("Enclave", function() {
         .to.be.revertedWithCustomError(enclave, "OwnableUnauthorizedAccount")
         .withArgs(notTheOwner);
     });
-    it("reverts if encryption scheme is already enabled", async function() {
+    it("reverts if encryption scheme is already enabled", async function () {
       const { enclave, mocks } = await loadFixture(setup);
 
       await expect(
@@ -261,7 +261,7 @@ describe("Enclave", function() {
         .to.be.revertedWithCustomError(enclave, "InvalidEncryptionScheme")
         .withArgs(encryptionSchemeId);
     });
-    it("enabled decryption verifier", async function() {
+    it("enabled decryption verifier", async function () {
       const { enclave, mocks } = await loadFixture(setup);
 
       expect(
@@ -274,7 +274,7 @@ describe("Enclave", function() {
         await enclave.getDecryptionVerifier(newEncryptionSchemeId),
       ).to.equal(await mocks.decryptionVerifier.getAddress());
     });
-    it("returns true if decryption verifier is enabled successfully", async function() {
+    it("returns true if decryption verifier is enabled successfully", async function () {
       const { enclave, mocks } = await loadFixture(setup);
 
       const result = await enclave.setDecryptionVerifier.staticCall(
@@ -283,7 +283,7 @@ describe("Enclave", function() {
       );
       expect(result).to.be.true;
     });
-    it("emits EncryptionSchemeEnabled", async function() {
+    it("emits EncryptionSchemeEnabled", async function () {
       const { enclave, mocks } = await loadFixture(setup);
 
       await expect(
@@ -297,8 +297,8 @@ describe("Enclave", function() {
     });
   });
 
-  describe("disableEncryptionScheme()", function() {
-    it("reverts if caller is not owner", async function() {
+  describe("disableEncryptionScheme()", function () {
+    it("reverts if caller is not owner", async function () {
       const { enclave, notTheOwner } = await loadFixture(setup);
 
       await expect(
@@ -309,14 +309,14 @@ describe("Enclave", function() {
         .to.be.revertedWithCustomError(enclave, "OwnableUnauthorizedAccount")
         .withArgs(notTheOwner);
     });
-    it("reverts if encryption scheme is not already enabled", async function() {
+    it("reverts if encryption scheme is not already enabled", async function () {
       const { enclave } = await loadFixture(setup);
 
       await expect(enclave.disableEncryptionScheme(newEncryptionSchemeId))
         .to.be.revertedWithCustomError(enclave, "InvalidEncryptionScheme")
         .withArgs(newEncryptionSchemeId);
     });
-    it("disables encryption scheme", async function() {
+    it("disables encryption scheme", async function () {
       const { enclave } = await loadFixture(setup);
 
       expect(await enclave.disableEncryptionScheme(encryptionSchemeId));
@@ -324,14 +324,14 @@ describe("Enclave", function() {
         ethers.ZeroAddress,
       );
     });
-    it("returns true if encryption scheme is disabled successfully", async function() {
+    it("returns true if encryption scheme is disabled successfully", async function () {
       const { enclave } = await loadFixture(setup);
 
       const result =
         await enclave.disableEncryptionScheme.staticCall(encryptionSchemeId);
       expect(result).to.be.true;
     });
-    it("emits EncryptionSchemeDisabled", async function() {
+    it("emits EncryptionSchemeDisabled", async function () {
       const { enclave } = await loadFixture(setup);
 
       await expect(await enclave.disableEncryptionScheme(encryptionSchemeId))
@@ -340,8 +340,8 @@ describe("Enclave", function() {
     });
   });
 
-  describe("enableE3Program()", function() {
-    it("reverts if not called by owner", async function() {
+  describe("enableE3Program()", function () {
+    it("reverts if not called by owner", async function () {
       const {
         notTheOwner,
         enclave,
@@ -352,7 +352,7 @@ describe("Enclave", function() {
         .to.be.revertedWithCustomError(enclave, "OwnableUnauthorizedAccount")
         .withArgs(notTheOwner);
     });
-    it("reverts if E3 Program is already enabled", async function() {
+    it("reverts if E3 Program is already enabled", async function () {
       const {
         enclave,
         mocks: { e3Program },
@@ -362,7 +362,7 @@ describe("Enclave", function() {
         .to.be.revertedWithCustomError(enclave, "ModuleAlreadyEnabled")
         .withArgs(e3Program);
     });
-    it("enables E3 Program correctly", async function() {
+    it("enables E3 Program correctly", async function () {
       const {
         enclave,
         mocks: { e3Program },
@@ -370,12 +370,12 @@ describe("Enclave", function() {
       const enabled = await enclave.e3Programs(e3Program);
       expect(enabled).to.be.true;
     });
-    it("returns true if E3 Program is enabled successfully", async function() {
+    it("returns true if E3 Program is enabled successfully", async function () {
       const { enclave } = await loadFixture(setup);
       const result = await enclave.enableE3Program.staticCall(AddressTwo);
       expect(result).to.be.true;
     });
-    it("emits E3ProgramEnabled event", async function() {
+    it("emits E3ProgramEnabled event", async function () {
       const { enclave } = await loadFixture(setup);
       await expect(enclave.enableE3Program(AddressTwo))
         .to.emit(enclave, "E3ProgramEnabled")
@@ -383,8 +383,8 @@ describe("Enclave", function() {
     });
   });
 
-  describe("disableE3Program()", function() {
-    it("reverts if not called by owner", async function() {
+  describe("disableE3Program()", function () {
+    it("reverts if not called by owner", async function () {
       const {
         notTheOwner,
         enclave,
@@ -394,13 +394,13 @@ describe("Enclave", function() {
         .to.be.revertedWithCustomError(enclave, "OwnableUnauthorizedAccount")
         .withArgs(notTheOwner);
     });
-    it("reverts if E3 Program is not enabled", async function() {
+    it("reverts if E3 Program is not enabled", async function () {
       const { enclave } = await loadFixture(setup);
       await expect(enclave.disableE3Program(AddressTwo))
         .to.be.revertedWithCustomError(enclave, "ModuleNotEnabled")
         .withArgs(AddressTwo);
     });
-    it("disables E3 Program correctly", async function() {
+    it("disables E3 Program correctly", async function () {
       const {
         enclave,
         mocks: { e3Program },
@@ -410,7 +410,7 @@ describe("Enclave", function() {
       const enabled = await enclave.e3Programs(e3Program);
       expect(enabled).to.be.false;
     });
-    it("returns true if E3 Program is disabled successfully", async function() {
+    it("returns true if E3 Program is disabled successfully", async function () {
       const {
         enclave,
         mocks: { e3Program },
@@ -419,7 +419,7 @@ describe("Enclave", function() {
 
       expect(result).to.be.true;
     });
-    it("emits E3ProgramDisabled event", async function() {
+    it("emits E3ProgramDisabled event", async function () {
       const {
         enclave,
         mocks: { e3Program },
@@ -430,8 +430,8 @@ describe("Enclave", function() {
     });
   });
 
-  describe("request()", function() {
-    it("reverts if msg.value is 0", async function() {
+  describe("request()", function () {
+    it("reverts if msg.value is 0", async function () {
       const { enclave, request } = await loadFixture(setup);
       await expect(
         enclave.request(
@@ -445,7 +445,7 @@ describe("Enclave", function() {
         ),
       ).to.be.revertedWithCustomError(enclave, "PaymentRequired");
     });
-    it("reverts if threshold is 0", async function() {
+    it("reverts if threshold is 0", async function () {
       const { enclave, request } = await loadFixture(setup);
       await expect(
         enclave.request(
@@ -460,7 +460,7 @@ describe("Enclave", function() {
         ),
       ).to.be.revertedWithCustomError(enclave, "InvalidThreshold");
     });
-    it("reverts if threshold is greater than number", async function() {
+    it("reverts if threshold is greater than number", async function () {
       const { enclave, request } = await loadFixture(setup);
       await expect(
         enclave.request(
@@ -475,7 +475,7 @@ describe("Enclave", function() {
         ),
       ).to.be.revertedWithCustomError(enclave, "InvalidThreshold");
     });
-    it("reverts if duration is 0", async function() {
+    it("reverts if duration is 0", async function () {
       const { enclave, request } = await loadFixture(setup);
       await expect(
         enclave.request(
@@ -490,7 +490,7 @@ describe("Enclave", function() {
         ),
       ).to.be.revertedWithCustomError(enclave, "InvalidDuration");
     });
-    it("reverts if duration is greater than maxDuration", async function() {
+    it("reverts if duration is greater than maxDuration", async function () {
       const { enclave, request } = await loadFixture(setup);
       await expect(
         enclave.request(
@@ -505,7 +505,7 @@ describe("Enclave", function() {
         ),
       ).to.be.revertedWithCustomError(enclave, "InvalidDuration");
     });
-    it("reverts if E3 Program is not enabled", async function() {
+    it("reverts if E3 Program is not enabled", async function () {
       const { enclave, request } = await loadFixture(setup);
       await expect(
         enclave.request(
@@ -522,7 +522,7 @@ describe("Enclave", function() {
         .to.be.revertedWithCustomError(enclave, "E3ProgramNotAllowed")
         .withArgs(ethers.ZeroAddress);
     });
-    it("reverts if given encryption scheme is not enabled", async function() {
+    it("reverts if given encryption scheme is not enabled", async function () {
       const { enclave, request } = await loadFixture(setup);
       await enclave.disableEncryptionScheme(encryptionSchemeId);
       await expect(
@@ -540,7 +540,7 @@ describe("Enclave", function() {
         .to.be.revertedWithCustomError(enclave, "InvalidEncryptionScheme")
         .withArgs(encryptionSchemeId);
     });
-    it("reverts if given E3 Program does not return input validator address", async function() {
+    it("reverts if given E3 Program does not return input validator address", async function () {
       const { enclave, mocks, owner, request } = await loadFixture(setup);
       await mocks.e3Program
         .connect(owner)
@@ -558,7 +558,7 @@ describe("Enclave", function() {
         ),
       ).to.be.revertedWithCustomError(enclave, "InvalidComputationRequest");
     });
-    it("reverts if committee selection fails", async function() {
+    it("reverts if committee selection fails", async function () {
       const { enclave, request } = await loadFixture(setup);
       await expect(
         enclave.request(
@@ -573,7 +573,7 @@ describe("Enclave", function() {
         ),
       ).to.be.revertedWithCustomError(enclave, "CommitteeSelectionFailed");
     });
-    it("instantiates a new E3", async function() {
+    it("instantiates a new E3", async function () {
       const { enclave, mocks, request } = await loadFixture(setup);
       await enclave.request(
         request.filter,
@@ -600,7 +600,7 @@ describe("Enclave", function() {
       expect(e3.ciphertextOutput).to.equal(ethers.ZeroHash);
       expect(e3.plaintextOutput).to.equal(ethers.ZeroHash);
     });
-    it("emits E3Requested event", async function() {
+    it("emits E3Requested event", async function () {
       const { enclave, request } = await loadFixture(setup);
       const tx = await enclave.request(
         request.filter,
@@ -620,15 +620,15 @@ describe("Enclave", function() {
     });
   });
 
-  describe("activate()", function() {
-    it("reverts if E3 does not exist", async function() {
+  describe("activate()", function () {
+    it("reverts if E3 does not exist", async function () {
       const { enclave } = await loadFixture(setup);
 
       await expect(enclave.activate(0))
         .to.be.revertedWithCustomError(enclave, "E3DoesNotExist")
         .withArgs(0);
     });
-    it("reverts if E3 has already been activated", async function() {
+    it("reverts if E3 has already been activated", async function () {
       const { enclave, request } = await loadFixture(setup);
 
       await enclave.request(
@@ -648,7 +648,7 @@ describe("Enclave", function() {
         .to.be.revertedWithCustomError(enclave, "E3AlreadyActivated")
         .withArgs(0);
     });
-    it("reverts if E3 is not yet ready to start", async function() {
+    it("reverts if E3 is not yet ready to start", async function () {
       const { enclave, request } = await loadFixture(setup);
       const startTime = [
         (await time.latest()) + 1000,
@@ -671,7 +671,7 @@ describe("Enclave", function() {
         "E3NotReady",
       );
     });
-    it("reverts if E3 start has expired", async function() {
+    it("reverts if E3 start has expired", async function () {
       const { enclave, request } = await loadFixture(setup);
       const startTime = [
         (await time.latest()) + 1,
@@ -696,7 +696,7 @@ describe("Enclave", function() {
         "E3Expired",
       );
     });
-    it("reverts if ciphernodeRegistry does not return a public key", async function() {
+    it("reverts if ciphernodeRegistry does not return a public key", async function () {
       const { enclave, request } = await loadFixture(setup);
       const startTime = [
         (await time.latest()) + 1000,
@@ -719,7 +719,7 @@ describe("Enclave", function() {
         "E3NotReady",
       );
     });
-    it("reverts if E3 start has expired", async function() {
+    it("reverts if E3 start has expired", async function () {
       const { enclave, request } = await loadFixture(setup);
       const startTime = [await time.latest(), (await time.latest()) + 1] as [
         number,
@@ -744,7 +744,7 @@ describe("Enclave", function() {
         "E3Expired",
       );
     });
-    it("reverts if ciphernodeRegistry does not return a public key", async function() {
+    it("reverts if ciphernodeRegistry does not return a public key", async function () {
       const { enclave, request } = await loadFixture(setup);
 
       await enclave.request(
@@ -842,8 +842,8 @@ describe("Enclave", function() {
     });
   });
 
-  describe("publishInput()", function() {
-    it("reverts if E3 does not exist", async function() {
+  describe("publishInput()", function () {
+    it("reverts if E3 does not exist", async function () {
       const { enclave } = await loadFixture(setup);
 
       await expect(enclave.publishInput(0, "0x"))
@@ -851,7 +851,7 @@ describe("Enclave", function() {
         .withArgs(0);
     });
 
-    it("reverts if E3 has not been activated", async function() {
+    it("reverts if E3 has not been activated", async function () {
       const { enclave, request } = await loadFixture(setup);
 
       await enclave.request(
@@ -875,7 +875,7 @@ describe("Enclave", function() {
       await enclave.activate(0);
     });
 
-    it("reverts if input is not valid", async function() {
+    it("reverts if input is not valid", async function () {
       const { enclave, request } = await loadFixture(setup);
 
       await enclave.request(
@@ -895,7 +895,7 @@ describe("Enclave", function() {
       ).to.be.revertedWithCustomError(enclave, "InvalidInput");
     });
 
-    it("reverts if outside of input window", async function() {
+    it("reverts if outside of input window", async function () {
       const { enclave, request } = await loadFixture(setup);
 
       await enclave.request(
@@ -917,7 +917,7 @@ describe("Enclave", function() {
         enclave.publishInput(0, ZeroHash),
       ).to.be.revertedWithCustomError(enclave, "InputDeadlinePassed");
     });
-    it("returns true if input is published successfully", async function() {
+    it("returns true if input is published successfully", async function () {
       const { enclave, request } = await loadFixture(setup);
       const inputData = "0x12345678";
 
@@ -939,7 +939,7 @@ describe("Enclave", function() {
       );
     });
 
-    it("adds inputHash to merkle tree", async function() {
+    it("adds inputHash to merkle tree", async function () {
       const { enclave, request } = await loadFixture(setup);
       const inputData = abiCoder.encode(["bytes"], ["0xaabbccddeeff"]);
 
@@ -971,7 +971,7 @@ describe("Enclave", function() {
       await enclave.publishInput(e3Id, secondInputData);
       expect(await enclave.getInputRoot(e3Id)).to.equal(tree.root);
     });
-    it("emits InputPublished event", async function() {
+    it("emits InputPublished event", async function () {
       const { enclave, request } = await loadFixture(setup);
 
       await enclave.request(
@@ -997,15 +997,15 @@ describe("Enclave", function() {
     });
   });
 
-  describe("publishCiphertextOutput()", function() {
-    it("reverts if E3 does not exist", async function() {
+  describe("publishCiphertextOutput()", function () {
+    it("reverts if E3 does not exist", async function () {
       const { enclave } = await loadFixture(setup);
 
       await expect(enclave.publishCiphertextOutput(0, "0x", "0x"))
         .to.be.revertedWithCustomError(enclave, "E3DoesNotExist")
         .withArgs(0);
     });
-    it("reverts if E3 has not been activated", async function() {
+    it("reverts if E3 has not been activated", async function () {
       const { enclave, request } = await loadFixture(setup);
       const e3Id = 0;
 
@@ -1023,7 +1023,7 @@ describe("Enclave", function() {
         .to.be.revertedWithCustomError(enclave, "E3NotActivated")
         .withArgs(e3Id);
     });
-    it("reverts if input deadline has not passed", async function() {
+    it("reverts if input deadline has not passed", async function () {
       const { enclave, request } = await loadFixture(setup);
       const tx = await enclave.request(
         request.filter,
@@ -1046,7 +1046,7 @@ describe("Enclave", function() {
         .to.be.revertedWithCustomError(enclave, "InputDeadlineNotPassed")
         .withArgs(e3Id, expectedExpiration);
     });
-    it("reverts if output has already been published", async function() {
+    it("reverts if output has already been published", async function () {
       const { enclave, request } = await loadFixture(setup);
       const e3Id = 0;
 
@@ -1070,7 +1070,7 @@ describe("Enclave", function() {
         )
         .withArgs(e3Id);
     });
-    it("reverts if output is not valid", async function() {
+    it("reverts if output is not valid", async function () {
       const { enclave, request } = await loadFixture(setup);
       const e3Id = 0;
 
@@ -1090,7 +1090,7 @@ describe("Enclave", function() {
         enclave.publishCiphertextOutput(e3Id, "0x", "0x"),
       ).to.be.revertedWithCustomError(enclave, "InvalidOutput");
     });
-    it("sets ciphertextOutput correctly", async function() {
+    it("sets ciphertextOutput correctly", async function () {
       const { enclave, request } = await loadFixture(setup);
       const e3Id = 0;
 
@@ -1110,7 +1110,7 @@ describe("Enclave", function() {
       const e3 = await enclave.getE3(e3Id);
       expect(e3.ciphertextOutput).to.equal(dataHash);
     });
-    it("returns true if output is published successfully", async function() {
+    it("returns true if output is published successfully", async function () {
       const { enclave, request } = await loadFixture(setup);
       const e3Id = 0;
 
@@ -1130,7 +1130,7 @@ describe("Enclave", function() {
         await enclave.publishCiphertextOutput.staticCall(e3Id, data, proof),
       ).to.equal(true);
     });
-    it("emits CiphertextOutputPublished event", async function() {
+    it("emits CiphertextOutputPublished event", async function () {
       const { enclave, request } = await loadFixture(setup);
       const e3Id = 0;
 
@@ -1152,8 +1152,8 @@ describe("Enclave", function() {
     });
   });
 
-  describe("publishPlaintextOutput()", function() {
-    it("reverts if E3 does not exist", async function() {
+  describe("publishPlaintextOutput()", function () {
+    it("reverts if E3 does not exist", async function () {
       const { enclave } = await loadFixture(setup);
       const e3Id = 0;
 
@@ -1161,7 +1161,7 @@ describe("Enclave", function() {
         .to.be.revertedWithCustomError(enclave, "E3DoesNotExist")
         .withArgs(e3Id);
     });
-    it("reverts if E3 has not been activated", async function() {
+    it("reverts if E3 has not been activated", async function () {
       const { enclave, request } = await loadFixture(setup);
       const e3Id = 0;
 
@@ -1179,7 +1179,7 @@ describe("Enclave", function() {
         .to.be.revertedWithCustomError(enclave, "E3NotActivated")
         .withArgs(e3Id);
     });
-    it("reverts if ciphertextOutput has not been published", async function() {
+    it("reverts if ciphertextOutput has not been published", async function () {
       const { enclave, request } = await loadFixture(setup);
       const e3Id = 0;
 
@@ -1198,7 +1198,7 @@ describe("Enclave", function() {
         .to.be.revertedWithCustomError(enclave, "CiphertextOutputNotPublished")
         .withArgs(e3Id);
     });
-    it("reverts if plaintextOutput has already been published", async function() {
+    it("reverts if plaintextOutput has already been published", async function () {
       const { enclave, request } = await loadFixture(setup);
       const e3Id = 0;
 
@@ -1223,7 +1223,7 @@ describe("Enclave", function() {
         )
         .withArgs(e3Id);
     });
-    it("reverts if output is not valid", async function() {
+    it("reverts if output is not valid", async function () {
       const { enclave, request } = await loadFixture(setup);
       const e3Id = 0;
 
@@ -1244,7 +1244,7 @@ describe("Enclave", function() {
         .to.be.revertedWithCustomError(enclave, "InvalidOutput")
         .withArgs(data);
     });
-    it("sets plaintextOutput correctly", async function() {
+    it("sets plaintextOutput correctly", async function () {
       const { enclave, request } = await loadFixture(setup);
       const e3Id = 0;
 
@@ -1266,7 +1266,7 @@ describe("Enclave", function() {
       const e3 = await enclave.getE3(e3Id);
       expect(e3.plaintextOutput).to.equal(dataHash);
     });
-    it("returns true if output is published successfully", async function() {
+    it("returns true if output is published successfully", async function () {
       const { enclave, request } = await loadFixture(setup);
       const e3Id = 0;
 
@@ -1287,7 +1287,7 @@ describe("Enclave", function() {
         await enclave.publishPlaintextOutput.staticCall(e3Id, data, proof),
       ).to.equal(true);
     });
-    it("emits PlaintextOutputPublished event", async function() {
+    it("emits PlaintextOutputPublished event", async function () {
       const { enclave, request } = await loadFixture(setup);
       const e3Id = 0;
 

--- a/packages/evm/test/Enclave.spec.ts
+++ b/packages/evm/test/Enclave.spec.ts
@@ -35,16 +35,18 @@ const proof = "0x1337";
 // Hash function used to compute the tree nodes.
 const hash = (a: bigint, b: bigint) => poseidon2([a, b]);
 
-describe("Enclave", function () {
+describe("Enclave", function() {
   async function setup() {
     const [owner, notTheOwner] = await ethers.getSigners();
 
     const poseidon = await PoseidonT3Fixture();
     const registry = await deployCiphernodeRegistryFixture();
-    const e3Program = await deployE3ProgramFixture();
     const decryptionVerifier = await deployDecryptionVerifierFixture();
     const computeProvider = await deployComputeProviderFixture();
     const inputValidator = await deployInputValidatorFixture();
+    const e3Program = await deployE3ProgramFixture(
+      await inputValidator.getAddress(),
+    );
 
     const enclave = await deployEnclaveFixture(
       owner.address,
@@ -79,10 +81,7 @@ describe("Enclave", function () {
         ],
         duration: time.duration.days(30),
         e3Program: await e3Program.getAddress(),
-        e3ProgramParams: abiCoder.encode(
-          ["bytes", "address"],
-          ["0x12345678", await inputValidator.getAddress()],
-        ),
+        e3ProgramParams: "0x12345678",
         computeProviderParams: abiCoder.encode(
           ["address"],
           [await decryptionVerifier.getAddress()],
@@ -91,43 +90,43 @@ describe("Enclave", function () {
     };
   }
 
-  describe("constructor / initialize()", function () {
-    it("correctly sets owner", async function () {
+  describe("constructor / initialize()", function() {
+    it("correctly sets owner", async function() {
       const { owner, enclave } = await loadFixture(setup);
       expect(await enclave.owner()).to.equal(owner.address);
     });
 
-    it("correctly sets ciphernodeRegistry address", async function () {
+    it("correctly sets ciphernodeRegistry address", async function() {
       const { mocks, enclave } = await loadFixture(setup);
       expect(await enclave.ciphernodeRegistry()).to.equal(
         await mocks.registry.getAddress(),
       );
     });
 
-    it("correctly sets max duration", async function () {
+    it("correctly sets max duration", async function() {
       const { enclave } = await loadFixture(setup);
       expect(await enclave.maxDuration()).to.equal(60 * 60 * 24 * 30);
     });
   });
 
-  describe("setMaxDuration()", function () {
-    it("reverts if not called by owner", async function () {
+  describe("setMaxDuration()", function() {
+    it("reverts if not called by owner", async function() {
       const { enclave, notTheOwner } = await loadFixture(setup);
       await expect(enclave.connect(notTheOwner).setMaxDuration(1))
         .to.be.revertedWithCustomError(enclave, "OwnableUnauthorizedAccount")
         .withArgs(notTheOwner);
     });
-    it("set max duration correctly", async function () {
+    it("set max duration correctly", async function() {
       const { enclave } = await loadFixture(setup);
       await enclave.setMaxDuration(1);
       expect(await enclave.maxDuration()).to.equal(1);
     });
-    it("returns true if max duration is set successfully", async function () {
+    it("returns true if max duration is set successfully", async function() {
       const { enclave } = await loadFixture(setup);
       const result = await enclave.setMaxDuration.staticCall(1);
       expect(result).to.be.true;
     });
-    it("emits MaxDurationSet event", async function () {
+    it("emits MaxDurationSet event", async function() {
       const { enclave } = await loadFixture(setup);
       await expect(enclave.setMaxDuration(1))
         .to.emit(enclave, "MaxDurationSet")
@@ -135,8 +134,8 @@ describe("Enclave", function () {
     });
   });
 
-  describe("setCiphernodeRegistry()", function () {
-    it("reverts if not called by owner", async function () {
+  describe("setCiphernodeRegistry()", function() {
+    it("reverts if not called by owner", async function() {
       const { enclave, notTheOwner } = await loadFixture(setup);
 
       await expect(
@@ -145,13 +144,13 @@ describe("Enclave", function () {
         .to.be.revertedWithCustomError(enclave, "OwnableUnauthorizedAccount")
         .withArgs(notTheOwner);
     });
-    it("reverts if given address(0)", async function () {
+    it("reverts if given address(0)", async function() {
       const { enclave } = await loadFixture(setup);
       await expect(enclave.setCiphernodeRegistry(ethers.ZeroAddress))
         .to.be.revertedWithCustomError(enclave, "InvalidCiphernodeRegistry")
         .withArgs(ethers.ZeroAddress);
     });
-    it("reverts if given address is the same as the current ciphernodeRegistry", async function () {
+    it("reverts if given address is the same as the current ciphernodeRegistry", async function() {
       const {
         enclave,
         mocks: { registry },
@@ -160,20 +159,20 @@ describe("Enclave", function () {
         .to.be.revertedWithCustomError(enclave, "InvalidCiphernodeRegistry")
         .withArgs(registry);
     });
-    it("sets ciphernodeRegistry correctly", async function () {
+    it("sets ciphernodeRegistry correctly", async function() {
       const { enclave } = await loadFixture(setup);
 
       expect(await enclave.ciphernodeRegistry()).to.not.equal(AddressTwo);
       await enclave.setCiphernodeRegistry(AddressTwo);
       expect(await enclave.ciphernodeRegistry()).to.equal(AddressTwo);
     });
-    it("returns true if ciphernodeRegistry is set successfully", async function () {
+    it("returns true if ciphernodeRegistry is set successfully", async function() {
       const { enclave } = await loadFixture(setup);
 
       const result = await enclave.setCiphernodeRegistry.staticCall(AddressTwo);
       expect(result).to.be.true;
     });
-    it("emits CiphernodeRegistrySet event", async function () {
+    it("emits CiphernodeRegistrySet event", async function() {
       const { enclave } = await loadFixture(setup);
 
       await expect(enclave.setCiphernodeRegistry(AddressTwo))
@@ -182,16 +181,16 @@ describe("Enclave", function () {
     });
   });
 
-  describe("getE3()", function () {
-    it("reverts if E3 does not exist", async function () {
+  describe("getE3()", function() {
+    it("reverts if E3 does not exist", async function() {
       const { enclave } = await loadFixture(setup);
 
       await expect(enclave.getE3(1))
         .to.be.revertedWithCustomError(enclave, "E3DoesNotExist")
         .withArgs(1);
     });
-    it("returns correct E3 details", async function () {
-      const { enclave, request } = await loadFixture(setup);
+    it("returns correct E3 details", async function() {
+      const { enclave, mocks, request } = await loadFixture(setup);
       await enclave.request(
         request.filter,
         request.threshold,
@@ -209,7 +208,7 @@ describe("Enclave", function () {
       expect(e3.e3Program).to.equal(request.e3Program);
       expect(e3.e3ProgramParams).to.equal(request.e3ProgramParams);
       expect(e3.inputValidator).to.equal(
-        abiCoder.decode(["bytes", "address"], request.e3ProgramParams)[1],
+        await mocks.inputValidator.getAddress(),
       );
       expect(e3.decryptionVerifier).to.equal(
         abiCoder.decode(["address"], request.computeProviderParams)[0],
@@ -220,14 +219,14 @@ describe("Enclave", function () {
     });
   });
 
-  describe("getDecryptionVerifier()", function () {
-    it("returns true if encryption scheme is enabled", async function () {
+  describe("getDecryptionVerifier()", function() {
+    it("returns true if encryption scheme is enabled", async function() {
       const { enclave, mocks } = await loadFixture(setup);
       expect(await enclave.getDecryptionVerifier(encryptionSchemeId)).to.equal(
         await mocks.decryptionVerifier.getAddress(),
       );
     });
-    it("returns false if encryption scheme is not enabled", async function () {
+    it("returns false if encryption scheme is not enabled", async function() {
       const { enclave } = await loadFixture(setup);
       expect(
         await enclave.getDecryptionVerifier(newEncryptionSchemeId),
@@ -235,8 +234,8 @@ describe("Enclave", function () {
     });
   });
 
-  describe("setDecryptionVerifier()", function () {
-    it("reverts if caller is not owner", async function () {
+  describe("setDecryptionVerifier()", function() {
+    it("reverts if caller is not owner", async function() {
       const { enclave, notTheOwner, mocks } = await loadFixture(setup);
 
       await expect(
@@ -250,7 +249,7 @@ describe("Enclave", function () {
         .to.be.revertedWithCustomError(enclave, "OwnableUnauthorizedAccount")
         .withArgs(notTheOwner);
     });
-    it("reverts if encryption scheme is already enabled", async function () {
+    it("reverts if encryption scheme is already enabled", async function() {
       const { enclave, mocks } = await loadFixture(setup);
 
       await expect(
@@ -262,7 +261,7 @@ describe("Enclave", function () {
         .to.be.revertedWithCustomError(enclave, "InvalidEncryptionScheme")
         .withArgs(encryptionSchemeId);
     });
-    it("enabled decryption verifier", async function () {
+    it("enabled decryption verifier", async function() {
       const { enclave, mocks } = await loadFixture(setup);
 
       expect(
@@ -275,7 +274,7 @@ describe("Enclave", function () {
         await enclave.getDecryptionVerifier(newEncryptionSchemeId),
       ).to.equal(await mocks.decryptionVerifier.getAddress());
     });
-    it("returns true if decryption verifier is enabled successfully", async function () {
+    it("returns true if decryption verifier is enabled successfully", async function() {
       const { enclave, mocks } = await loadFixture(setup);
 
       const result = await enclave.setDecryptionVerifier.staticCall(
@@ -284,7 +283,7 @@ describe("Enclave", function () {
       );
       expect(result).to.be.true;
     });
-    it("emits EncryptionSchemeEnabled", async function () {
+    it("emits EncryptionSchemeEnabled", async function() {
       const { enclave, mocks } = await loadFixture(setup);
 
       await expect(
@@ -298,8 +297,8 @@ describe("Enclave", function () {
     });
   });
 
-  describe("disableEncryptionScheme()", function () {
-    it("reverts if caller is not owner", async function () {
+  describe("disableEncryptionScheme()", function() {
+    it("reverts if caller is not owner", async function() {
       const { enclave, notTheOwner } = await loadFixture(setup);
 
       await expect(
@@ -310,14 +309,14 @@ describe("Enclave", function () {
         .to.be.revertedWithCustomError(enclave, "OwnableUnauthorizedAccount")
         .withArgs(notTheOwner);
     });
-    it("reverts if encryption scheme is not already enabled", async function () {
+    it("reverts if encryption scheme is not already enabled", async function() {
       const { enclave } = await loadFixture(setup);
 
       await expect(enclave.disableEncryptionScheme(newEncryptionSchemeId))
         .to.be.revertedWithCustomError(enclave, "InvalidEncryptionScheme")
         .withArgs(newEncryptionSchemeId);
     });
-    it("disables encryption scheme", async function () {
+    it("disables encryption scheme", async function() {
       const { enclave } = await loadFixture(setup);
 
       expect(await enclave.disableEncryptionScheme(encryptionSchemeId));
@@ -325,14 +324,14 @@ describe("Enclave", function () {
         ethers.ZeroAddress,
       );
     });
-    it("returns true if encryption scheme is disabled successfully", async function () {
+    it("returns true if encryption scheme is disabled successfully", async function() {
       const { enclave } = await loadFixture(setup);
 
       const result =
         await enclave.disableEncryptionScheme.staticCall(encryptionSchemeId);
       expect(result).to.be.true;
     });
-    it("emits EncryptionSchemeDisabled", async function () {
+    it("emits EncryptionSchemeDisabled", async function() {
       const { enclave } = await loadFixture(setup);
 
       await expect(await enclave.disableEncryptionScheme(encryptionSchemeId))
@@ -341,8 +340,8 @@ describe("Enclave", function () {
     });
   });
 
-  describe("enableE3Program()", function () {
-    it("reverts if not called by owner", async function () {
+  describe("enableE3Program()", function() {
+    it("reverts if not called by owner", async function() {
       const {
         notTheOwner,
         enclave,
@@ -353,7 +352,7 @@ describe("Enclave", function () {
         .to.be.revertedWithCustomError(enclave, "OwnableUnauthorizedAccount")
         .withArgs(notTheOwner);
     });
-    it("reverts if E3 Program is already enabled", async function () {
+    it("reverts if E3 Program is already enabled", async function() {
       const {
         enclave,
         mocks: { e3Program },
@@ -363,7 +362,7 @@ describe("Enclave", function () {
         .to.be.revertedWithCustomError(enclave, "ModuleAlreadyEnabled")
         .withArgs(e3Program);
     });
-    it("enables E3 Program correctly", async function () {
+    it("enables E3 Program correctly", async function() {
       const {
         enclave,
         mocks: { e3Program },
@@ -371,12 +370,12 @@ describe("Enclave", function () {
       const enabled = await enclave.e3Programs(e3Program);
       expect(enabled).to.be.true;
     });
-    it("returns true if E3 Program is enabled successfully", async function () {
+    it("returns true if E3 Program is enabled successfully", async function() {
       const { enclave } = await loadFixture(setup);
       const result = await enclave.enableE3Program.staticCall(AddressTwo);
       expect(result).to.be.true;
     });
-    it("emits E3ProgramEnabled event", async function () {
+    it("emits E3ProgramEnabled event", async function() {
       const { enclave } = await loadFixture(setup);
       await expect(enclave.enableE3Program(AddressTwo))
         .to.emit(enclave, "E3ProgramEnabled")
@@ -384,8 +383,8 @@ describe("Enclave", function () {
     });
   });
 
-  describe("disableE3Program()", function () {
-    it("reverts if not called by owner", async function () {
+  describe("disableE3Program()", function() {
+    it("reverts if not called by owner", async function() {
       const {
         notTheOwner,
         enclave,
@@ -395,13 +394,13 @@ describe("Enclave", function () {
         .to.be.revertedWithCustomError(enclave, "OwnableUnauthorizedAccount")
         .withArgs(notTheOwner);
     });
-    it("reverts if E3 Program is not enabled", async function () {
+    it("reverts if E3 Program is not enabled", async function() {
       const { enclave } = await loadFixture(setup);
       await expect(enclave.disableE3Program(AddressTwo))
         .to.be.revertedWithCustomError(enclave, "ModuleNotEnabled")
         .withArgs(AddressTwo);
     });
-    it("disables E3 Program correctly", async function () {
+    it("disables E3 Program correctly", async function() {
       const {
         enclave,
         mocks: { e3Program },
@@ -411,7 +410,7 @@ describe("Enclave", function () {
       const enabled = await enclave.e3Programs(e3Program);
       expect(enabled).to.be.false;
     });
-    it("returns true if E3 Program is disabled successfully", async function () {
+    it("returns true if E3 Program is disabled successfully", async function() {
       const {
         enclave,
         mocks: { e3Program },
@@ -420,7 +419,7 @@ describe("Enclave", function () {
 
       expect(result).to.be.true;
     });
-    it("emits E3ProgramDisabled event", async function () {
+    it("emits E3ProgramDisabled event", async function() {
       const {
         enclave,
         mocks: { e3Program },
@@ -431,8 +430,8 @@ describe("Enclave", function () {
     });
   });
 
-  describe("request()", function () {
-    it("reverts if msg.value is 0", async function () {
+  describe("request()", function() {
+    it("reverts if msg.value is 0", async function() {
       const { enclave, request } = await loadFixture(setup);
       await expect(
         enclave.request(
@@ -446,7 +445,7 @@ describe("Enclave", function () {
         ),
       ).to.be.revertedWithCustomError(enclave, "PaymentRequired");
     });
-    it("reverts if threshold is 0", async function () {
+    it("reverts if threshold is 0", async function() {
       const { enclave, request } = await loadFixture(setup);
       await expect(
         enclave.request(
@@ -461,7 +460,7 @@ describe("Enclave", function () {
         ),
       ).to.be.revertedWithCustomError(enclave, "InvalidThreshold");
     });
-    it("reverts if threshold is greater than number", async function () {
+    it("reverts if threshold is greater than number", async function() {
       const { enclave, request } = await loadFixture(setup);
       await expect(
         enclave.request(
@@ -476,7 +475,7 @@ describe("Enclave", function () {
         ),
       ).to.be.revertedWithCustomError(enclave, "InvalidThreshold");
     });
-    it("reverts if duration is 0", async function () {
+    it("reverts if duration is 0", async function() {
       const { enclave, request } = await loadFixture(setup);
       await expect(
         enclave.request(
@@ -491,7 +490,7 @@ describe("Enclave", function () {
         ),
       ).to.be.revertedWithCustomError(enclave, "InvalidDuration");
     });
-    it("reverts if duration is greater than maxDuration", async function () {
+    it("reverts if duration is greater than maxDuration", async function() {
       const { enclave, request } = await loadFixture(setup);
       await expect(
         enclave.request(
@@ -506,7 +505,7 @@ describe("Enclave", function () {
         ),
       ).to.be.revertedWithCustomError(enclave, "InvalidDuration");
     });
-    it("reverts if E3 Program is not enabled", async function () {
+    it("reverts if E3 Program is not enabled", async function() {
       const { enclave, request } = await loadFixture(setup);
       await expect(
         enclave.request(
@@ -523,7 +522,7 @@ describe("Enclave", function () {
         .to.be.revertedWithCustomError(enclave, "E3ProgramNotAllowed")
         .withArgs(ethers.ZeroAddress);
     });
-    it("reverts if given encryption scheme is not enabled", async function () {
+    it("reverts if given encryption scheme is not enabled", async function() {
       const { enclave, request } = await loadFixture(setup);
       await enclave.disableEncryptionScheme(encryptionSchemeId);
       await expect(
@@ -541,9 +540,11 @@ describe("Enclave", function () {
         .to.be.revertedWithCustomError(enclave, "InvalidEncryptionScheme")
         .withArgs(encryptionSchemeId);
     });
-    it("reverts if given E3 Program does not return input validator address", async function () {
-      const { enclave, request } = await loadFixture(setup);
-
+    it("reverts if given E3 Program does not return input validator address", async function() {
+      const { enclave, mocks, owner, request } = await loadFixture(setup);
+      await mocks.e3Program
+        .connect(owner)
+        .setInputValidator(ethers.ZeroAddress);
       await expect(
         enclave.request(
           request.filter,
@@ -551,13 +552,13 @@ describe("Enclave", function () {
           request.startTime,
           request.duration,
           request.e3Program,
-          abiCoder.encode(["bytes", "address"], [ZeroHash, ethers.ZeroAddress]),
+          request.e3ProgramParams,
           request.computeProviderParams,
           { value: 10 },
         ),
       ).to.be.revertedWithCustomError(enclave, "InvalidComputationRequest");
     });
-    it("reverts if committee selection fails", async function () {
+    it("reverts if committee selection fails", async function() {
       const { enclave, request } = await loadFixture(setup);
       await expect(
         enclave.request(
@@ -572,8 +573,8 @@ describe("Enclave", function () {
         ),
       ).to.be.revertedWithCustomError(enclave, "CommitteeSelectionFailed");
     });
-    it("instantiates a new E3", async function () {
-      const { enclave, request } = await loadFixture(setup);
+    it("instantiates a new E3", async function() {
+      const { enclave, mocks, request } = await loadFixture(setup);
       await enclave.request(
         request.filter,
         request.threshold,
@@ -590,7 +591,7 @@ describe("Enclave", function () {
       expect(e3.expiration).to.equal(0n);
       expect(e3.e3Program).to.equal(request.e3Program);
       expect(e3.inputValidator).to.equal(
-        abiCoder.decode(["bytes", "address"], request.e3ProgramParams)[1],
+        await mocks.inputValidator.getAddress(),
       );
       expect(e3.decryptionVerifier).to.equal(
         abiCoder.decode(["address"], request.computeProviderParams)[0],
@@ -599,7 +600,7 @@ describe("Enclave", function () {
       expect(e3.ciphertextOutput).to.equal(ethers.ZeroHash);
       expect(e3.plaintextOutput).to.equal(ethers.ZeroHash);
     });
-    it("emits E3Requested event", async function () {
+    it("emits E3Requested event", async function() {
       const { enclave, request } = await loadFixture(setup);
       const tx = await enclave.request(
         request.filter,
@@ -619,15 +620,15 @@ describe("Enclave", function () {
     });
   });
 
-  describe("activate()", function () {
-    it("reverts if E3 does not exist", async function () {
+  describe("activate()", function() {
+    it("reverts if E3 does not exist", async function() {
       const { enclave } = await loadFixture(setup);
 
       await expect(enclave.activate(0))
         .to.be.revertedWithCustomError(enclave, "E3DoesNotExist")
         .withArgs(0);
     });
-    it("reverts if E3 has already been activated", async function () {
+    it("reverts if E3 has already been activated", async function() {
       const { enclave, request } = await loadFixture(setup);
 
       await enclave.request(
@@ -647,7 +648,7 @@ describe("Enclave", function () {
         .to.be.revertedWithCustomError(enclave, "E3AlreadyActivated")
         .withArgs(0);
     });
-    it("reverts if E3 is not yet ready to start", async function () {
+    it("reverts if E3 is not yet ready to start", async function() {
       const { enclave, request } = await loadFixture(setup);
       const startTime = [
         (await time.latest()) + 1000,
@@ -670,7 +671,7 @@ describe("Enclave", function () {
         "E3NotReady",
       );
     });
-    it("reverts if E3 start has expired", async function () {
+    it("reverts if E3 start has expired", async function() {
       const { enclave, request } = await loadFixture(setup);
       const startTime = [
         (await time.latest()) + 1,
@@ -695,7 +696,7 @@ describe("Enclave", function () {
         "E3Expired",
       );
     });
-    it("reverts if ciphernodeRegistry does not return a public key", async function () {
+    it("reverts if ciphernodeRegistry does not return a public key", async function() {
       const { enclave, request } = await loadFixture(setup);
       const startTime = [
         (await time.latest()) + 1000,
@@ -718,7 +719,7 @@ describe("Enclave", function () {
         "E3NotReady",
       );
     });
-    it("reverts if E3 start has expired", async function () {
+    it("reverts if E3 start has expired", async function() {
       const { enclave, request } = await loadFixture(setup);
       const startTime = [await time.latest(), (await time.latest()) + 1] as [
         number,
@@ -743,7 +744,7 @@ describe("Enclave", function () {
         "E3Expired",
       );
     });
-    it("reverts if ciphernodeRegistry does not return a public key", async function () {
+    it("reverts if ciphernodeRegistry does not return a public key", async function() {
       const { enclave, request } = await loadFixture(setup);
 
       await enclave.request(
@@ -841,8 +842,8 @@ describe("Enclave", function () {
     });
   });
 
-  describe("publishInput()", function () {
-    it("reverts if E3 does not exist", async function () {
+  describe("publishInput()", function() {
+    it("reverts if E3 does not exist", async function() {
       const { enclave } = await loadFixture(setup);
 
       await expect(enclave.publishInput(0, "0x"))
@@ -850,7 +851,7 @@ describe("Enclave", function () {
         .withArgs(0);
     });
 
-    it("reverts if E3 has not been activated", async function () {
+    it("reverts if E3 has not been activated", async function() {
       const { enclave, request } = await loadFixture(setup);
 
       await enclave.request(
@@ -874,7 +875,7 @@ describe("Enclave", function () {
       await enclave.activate(0);
     });
 
-    it("reverts if input is not valid", async function () {
+    it("reverts if input is not valid", async function() {
       const { enclave, request } = await loadFixture(setup);
 
       await enclave.request(
@@ -894,7 +895,7 @@ describe("Enclave", function () {
       ).to.be.revertedWithCustomError(enclave, "InvalidInput");
     });
 
-    it("reverts if outside of input window", async function () {
+    it("reverts if outside of input window", async function() {
       const { enclave, request } = await loadFixture(setup);
 
       await enclave.request(
@@ -916,7 +917,7 @@ describe("Enclave", function () {
         enclave.publishInput(0, ZeroHash),
       ).to.be.revertedWithCustomError(enclave, "InputDeadlinePassed");
     });
-    it("returns true if input is published successfully", async function () {
+    it("returns true if input is published successfully", async function() {
       const { enclave, request } = await loadFixture(setup);
       const inputData = "0x12345678";
 
@@ -938,7 +939,7 @@ describe("Enclave", function () {
       );
     });
 
-    it("adds inputHash to merkle tree", async function () {
+    it("adds inputHash to merkle tree", async function() {
       const { enclave, request } = await loadFixture(setup);
       const inputData = abiCoder.encode(["bytes"], ["0xaabbccddeeff"]);
 
@@ -970,7 +971,7 @@ describe("Enclave", function () {
       await enclave.publishInput(e3Id, secondInputData);
       expect(await enclave.getInputRoot(e3Id)).to.equal(tree.root);
     });
-    it("emits InputPublished event", async function () {
+    it("emits InputPublished event", async function() {
       const { enclave, request } = await loadFixture(setup);
 
       await enclave.request(
@@ -996,15 +997,15 @@ describe("Enclave", function () {
     });
   });
 
-  describe("publishCiphertextOutput()", function () {
-    it("reverts if E3 does not exist", async function () {
+  describe("publishCiphertextOutput()", function() {
+    it("reverts if E3 does not exist", async function() {
       const { enclave } = await loadFixture(setup);
 
       await expect(enclave.publishCiphertextOutput(0, "0x", "0x"))
         .to.be.revertedWithCustomError(enclave, "E3DoesNotExist")
         .withArgs(0);
     });
-    it("reverts if E3 has not been activated", async function () {
+    it("reverts if E3 has not been activated", async function() {
       const { enclave, request } = await loadFixture(setup);
       const e3Id = 0;
 
@@ -1022,7 +1023,7 @@ describe("Enclave", function () {
         .to.be.revertedWithCustomError(enclave, "E3NotActivated")
         .withArgs(e3Id);
     });
-    it("reverts if input deadline has not passed", async function () {
+    it("reverts if input deadline has not passed", async function() {
       const { enclave, request } = await loadFixture(setup);
       const tx = await enclave.request(
         request.filter,
@@ -1045,7 +1046,7 @@ describe("Enclave", function () {
         .to.be.revertedWithCustomError(enclave, "InputDeadlineNotPassed")
         .withArgs(e3Id, expectedExpiration);
     });
-    it("reverts if output has already been published", async function () {
+    it("reverts if output has already been published", async function() {
       const { enclave, request } = await loadFixture(setup);
       const e3Id = 0;
 
@@ -1069,7 +1070,7 @@ describe("Enclave", function () {
         )
         .withArgs(e3Id);
     });
-    it("reverts if output is not valid", async function () {
+    it("reverts if output is not valid", async function() {
       const { enclave, request } = await loadFixture(setup);
       const e3Id = 0;
 
@@ -1089,7 +1090,7 @@ describe("Enclave", function () {
         enclave.publishCiphertextOutput(e3Id, "0x", "0x"),
       ).to.be.revertedWithCustomError(enclave, "InvalidOutput");
     });
-    it("sets ciphertextOutput correctly", async function () {
+    it("sets ciphertextOutput correctly", async function() {
       const { enclave, request } = await loadFixture(setup);
       const e3Id = 0;
 
@@ -1109,7 +1110,7 @@ describe("Enclave", function () {
       const e3 = await enclave.getE3(e3Id);
       expect(e3.ciphertextOutput).to.equal(dataHash);
     });
-    it("returns true if output is published successfully", async function () {
+    it("returns true if output is published successfully", async function() {
       const { enclave, request } = await loadFixture(setup);
       const e3Id = 0;
 
@@ -1129,7 +1130,7 @@ describe("Enclave", function () {
         await enclave.publishCiphertextOutput.staticCall(e3Id, data, proof),
       ).to.equal(true);
     });
-    it("emits CiphertextOutputPublished event", async function () {
+    it("emits CiphertextOutputPublished event", async function() {
       const { enclave, request } = await loadFixture(setup);
       const e3Id = 0;
 
@@ -1151,8 +1152,8 @@ describe("Enclave", function () {
     });
   });
 
-  describe("publishPlaintextOutput()", function () {
-    it("reverts if E3 does not exist", async function () {
+  describe("publishPlaintextOutput()", function() {
+    it("reverts if E3 does not exist", async function() {
       const { enclave } = await loadFixture(setup);
       const e3Id = 0;
 
@@ -1160,7 +1161,7 @@ describe("Enclave", function () {
         .to.be.revertedWithCustomError(enclave, "E3DoesNotExist")
         .withArgs(e3Id);
     });
-    it("reverts if E3 has not been activated", async function () {
+    it("reverts if E3 has not been activated", async function() {
       const { enclave, request } = await loadFixture(setup);
       const e3Id = 0;
 
@@ -1178,7 +1179,7 @@ describe("Enclave", function () {
         .to.be.revertedWithCustomError(enclave, "E3NotActivated")
         .withArgs(e3Id);
     });
-    it("reverts if ciphertextOutput has not been published", async function () {
+    it("reverts if ciphertextOutput has not been published", async function() {
       const { enclave, request } = await loadFixture(setup);
       const e3Id = 0;
 
@@ -1197,7 +1198,7 @@ describe("Enclave", function () {
         .to.be.revertedWithCustomError(enclave, "CiphertextOutputNotPublished")
         .withArgs(e3Id);
     });
-    it("reverts if plaintextOutput has already been published", async function () {
+    it("reverts if plaintextOutput has already been published", async function() {
       const { enclave, request } = await loadFixture(setup);
       const e3Id = 0;
 
@@ -1222,7 +1223,7 @@ describe("Enclave", function () {
         )
         .withArgs(e3Id);
     });
-    it("reverts if output is not valid", async function () {
+    it("reverts if output is not valid", async function() {
       const { enclave, request } = await loadFixture(setup);
       const e3Id = 0;
 
@@ -1243,7 +1244,7 @@ describe("Enclave", function () {
         .to.be.revertedWithCustomError(enclave, "InvalidOutput")
         .withArgs(data);
     });
-    it("sets plaintextOutput correctly", async function () {
+    it("sets plaintextOutput correctly", async function() {
       const { enclave, request } = await loadFixture(setup);
       const e3Id = 0;
 
@@ -1265,7 +1266,7 @@ describe("Enclave", function () {
       const e3 = await enclave.getE3(e3Id);
       expect(e3.plaintextOutput).to.equal(dataHash);
     });
-    it("returns true if output is published successfully", async function () {
+    it("returns true if output is published successfully", async function() {
       const { enclave, request } = await loadFixture(setup);
       const e3Id = 0;
 
@@ -1286,7 +1287,7 @@ describe("Enclave", function () {
         await enclave.publishPlaintextOutput.staticCall(e3Id, data, proof),
       ).to.equal(true);
     });
-    it("emits PlaintextOutputPublished event", async function () {
+    it("emits PlaintextOutputPublished event", async function() {
       const { enclave, request } = await loadFixture(setup);
       const e3Id = 0;
 

--- a/packages/evm/test/fixtures/MockE3Program.fixture.ts
+++ b/packages/evm/test/fixtures/MockE3Program.fixture.ts
@@ -2,10 +2,10 @@ import { ethers } from "hardhat";
 
 import { MockE3Program__factory } from "../../types/factories/contracts/test/MockE3Program__factory";
 
-export async function deployE3ProgramFixture() {
+export async function deployE3ProgramFixture(inputValidatorAddress: string) {
   const deployment = await (
     await ethers.getContractFactory("MockE3Program")
-  ).deploy();
+  ).deploy(inputValidatorAddress);
 
   return MockE3Program__factory.connect(await deployment.getAddress());
 }

--- a/tests/basic_integration/test.sh
+++ b/tests/basic_integration/test.sh
@@ -90,6 +90,8 @@ until curl -f -s "http://localhost:8545" > /dev/null; do
   sleep 1
 done
 
+# Launch 4 ciphernodes
+
 heading "Launch ciphernode $CIPHERNODE_ADDRESS_1"
 yarn ciphernode:launch --address $CIPHERNODE_ADDRESS_1 --rpc "$RPC_URL" --enclave-contract $ENCLAVE_CONTRACT --registry-contract $REGISTRY_CONTRACT &
 
@@ -102,6 +104,7 @@ yarn ciphernode:launch --address $CIPHERNODE_ADDRESS_3 --rpc "$RPC_URL" --enclav
 heading "Launch ciphernode $CIPHERNODE_ADDRESS_4"
 yarn ciphernode:launch --address $CIPHERNODE_ADDRESS_4 --rpc "$RPC_URL" --enclave-contract $ENCLAVE_CONTRACT --registry-contract $REGISTRY_CONTRACT &
 
+# NOTE: This node is configured to be an aggregator
 yarn ciphernode:aggregator --rpc "$RPC_URL" --enclave-contract $ENCLAVE_CONTRACT --registry-contract $REGISTRY_CONTRACT --pubkey-write-path "$SCRIPT_DIR/output/pubkey.bin" --plaintext-write-path "$SCRIPT_DIR/output/plaintext.txt" &
 
 sleep 1
@@ -122,7 +125,7 @@ yarn ciphernode:add --ciphernode-address $CIPHERNODE_ADDRESS_4 --network localho
 
 heading "Request Committee"
 
-ENCODED_PARAMS=0x$($SCRIPT_DIR/lib/pack_e3_params.sh --moduli 0x3FFFFFFF000001 --degree 2048 --plaintext-modulus 1032193 --input-validator "$INPUT_VALIDATOR_CONTRACT")
+ENCODED_PARAMS=0x$($SCRIPT_DIR/lib/pack_e3_params.sh --moduli 0x3FFFFFFF000001 --degree 2048 --plaintext-modulus 1032193)
 
 yarn committee:new --network localhost --duration 4 --e3-params "$ENCODED_PARAMS"
 


### PR DESCRIPTION
After the conversation with @auryn-macmillan this removes the encoding of the inputValidator from the e3Params and relies on the Mock contract to pass in the inputValidator

e3ProgramParams now only need to be the bytes representation of the BfvParamerters

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Simplified event processing logic for `E3Requested` and `CiphertextOutputPublished` events.
  - Updated `MockE3Program` contract to allow dynamic input validator management.

- **Bug Fixes**
  - Enhanced clarity and correctness in test cases for the `Enclave` contract.

- **Chores**
  - Streamlined the script for launching and managing cipher nodes in the EVM environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->