### PR TITLE
Actor Destruction

### DIFF
--- a/packages/ciphernode/aggregator/src/plaintext_aggregator.rs
+++ b/packages/ciphernode/aggregator/src/plaintext_aggregator.rs
@@ -1,7 +1,7 @@
 use actix::prelude::*;
 use anyhow::Result;
 use enclave_core::{
-    DecryptionshareCreated, E3id, EnclaveEvent, EventBus, OrderedSet, PlaintextAggregated, Seed,
+    DecryptionshareCreated, Die, E3id, EnclaveEvent, EventBus, OrderedSet, PlaintextAggregated, E3RequestComplete, Seed
 };
 use fhe::{Fhe, GetAggregatePlaintext};
 use sortition::{GetHasNode, Sortition};
@@ -191,6 +191,14 @@ impl Handler<ComputeAggregate> for PlaintextAggregator {
 
         self.bus.do_send(event);
 
+
         Ok(())
+    }
+}
+
+impl Handler<Die> for PlaintextAggregator {
+    type Result = ();
+    fn handle(&mut self, _: Die, ctx: &mut Self::Context) -> Self::Result {
+       ctx.stop()
     }
 }

--- a/packages/ciphernode/aggregator/src/plaintext_aggregator.rs
+++ b/packages/ciphernode/aggregator/src/plaintext_aggregator.rs
@@ -1,7 +1,8 @@
 use actix::prelude::*;
 use anyhow::Result;
 use enclave_core::{
-    DecryptionshareCreated, Die, E3id, EnclaveEvent, EventBus, OrderedSet, PlaintextAggregated, E3RequestComplete, Seed
+    DecryptionshareCreated, Die, E3RequestComplete, E3id, EnclaveEvent, EventBus, OrderedSet,
+    PlaintextAggregated, Seed,
 };
 use fhe::{Fhe, GetAggregatePlaintext};
 use sortition::{GetHasNode, Sortition};
@@ -107,8 +108,10 @@ impl Actor for PlaintextAggregator {
 impl Handler<EnclaveEvent> for PlaintextAggregator {
     type Result = ();
     fn handle(&mut self, msg: EnclaveEvent, ctx: &mut Self::Context) -> Self::Result {
-        if let EnclaveEvent::DecryptionshareCreated { data, .. } = msg {
-            ctx.notify(data)
+        match msg {
+            EnclaveEvent::DecryptionshareCreated { data, .. } => ctx.notify(data),
+            EnclaveEvent::E3RequestComplete { .. } => ctx.notify(Die),
+            _ => (),
         }
     }
 }
@@ -191,7 +194,6 @@ impl Handler<ComputeAggregate> for PlaintextAggregator {
 
         self.bus.do_send(event);
 
-
         Ok(())
     }
 }
@@ -199,6 +201,6 @@ impl Handler<ComputeAggregate> for PlaintextAggregator {
 impl Handler<Die> for PlaintextAggregator {
     type Result = ();
     fn handle(&mut self, _: Die, ctx: &mut Self::Context) -> Self::Result {
-       ctx.stop()
+        ctx.stop()
     }
 }

--- a/packages/ciphernode/aggregator/src/publickey_aggregator.rs
+++ b/packages/ciphernode/aggregator/src/publickey_aggregator.rs
@@ -1,7 +1,7 @@
 use actix::prelude::*;
 use anyhow::Result;
 use enclave_core::{
-    E3id, EnclaveEvent, EventBus, KeyshareCreated, OrderedSet, PublicKeyAggregated, Seed,
+    Die, E3id, EnclaveEvent, EventBus, KeyshareCreated, OrderedSet, PublicKeyAggregated, Seed
 };
 use fhe::{Fhe, GetAggregatePublicKey};
 use sortition::{GetHasNode, GetNodes, Sortition};
@@ -217,5 +217,12 @@ impl Handler<NotifyNetwork> for PublicKeyAggregator {
                     Ok(())
                 }),
         )
+    }
+}
+
+impl Handler<Die> for PublicKeyAggregator {
+    type Result = ();
+    fn handle(&mut self, _: Die, ctx: &mut Self::Context) -> Self::Result {
+       ctx.stop()
     }
 }

--- a/packages/ciphernode/aggregator/src/publickey_aggregator.rs
+++ b/packages/ciphernode/aggregator/src/publickey_aggregator.rs
@@ -1,7 +1,7 @@
 use actix::prelude::*;
 use anyhow::Result;
 use enclave_core::{
-    Die, E3id, EnclaveEvent, EventBus, KeyshareCreated, OrderedSet, PublicKeyAggregated, Seed
+    Die, E3id, EnclaveEvent, EventBus, KeyshareCreated, OrderedSet, PublicKeyAggregated, Seed,
 };
 use fhe::{Fhe, GetAggregatePublicKey};
 use sortition::{GetHasNode, GetNodes, Sortition};
@@ -116,8 +116,10 @@ impl Actor for PublicKeyAggregator {
 impl Handler<EnclaveEvent> for PublicKeyAggregator {
     type Result = ();
     fn handle(&mut self, msg: EnclaveEvent, ctx: &mut Self::Context) -> Self::Result {
-        if let EnclaveEvent::KeyshareCreated { data, .. } = msg {
-            ctx.notify(data)
+        match msg {
+            EnclaveEvent::KeyshareCreated { data, .. } => ctx.notify(data),
+            EnclaveEvent::E3RequestComplete { .. } => ctx.notify(Die),
+            _ => (),
         }
     }
 }
@@ -223,6 +225,6 @@ impl Handler<NotifyNetwork> for PublicKeyAggregator {
 impl Handler<Die> for PublicKeyAggregator {
     type Result = ();
     fn handle(&mut self, _: Die, ctx: &mut Self::Context) -> Self::Result {
-       ctx.stop()
+        ctx.stop()
     }
 }

--- a/packages/ciphernode/core/src/events.rs
+++ b/packages/ciphernode/core/src/events.rs
@@ -364,7 +364,6 @@ pub struct PlaintextAggregated {
     pub src_chain_id: u64,
 }
 
-
 /// E3RequestComplete event is a local only event
 #[derive(Message, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[rtype(result = "()")]

--- a/packages/ciphernode/keyshare/src/keyshare.rs
+++ b/packages/ciphernode/keyshare/src/keyshare.rs
@@ -2,7 +2,8 @@ use actix::prelude::*;
 use anyhow::{anyhow, Context, Result};
 use data::{Data, Get, Insert};
 use enclave_core::{
-    CiphernodeSelected, CiphertextOutputPublished, DecryptionshareCreated, Die, EnclaveErrorType, EnclaveEvent, EventBus, FromError, KeyshareCreated
+    CiphernodeSelected, CiphertextOutputPublished, DecryptionshareCreated, Die, EnclaveErrorType,
+    EnclaveEvent, EventBus, FromError, KeyshareCreated,
 };
 use fhe::{DecryptCiphertext, Fhe};
 use std::sync::Arc;
@@ -34,8 +35,9 @@ impl Handler<EnclaveEvent> for Keyshare {
 
     fn handle(&mut self, event: EnclaveEvent, ctx: &mut actix::Context<Self>) -> Self::Result {
         match event {
-            EnclaveEvent::CiphernodeSelected { data, .. } => ctx.address().do_send(data),
-            EnclaveEvent::CiphertextOutputPublished { data, .. } => ctx.address().do_send(data),
+            EnclaveEvent::CiphernodeSelected { data, .. } => ctx.notify(data),
+            EnclaveEvent::CiphertextOutputPublished { data, .. } => ctx.notify(data),
+            EnclaveEvent::E3RequestComplete { .. } => ctx.notify(Die),
             _ => (),
         }
     }
@@ -101,7 +103,7 @@ impl Handler<CiphertextOutputPublished> for Keyshare {
 impl Handler<Die> for Keyshare {
     type Result = ();
     fn handle(&mut self, _: Die, ctx: &mut Self::Context) -> Self::Result {
-       ctx.stop()
+        ctx.stop()
     }
 }
 

--- a/packages/ciphernode/keyshare/src/keyshare.rs
+++ b/packages/ciphernode/keyshare/src/keyshare.rs
@@ -2,8 +2,7 @@ use actix::prelude::*;
 use anyhow::{anyhow, Context, Result};
 use data::{Data, Get, Insert};
 use enclave_core::{
-    CiphernodeSelected, CiphertextOutputPublished, DecryptionshareCreated, EnclaveErrorType,
-    EnclaveEvent, EventBus, FromError, KeyshareCreated,
+    CiphernodeSelected, CiphertextOutputPublished, DecryptionshareCreated, Die, EnclaveErrorType, EnclaveEvent, EventBus, FromError, KeyshareCreated
 };
 use fhe::{DecryptCiphertext, Fhe};
 use std::sync::Arc;
@@ -96,6 +95,13 @@ impl Handler<CiphertextOutputPublished> for Keyshare {
                 .await
                 .unwrap()
         })
+    }
+}
+
+impl Handler<Die> for Keyshare {
+    type Result = ();
+    fn handle(&mut self, _: Die, ctx: &mut Self::Context) -> Self::Result {
+       ctx.stop()
     }
 }
 

--- a/packages/ciphernode/router/src/e3_request_router.rs
+++ b/packages/ciphernode/router/src/e3_request_router.rs
@@ -123,7 +123,7 @@ impl Handler<EnclaveEvent> for E3RequestRouter {
 
         context.forward_message(&msg, &mut self.buffer);
 
-        match msg.clone() {
+        match &msg {
             EnclaveEvent::PlaintextAggregated { .. } => {
                 // Here we are detemining that by receiving the PlaintextAggregated event our request is
                 // complete and we can notify everyone. This might change as we consider other factors

--- a/packages/ciphernode/router/src/e3_request_router.rs
+++ b/packages/ciphernode/router/src/e3_request_router.rs
@@ -143,6 +143,8 @@ impl Handler<EnclaveEvent> for E3RequestRouter {
 
             // Send to bus so all other actors can react to a request being complete.
             self.bus.do_send(event);
+
+            // clean up context
             context.cleanup();
             self.contexts.remove(&e3_id);
         }

--- a/packages/ciphernode/router/src/e3_request_router.rs
+++ b/packages/ciphernode/router/src/e3_request_router.rs
@@ -128,14 +128,12 @@ impl Handler<EnclaveEvent> for E3RequestRouter {
                 // Here we are detemining that by receiving the PlaintextAggregated event our request is
                 // complete and we can notify everyone. This might change as we consider other factors
                 // when determining if the request is complete
-                let bus = self.bus.clone();
-
                 let event = EnclaveEvent::from(E3RequestComplete {
                     e3_id: e3_id.clone(),
                 });
 
                 // Send to bus so all other actors can react to a request being complete.
-                bus.do_send(event);
+                self.bus.do_send(event);
             }
             EnclaveEvent::E3RequestComplete { .. } => {
                 // Note this will be sent above to the children who can kill themselves based on

--- a/packages/ciphernode/router/src/hooks.rs
+++ b/packages/ciphernode/router/src/hooks.rs
@@ -2,7 +2,7 @@ use crate::EventHook;
 use actix::{Actor, Addr};
 use aggregator::{PlaintextAggregator, PublicKeyAggregator};
 use data::Data;
-use enclave_core::{E3Requested, EnclaveEvent, EventBus};
+use enclave_core::{Die, E3Requested, EnclaveEvent, EventBus};
 use fhe::{Fhe, SharedRng};
 use keyshare::Keyshare;
 use sortition::Sortition;
@@ -30,18 +30,23 @@ pub struct LazyKeyshare;
 impl LazyKeyshare {
     pub fn create(bus: Addr<EventBus>, data: Addr<Data>, address: &str) -> EventHook {
         let address = address.to_string();
-        Box::new(move |ctx, evt| {
-            // Save Ciphernode on CiphernodeSelected
-            let EnclaveEvent::CiphernodeSelected { .. } = evt else {
-                return;
-            };
+        Box::new(move |ctx, evt| match evt {
+            EnclaveEvent::CiphernodeSelected { .. } => {
+                let Some(ref fhe) = ctx.fhe else {
+                    return;
+                };
 
-            let Some(ref fhe) = ctx.fhe else {
-                return;
-            };
+                ctx.keyshare =
+                    Some(Keyshare::new(bus.clone(), data.clone(), fhe.clone(), &address).start())
+            }
+            EnclaveEvent::E3RequestComplete { .. } => {
+                let Some(actor) = ctx.keyshare.take() else {
+                    return;
+                };
 
-            ctx.keyshare =
-                Some(Keyshare::new(bus.clone(), data.clone(), fhe.clone(), &address).start())
+                actor.do_send(Die);
+            }
+            _ => (),
         })
     }
 }
@@ -49,31 +54,38 @@ impl LazyKeyshare {
 pub struct LazyPlaintextAggregator;
 impl LazyPlaintextAggregator {
     pub fn create(bus: Addr<EventBus>, sortition: Addr<Sortition>) -> EventHook {
-        Box::new(move |ctx, evt| {
-            // Save plaintext aggregator
-            let EnclaveEvent::CiphertextOutputPublished { data, .. } = evt else {
-                return;
-            };
-            let Some(ref fhe) = ctx.fhe else {
-                return;
-            };
-            let Some(ref meta) = ctx.meta else {
-                return;
-            };
+        Box::new(move |ctx, evt| match evt {
+            EnclaveEvent::CiphertextOutputPublished { data, .. } => {
+                let Some(ref fhe) = ctx.fhe else {
+                    return;
+                };
+                let Some(ref meta) = ctx.meta else {
+                    return;
+                };
 
-            ctx.plaintext = Some(
-                PlaintextAggregator::new(
-                    fhe.clone(),
-                    bus.clone(),
-                    sortition.clone(),
-                    data.e3_id,
-                    meta.threshold_m,
-                    meta.seed,
-                    data.ciphertext_output,
-                    meta.src_chain_id,
-                )
-                .start(),
-            );
+                // Save plaintext aggregator
+                ctx.plaintext = Some(
+                    PlaintextAggregator::new(
+                        fhe.clone(),
+                        bus.clone(),
+                        sortition.clone(),
+                        data.e3_id,
+                        meta.threshold_m,
+                        meta.seed,
+                        data.ciphertext_output,
+                        meta.src_chain_id,
+                    )
+                    .start(),
+                );
+            }
+            EnclaveEvent::E3RequestComplete { .. } => {
+                let Some(actor) = ctx.plaintext.take() else {
+                    return;
+                };
+
+                actor.do_send(Die);
+            }
+            _ => (),
         })
     }
 }
@@ -81,33 +93,40 @@ impl LazyPlaintextAggregator {
 pub struct LazyPublicKeyAggregator;
 impl LazyPublicKeyAggregator {
     pub fn create(bus: Addr<EventBus>, sortition: Addr<Sortition>) -> EventHook {
-        Box::new(move |ctx, evt| {
+        Box::new(move |ctx, evt| match evt {
             // Saving the publickey aggregator with deps on E3Requested
-            let EnclaveEvent::E3Requested { data, .. } = evt else {
-                return;
-            };
+            EnclaveEvent::E3Requested { data, .. } => {
+                let Some(ref fhe) = ctx.fhe else {
+                    println!("fhe was not on ctx");
+                    return;
+                };
+                let Some(ref meta) = ctx.meta else {
+                    println!("meta was not on ctx");
+                    return;
+                };
 
-            let Some(ref fhe) = ctx.fhe else {
-                println!("fhe was not on ctx");
-                return;
-            };
-            let Some(ref meta) = ctx.meta else {
-                println!("meta was not on ctx");
-                return;
-            };
+                ctx.publickey = Some(
+                    PublicKeyAggregator::new(
+                        fhe.clone(),
+                        bus.clone(),
+                        sortition.clone(),
+                        data.e3_id,
+                        meta.threshold_m,
+                        meta.seed,
+                        meta.src_chain_id,
+                    )
+                    .start(),
+                );
+            }
+            EnclaveEvent::E3RequestComplete { .. } => {
+                let Some(actor) = ctx.publickey.take() else {
+                    return;
+                };
 
-            ctx.publickey = Some(
-                PublicKeyAggregator::new(
-                    fhe.clone(),
-                    bus.clone(),
-                    sortition.clone(),
-                    data.e3_id,
-                    meta.threshold_m,
-                    meta.seed,
-                    meta.src_chain_id,
-                )
-                .start(),
-            );
+                actor.do_send(Die);
+            }
+
+            _ => (),
         })
     }
 }

--- a/packages/ciphernode/tests/tests/test_aggregation_and_decryption.rs
+++ b/packages/ciphernode/tests/tests/test_aggregation_and_decryption.rs
@@ -1,8 +1,8 @@
 use data::Data;
 use enclave_core::{
     CiphernodeAdded, CiphernodeSelected, CiphertextOutputPublished, DecryptionshareCreated,
-    E3Requested, E3id, EnclaveEvent, EventBus, GetHistory, KeyshareCreated, OrderedSet,
-    PlaintextAggregated, PublicKeyAggregated, ResetHistory, Seed,
+    E3RequestComplete, E3Requested, E3id, EnclaveEvent, EventBus, GetHistory, KeyshareCreated,
+    OrderedSet, PlaintextAggregated, PublicKeyAggregated, ResetHistory, Seed,
 };
 use fhe::{setup_crp_params, ParamsWithCrp, SharedRng};
 use logger::SimpleLogger;
@@ -181,7 +181,7 @@ async fn test_public_key_aggregation_and_decryption() -> Result<()> {
                 e3_id: e3_id.clone(),
                 nodes: OrderedSet::from(eth_addrs.clone()),
                 src_chain_id: 1
-            })
+            }),
         ]
     );
 
@@ -223,7 +223,7 @@ async fn test_public_key_aggregation_and_decryption() -> Result<()> {
     sleep(Duration::from_millis(1)).await; // need to push to next tick
     let history = bus.send(GetHistory).await?;
 
-    assert_eq!(history.len(), 5);
+    assert_eq!(history.len(), 6);
 
     assert_eq!(
         history,
@@ -248,6 +248,9 @@ async fn test_public_key_aggregation_and_decryption() -> Result<()> {
                 e3_id: e3_id.clone(),
                 decrypted_output: expected_raw_plaintext.clone(),
                 src_chain_id: 1
+            }),
+            EnclaveEvent::from(E3RequestComplete {
+                e3_id: e3_id.clone()
             })
         ]
     );


### PR DESCRIPTION
Closes: #135

This ensures that actors for past e3 requests don't hang around after they have finished processing the requests.

`E3RequestRouter` determines when an E3Request is completed and cleans up its references. 

Relevant actors listen for E3RequestComplete event and then commit seppuku 

Considered a few other designs like having actors termination trigger router clean up but they were too complex and this was the simplest and cleanest way to do this which keeps things ready for future management.