### PR TITLE
add tasks for activating E3, removing ciphernodes and generating sibling data

### DIFF
--- a/packages/evm/tasks/ciphernode.ts
+++ b/packages/evm/tasks/ciphernode.ts
@@ -51,7 +51,7 @@ task("ciphernode:siblings", "Get the sibling of a ciphernode in the registry")
     "ciphernodeAddresses",
     "comma separated addresses of ciphernodes in the order they were added to the registry",
   )
-  .setAction(async function (taskArguments: TaskArguments, hre) {
+  .setAction(async function (taskArguments: TaskArguments) {
     const hash = (a: bigint, b: bigint) => poseidon2([a, b]);
     const tree = new LeanIMT(hash);
 

--- a/packages/evm/tasks/ciphernode.ts
+++ b/packages/evm/tasks/ciphernode.ts
@@ -1,5 +1,7 @@
+import { LeanIMT } from "@zk-kit/lean-imt";
 import { task } from "hardhat/config";
 import type { TaskArguments } from "hardhat/types";
+import { poseidon2 } from "poseidon-lite";
 
 task("ciphernode:add", "Register a ciphernode to the registry")
   .addParam("ciphernodeAddress", "address of ciphernode to register")
@@ -17,4 +19,50 @@ task("ciphernode:add", "Register a ciphernode to the registry")
     await tx.wait();
 
     console.log(`Ciphernode ${taskArguments.ciphernodeAddress} registered`);
+  });
+
+task("ciphernode:remove", "Remove a ciphernode from the registry")
+  .addParam("ciphernodeAddress", "address of ciphernode to remove")
+  .addParam("siblings", "comma separated siblings from tree proof")
+  .setAction(async function (taskArguments: TaskArguments, hre) {
+    const registry = await hre.deployments.get("CiphernodeRegistryOwnable");
+
+    const registryContract = await hre.ethers.getContractAt(
+      "CiphernodeRegistryOwnable",
+      registry.address,
+    );
+
+    const siblings = taskArguments.siblings
+      .split(",")
+      .map((s: string) => BigInt(s));
+
+    const tx = await registryContract.removeCiphernode(
+      taskArguments.ciphernodeAddress,
+      siblings,
+    );
+    await tx.wait();
+
+    console.log(`Ciphernode ${taskArguments.ciphernodeAddress} removed`);
+  });
+
+task("ciphernode:siblings", "Get the sibling of a ciphernode in the registry")
+  .addParam("ciphernodeAddress", "address of ciphernode to get siblings for")
+  .addParam(
+    "ciphernodeAddresses",
+    "comma separated addresses of ciphernodes in the order they were added to the registry",
+  )
+  .setAction(async function (taskArguments: TaskArguments, hre) {
+    const hash = (a: bigint, b: bigint) => poseidon2([a, b]);
+    const tree = new LeanIMT(hash);
+
+    const addresses = taskArguments.ciphernodeAddresses.split(",");
+
+    for (const address of addresses) {
+      tree.insert(BigInt(address));
+    }
+
+    const index = tree.indexOf(BigInt(taskArguments.ciphernodeAddress));
+    const { siblings } = tree.generateProof(index);
+
+    console.log(`Siblings for ${taskArguments.ciphernodeAddress}: ${siblings}`);
   });

--- a/packages/evm/tasks/enclave.ts
+++ b/packages/evm/tasks/enclave.ts
@@ -138,6 +138,24 @@ task(
     console.log(`Committee requested`);
   });
 
+task("enclave:enableE3", "Enable an E3 program")
+  .addParam("e3Address", "address of the E3 program")
+  .setAction(async function (taskArguments: TaskArguments, hre) {
+    const enclave = await hre.deployments.get("Enclave");
+
+    const enclaveContract = await hre.ethers.getContractAt(
+      "Enclave",
+      enclave.address,
+    );
+
+    const tx = await enclaveContract.enableE3Program(taskArguments.e3Address);
+
+    console.log("Enabling E3 program... ", tx.hash);
+    await tx.wait();
+
+    console.log(`E3 program enabled`);
+  });
+
 task("committee:publish", "Publish the publickey of the committee")
   .addOptionalParam(
     "filter",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced tasks for managing ciphernodes: 
		- `ciphernode:remove` for removing a ciphernode from the registry.
		- `ciphernode:siblings` for retrieving siblings of a specified ciphernode.
	- Added `enclave:enableE3` task to enable an E3 program by providing its address.

- **Bug Fixes**
	- No bug fixes included in this release. 

- **Documentation**
	- Updated task definitions for clarity and usage instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->