### PR TITLE
add: block number to e3 struct

### DIFF
--- a/packages/evm/contracts/Enclave.sol
+++ b/packages/evm/contracts/Enclave.sol
@@ -160,6 +160,7 @@ contract Enclave is IEnclave, OwnableUpgradeable {
         e3 = E3({
             seed: seed,
             threshold: threshold,
+            requestBlock: block.number,
             startWindow: startWindow,
             duration: duration,
             expiration: 0,

--- a/packages/evm/contracts/interfaces/IE3.sol
+++ b/packages/evm/contracts/interfaces/IE3.sol
@@ -8,6 +8,7 @@ import { IDecryptionVerifier } from "./IDecryptionVerifier.sol";
 /// @title E3 struct
 /// @notice This struct represents an E3 computation.
 /// @param threshold M/N threshold for the committee.
+/// @param requestBlock Block number when the E3 was requested.
 /// @param startWindow Start window for the computation: index zero is minimum, index 1 is the maxium.
 /// @param duration Duration of the E3.
 /// @param expiration Timestamp when committee duties expire.
@@ -21,6 +22,7 @@ import { IDecryptionVerifier } from "./IDecryptionVerifier.sol";
 struct E3 {
     uint256 seed;
     uint32[2] threshold;
+    uint256 requestBlock;
     uint256[2] startWindow;
     uint256 duration;
     uint256 expiration;

--- a/packages/evm/contracts/registry/NaiveRegistryFilter.sol
+++ b/packages/evm/contracts/registry/NaiveRegistryFilter.sol
@@ -34,6 +34,7 @@ contract NaiveRegistryFilter is IRegistryFilter, OwnableUpgradeable {
     error CommitteeAlreadyPublished();
     error CommitteeDoesNotExist();
     error CommitteeNotPublished();
+    error CiphernodeNotEnabled(address ciphernode);
     error OnlyRegistry();
 
     ////////////////////////////////////////////////////////////
@@ -44,6 +45,15 @@ contract NaiveRegistryFilter is IRegistryFilter, OwnableUpgradeable {
 
     modifier onlyRegistry() {
         require(msg.sender == registry, OnlyRegistry());
+        _;
+    }
+
+    modifier onlyOwnerOrCiphernode() {
+        require(
+            msg.sender == owner() ||
+                ICiphernodeRegistry(registry).isCiphernodeEligible(msg.sender),
+            CiphernodeNotEnabled(msg.sender)
+        );
         _;
     }
 

--- a/packages/evm/test/Enclave.spec.ts
+++ b/packages/evm/test/Enclave.spec.ts
@@ -587,10 +587,12 @@ describe("Enclave", function () {
         { value: 10 },
       );
       const e3 = await enclave.getE3(0);
+      const block = await ethers.provider.getBlock("latest").catch((e) => e);
 
       expect(e3.threshold).to.deep.equal(request.threshold);
       expect(e3.expiration).to.equal(0n);
       expect(e3.e3Program).to.equal(request.e3Program);
+      expect(e3.requestBlock).to.equal(block.number);
       expect(e3.inputValidator).to.equal(
         await mocks.inputValidator.getAddress(),
       );


### PR DESCRIPTION
This PR adds adds `requestBlock` to the E3 struct, allowing for simpler queries to fetch inputs for a given E3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced tracking of requests by adding a `requestBlock` field to the `E3` structure, capturing the block number at the time of the request.
	- Introduced a new modifier, `onlyOwnerOrCiphernode`, to improve access control for functions in the `NaiveRegistryFilter` contract.

- **Bug Fixes**
	- Added a new error type, `CiphernodeNotEnabled`, to handle eligibility issues for ciphernodes.

- **Tests**
	- Updated test cases for the `request()` method to verify the correct assignment of the new `requestBlock` property.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->