### PR TITLE
Keyshare cleans state

### DIFF
--- a/packages/ciphernode/Cargo.lock
+++ b/packages/ciphernode/Cargo.lock
@@ -43,7 +43,6 @@ version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24eda4e2a6e042aa4e55ac438a2ae052d3b5da0ecf83d7411e1a368946925208"
 dependencies = [
- "actix-macros",
  "futures-core",
  "tokio",
 ]
@@ -1876,7 +1875,6 @@ name = "data"
 version = "0.1.0"
 dependencies = [
  "actix",
- "actix-rt",
  "anyhow",
  "async-trait",
  "bincode",
@@ -2149,7 +2147,6 @@ name = "enclave"
 version = "0.1.0"
 dependencies = [
  "actix",
- "actix-rt",
  "alloy",
  "anyhow",
  "cipher 0.1.0",
@@ -2189,7 +2186,6 @@ name = "enclave_node"
 version = "0.1.0"
 dependencies = [
  "actix",
- "actix-rt",
  "aggregator",
  "alloy",
  "alloy-primitives 0.6.4",
@@ -5985,7 +5981,6 @@ name = "tests"
 version = "0.1.0"
 dependencies = [
  "actix",
- "actix-rt",
  "aggregator",
  "alloy",
  "alloy-primitives 0.6.4",

--- a/packages/ciphernode/Cargo.toml
+++ b/packages/ciphernode/Cargo.toml
@@ -20,7 +20,6 @@ members = [
 
 [workspace.dependencies]
 actix = "0.13.5"
-actix-rt = "2.10.0"
 aes-gcm = "0.10.3"
 alloy = { version = "0.3.3", features = ["full"] }
 alloy-primitives = { version = "0.6", default-features = false, features = [

--- a/packages/ciphernode/data/Cargo.toml
+++ b/packages/ciphernode/data/Cargo.toml
@@ -15,5 +15,3 @@ bincode = { workspace = true }
 tracing = { workspace = true }
 async-trait = { workspace = true }
 
-[dev-dependencies]
-actix-rt = { workspace = true }

--- a/packages/ciphernode/data/src/data_store.rs
+++ b/packages/ciphernode/data/src/data_store.rs
@@ -82,7 +82,7 @@ impl DataStore {
     /// use actix::Actor;
     /// use anyhow::Result;
     ///
-    /// #[actix_rt::main]
+    /// #[actix::main]
     /// async fn main() -> Result<()>{  
     ///   let addr = InMemStore::new(false).start();
     ///   let store = DataStore::from(&addr);

--- a/packages/ciphernode/enclave/Cargo.toml
+++ b/packages/ciphernode/enclave/Cargo.toml
@@ -9,7 +9,6 @@ repository = "https://github.com/gnosisguild/enclave/packages/ciphernode"
 
 [dependencies]
 actix = { workspace = true }
-actix-rt = { workspace = true }
 alloy = { workspace = true }
 anyhow = { workspace = true }
 cipher = { path = "../cipher" }

--- a/packages/ciphernode/enclave/src/main.rs
+++ b/packages/ciphernode/enclave/src/main.rs
@@ -53,7 +53,7 @@ impl Cli {
     }
 }
 
-#[actix_rt::main]
+#[actix::main]
 pub async fn main() {
     tracing_subscriber::fmt::init();
 

--- a/packages/ciphernode/enclave_node/Cargo.toml
+++ b/packages/ciphernode/enclave_node/Cargo.toml
@@ -9,7 +9,6 @@ repository = "https://github.com/gnosisguild/enclave/packages/ciphernode"
 
 [dependencies]
 actix = { workspace = true }
-actix-rt = { workspace = true }
 aggregator = { path = "../aggregator" }
 alloy = { workspace = true }
 alloy-primitives = { workspace = true }

--- a/packages/ciphernode/keyshare/src/keyshare.rs
+++ b/packages/ciphernode/keyshare/src/keyshare.rs
@@ -206,7 +206,7 @@ impl Handler<E3RequestComplete> for Keyshare {
 impl Handler<Die> for Keyshare {
     type Result = ();
     fn handle(&mut self, _: Die, ctx: &mut Self::Context) -> Self::Result {
-        warn!("Keyshare is shutting down");
+        warn!("Keyshare is shutting down now");
         ctx.stop()
     }
 }

--- a/packages/ciphernode/keyshare/src/keyshare.rs
+++ b/packages/ciphernode/keyshare/src/keyshare.rs
@@ -5,7 +5,7 @@ use cipher::Cipher;
 use data::{Checkpoint, FromSnapshotWithParams, Repository, Snapshot};
 use enclave_core::{
     BusError, CiphernodeSelected, CiphertextOutputPublished, DecryptionshareCreated, Die,
-    EnclaveErrorType, EnclaveEvent, EventBus, FromError, KeyshareCreated,
+    E3RequestComplete, EnclaveErrorType, EnclaveEvent, EventBus, FromError, KeyshareCreated,
 };
 use fhe::{DecryptCiphertext, Fhe};
 use serde::{Deserialize, Serialize};
@@ -68,6 +68,10 @@ impl Keyshare {
 
         Ok(decrypted)
     }
+
+    fn clear_secret(&mut self) {
+        self.secret = None;
+    }
 }
 
 impl Snapshot for Keyshare {
@@ -108,7 +112,7 @@ impl Handler<EnclaveEvent> for Keyshare {
         match event {
             EnclaveEvent::CiphernodeSelected { data, .. } => ctx.notify(data),
             EnclaveEvent::CiphertextOutputPublished { data, .. } => ctx.notify(data),
-            EnclaveEvent::E3RequestComplete { .. } => ctx.notify(Die),
+            EnclaveEvent::E3RequestComplete { data, .. } => ctx.notify(data),
             EnclaveEvent::Shutdown { .. } => ctx.notify(Die),
             _ => (),
         }
@@ -187,6 +191,15 @@ impl Handler<CiphertextOutputPublished> for Keyshare {
             decryption_share,
             node: self.address.clone(),
         }));
+    }
+}
+
+impl Handler<E3RequestComplete> for Keyshare {
+    type Result = ();
+    fn handle(&mut self, _: E3RequestComplete, ctx: &mut Self::Context) -> Self::Result {
+        self.clear_secret();
+        self.checkpoint();
+        ctx.notify(Die);
     }
 }
 

--- a/packages/ciphernode/tests/Cargo.toml
+++ b/packages/ciphernode/tests/Cargo.toml
@@ -22,7 +22,6 @@ fhe-traits = { workspace = true }
 fhe-util = { workspace = true }
 async-std = { workspace = true }
 tokio = { workspace = true }
-actix-rt = { workspace = true }
 alloy-primitives = { workspace = true }
 alloy = { workspace = true }
 clap = { workspace = true }


### PR DESCRIPTION
Closes: #152 
Closes: #161

Currently when an E3 round has finished and we clean up keyshares in memory we should also nullify the persisted keyshare

This PR:

- [x] Delete keyshare state and commit on `E3RequestComplete` (#152)
- [x] Remove actix_rt as actix wraps the functionality (#161)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a new method `clear_secret` in the Keyshare implementation for enhanced event handling.
	- Added detailed handling for the `E3RequestComplete` event.

- **Bug Fixes**
	- Simplified dependency management by removing the `actix-rt` dependency across multiple packages.

- **Refactor**
	- Updated the main asynchronous function attributes to use the new Actix runtime.

- **Chores**
	- Cleaned up the `Cargo.toml` files by removing unnecessary dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->