### PR TITLE
Event sync pt I

### DIFF
--- a/packages/ciphernode/Cargo.lock
+++ b/packages/ciphernode/Cargo.lock
@@ -5787,6 +5787,7 @@ dependencies = [
  "num",
  "rand",
  "serde",
+ "tokio",
  "tracing",
 ]
 

--- a/packages/ciphernode/data/src/data_store.rs
+++ b/packages/ciphernode/data/src/data_store.rs
@@ -1,8 +1,9 @@
-use std::borrow::Cow;
+use std::{borrow::Cow, path::PathBuf};
 
 use crate::{InMemStore, IntoKey, SledStore};
-use actix::{Addr, Message, Recipient};
+use actix::{Actor, Addr, Message, Recipient};
 use anyhow::Result;
+use enclave_core::EventBus;
 use serde::{Deserialize, Serialize};
 use tracing::error;
 
@@ -113,6 +114,14 @@ impl DataStore {
             insert: self.insert.clone(),
             scope: key.into_key(),
         }
+    }
+
+    pub fn in_mem() -> DataStore {
+        (&InMemStore::new(true).start()).into()
+    }
+
+    pub fn persistent(bus: &Addr<EventBus>, path: &PathBuf) -> Result<DataStore> {
+        Ok((&SledStore::new(bus, path)?.start()).into())
     }
 }
 

--- a/packages/ciphernode/enclave_node/src/aggregator.rs
+++ b/packages/ciphernode/enclave_node/src/aggregator.rs
@@ -32,7 +32,7 @@ pub async fn setup_aggregator(
     ));
     let store = setup_datastore(&config, &bus)?;
     let repositories = store.repositories();
-    let sortition = Sortition::attach(&bus, repositories.sortition());
+    let sortition = Sortition::load(&bus, &repositories.sortition()).await?;
     let cipher = Arc::new(Cipher::from_config(&config).await?);
     let signer = get_signer_from_repository(repositories.eth_private_key(), &cipher).await?;
     for chain in config

--- a/packages/ciphernode/enclave_node/src/ciphernode.rs
+++ b/packages/ciphernode/enclave_node/src/ciphernode.rs
@@ -32,7 +32,7 @@ pub async fn setup_ciphernode(
 
     let repositories = store.repositories();
 
-    let sortition = Sortition::attach(&bus, repositories.sortition());
+    let sortition = Sortition::load(&bus, &repositories.sortition()).await?;
     CiphernodeSelector::attach(&bus, &sortition, &address.to_string());
 
     for chain in config

--- a/packages/ciphernode/enclave_node/src/datastore.rs
+++ b/packages/ciphernode/enclave_node/src/datastore.rs
@@ -6,12 +6,11 @@ use enclave_core::EventBus;
 use router::{Repositories, RepositoriesFactory};
 
 pub fn setup_datastore(config: &AppConfig, bus: &Addr<EventBus>) -> Result<DataStore> {
-    let store: DataStore = if !config.use_in_mem_store() {
-        (&SledStore::new(&bus, &config.db_file())?.start()).into()
-    } else {
-        (&InMemStore::new(true).start()).into()
-    };
-    Ok(store)
+    if config.use_in_mem_store() {
+        return Ok(DataStore::in_mem());
+    }
+
+    Ok(DataStore::persistent(&bus, &config.db_file())?)
 }
 
 pub fn get_repositories(config: &AppConfig, bus: &Addr<EventBus>) -> Result<Repositories> {

--- a/packages/ciphernode/evm/src/helpers.rs
+++ b/packages/ciphernode/evm/src/helpers.rs
@@ -30,7 +30,7 @@ pub async fn stream_from_evm<P: Provider>(
 
     info!("Fetching historical events");
 
-    // historical events
+    // Historical events
     match provider
         .get_provider()
         .get_logs(&filter)

--- a/packages/ciphernode/evm/src/helpers.rs
+++ b/packages/ciphernode/evm/src/helpers.rs
@@ -27,7 +27,6 @@ pub async fn stream_from_evm<P: Provider>(
     extractor: fn(&LogData, Option<&B256>, u64) -> Option<EnclaveEvent>,
     mut shutdown: oneshot::Receiver<()>,
 ) {
-
     info!("Fetching historical events");
 
     // Historical events

--- a/packages/ciphernode/router/src/repositories.rs
+++ b/packages/ciphernode/router/src/repositories.rs
@@ -4,7 +4,7 @@ use data::{DataStore, Repository};
 use enclave_core::E3id;
 use fhe::FheSnapshot;
 use keyshare::KeyshareState;
-use sortition::SortitionModule;
+use sortition::{SortitionModule, SortitionSnapshot};
 
 pub struct Repositories {
     store: DataStore,
@@ -65,7 +65,7 @@ impl Repositories {
         Repository::new(self.store.scope(format!("//router")))
     }
 
-    pub fn sortition(&self) -> Repository<SortitionModule> {
+    pub fn sortition(&self) -> Repository<SortitionSnapshot> {
         Repository::new(self.store.scope(format!("//sortition")))
     }
 

--- a/packages/ciphernode/sortition/Cargo.toml
+++ b/packages/ciphernode/sortition/Cargo.toml
@@ -19,3 +19,4 @@ num = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }
 tracing = { workspace = true }
+tokio = { workspace = true }

--- a/packages/ciphernode/sortition/src/sortition.rs
+++ b/packages/ciphernode/sortition/src/sortition.rs
@@ -7,8 +7,8 @@ use data::{Checkpoint, FromSnapshotWithParams, Repository, Snapshot};
 use enclave_core::{
     BusError, Die, EnclaveErrorType, EnclaveEvent, EventBus, EventId, Seed, Subscribe, Unsubscribe,
 };
-use tracing::trace;
 use std::collections::HashSet;
+use tracing::trace;
 
 #[derive(Message, Clone, Debug, PartialEq, Eq)]
 #[rtype(result = "bool")]
@@ -178,7 +178,10 @@ impl Handler<EnclaveEvent> for Sortition {
     type Result = ();
     fn handle(&mut self, msg: EnclaveEvent, _: &mut Self::Context) -> Self::Result {
         if self.processed.contains(&msg.get_id()) {
-            trace!("Skipping processing event {} as has been seen before.", msg.get_id());
+            trace!(
+                "Skipping processing event {} as has been seen before.",
+                msg.get_id()
+            );
             return;
         };
 

--- a/packages/ciphernode/tests/tests/test_aggregation_and_decryption.rs
+++ b/packages/ciphernode/tests/tests/test_aggregation_and_decryption.rs
@@ -52,7 +52,7 @@ async fn setup_local_ciphernode(
     let store = DataStore::from(&data_actor);
     let repositories = store.repositories();
     // create ciphernode actor for managing ciphernode flow
-    let sortition = Sortition::attach(&bus, repositories.sortition());
+    let sortition = Sortition::load(&bus, &repositories.sortition()).await?;
     CiphernodeSelector::attach(&bus, &sortition, addr);
 
     let router = E3RequestRouter::builder(&bus, store)

--- a/tests/basic_integration/test.sh
+++ b/tests/basic_integration/test.sh
@@ -142,6 +142,10 @@ set_password ag "$CIPHERNODE_SECRET"
 
 set_private_key ag "$PRIVATE_KEY"
 
+# Send an evm event before the nodes are launched
+heading "Add ciphernode $CIPHERNODE_ADDRESS_1"
+yarn ciphernode:add --ciphernode-address $CIPHERNODE_ADDRESS_1 --network localhost
+
 # Launch 4 ciphernodes
 launch_ciphernode cn1
 launch_ciphernode cn2
@@ -152,10 +156,6 @@ launch_aggregator ag
 sleep 1
 
 waiton-files "$ROOT_DIR/packages/ciphernode/target/debug/enclave" "$ROOT_DIR/packages/ciphernode/target/debug/fake_encrypt"
-
-heading "Add ciphernode $CIPHERNODE_ADDRESS_1"
-yarn ciphernode:add --ciphernode-address $CIPHERNODE_ADDRESS_1 --network localhost
-
 heading "Add ciphernode $CIPHERNODE_ADDRESS_2"
 yarn ciphernode:add --ciphernode-address $CIPHERNODE_ADDRESS_2 --network localhost
 


### PR DESCRIPTION
This starts setting up evm event syncing but does not include p2p event syncing.

- [x] This consumes historical EVM events from the EVM (this is not quite in a working state)
- [x] Fixes some issues with Sortition Module 
  - [x] Ensure listening for CiphernodeRemoved events
  - [x] Add sortition de-duplicate cache to snapshot to enable event playback. 
- [ ] Refactor to enable evm listener to keep track of the last block processed add to snapshot and use that to request block from evm