### PR TITLE
Consolidate providers

### DIFF
--- a/packages/ciphernode/enclave_node/src/aggregator.rs
+++ b/packages/ciphernode/enclave_node/src/aggregator.rs
@@ -54,7 +54,6 @@ pub async fn setup_aggregator(
             &read_provider,
             &write_provider,
             &chain.contracts.enclave,
-            &signer,
         )
         .await?;
         RegistryFilterSol::attach(&bus, &write_provider, &chain.contracts.filter_registry).await?;

--- a/packages/ciphernode/enclave_node/src/aggregator.rs
+++ b/packages/ciphernode/enclave_node/src/aggregator.rs
@@ -47,8 +47,16 @@ pub async fn setup_aggregator(
     {
         let rpc_url = &chain.rpc_url;
         let read_provider = create_readonly_provider(&ensure_ws_rpc(rpc_url)).await?;
-        let write_provider = create_provider_with_signer(&ensure_http_rpc(rpc_url), &signer).await?;
-        EnclaveSol::attach(&bus, &read_provider, &write_provider, &chain.contracts.enclave, &signer).await?;
+        let write_provider =
+            create_provider_with_signer(&ensure_http_rpc(rpc_url), &signer).await?;
+        EnclaveSol::attach(
+            &bus,
+            &read_provider,
+            &write_provider,
+            &chain.contracts.enclave,
+            &signer,
+        )
+        .await?;
         RegistryFilterSol::attach(&bus, &write_provider, &chain.contracts.filter_registry).await?;
         CiphernodeRegistrySol::attach(&bus, &read_provider, &chain.contracts.ciphernode_registry)
             .await?;

--- a/packages/ciphernode/enclave_node/src/aggregator.rs
+++ b/packages/ciphernode/enclave_node/src/aggregator.rs
@@ -48,7 +48,7 @@ pub async fn setup_aggregator(
         let rpc_url = &chain.rpc_url;
         let read_provider = create_readonly_provider(&ensure_ws_rpc(rpc_url)).await?;
         let write_provider = create_provider_with_signer(&ensure_http_rpc(rpc_url), &signer).await?;
-        EnclaveSol::attach(&bus, &read_provider, &chain.contracts.enclave, &signer).await?;
+        EnclaveSol::attach(&bus, &read_provider, &write_provider, &chain.contracts.enclave, &signer).await?;
         RegistryFilterSol::attach(&bus, &write_provider, &chain.contracts.filter_registry).await?;
         CiphernodeRegistrySol::attach(&bus, &read_provider, &chain.contracts.ciphernode_registry)
             .await?;

--- a/packages/ciphernode/enclave_node/src/ciphernode.rs
+++ b/packages/ciphernode/enclave_node/src/ciphernode.rs
@@ -5,7 +5,10 @@ use cipher::Cipher;
 use config::AppConfig;
 use data::{DataStore, InMemStore, SledStore};
 use enclave_core::EventBus;
-use evm::{helpers::{create_readonly_provider, ensure_ws_rpc}, CiphernodeRegistrySol, EnclaveSolReader};
+use evm::{
+    helpers::{create_readonly_provider, ensure_ws_rpc},
+    CiphernodeRegistrySol, EnclaveSolReader,
+};
 use logger::SimpleLogger;
 use p2p::P2p;
 use rand::SeedableRng;
@@ -44,7 +47,8 @@ pub async fn setup_ciphernode(
 
         let read_provider = create_readonly_provider(&ensure_ws_rpc(rpc_url)).await?;
         EnclaveSolReader::attach(&bus, &read_provider, &chain.contracts.enclave).await?;
-        CiphernodeRegistrySol::attach(&bus, &read_provider, &chain.contracts.ciphernode_registry).await?;
+        CiphernodeRegistrySol::attach(&bus, &read_provider, &chain.contracts.ciphernode_registry)
+            .await?;
     }
 
     E3RequestRouter::builder(&bus, store.clone())

--- a/packages/ciphernode/evm/src/ciphernode_registry_sol.rs
+++ b/packages/ciphernode/evm/src/ciphernode_registry_sol.rs
@@ -107,7 +107,11 @@ impl CiphernodeRegistrySolReader {
 
 pub struct CiphernodeRegistrySol;
 impl CiphernodeRegistrySol {
-    pub async fn attach(bus: &Addr<EventBus>, provider: &ReadonlyProvider, contract_address: &str) -> Result<()> {
+    pub async fn attach(
+        bus: &Addr<EventBus>,
+        provider: &ReadonlyProvider,
+        contract_address: &str,
+    ) -> Result<()> {
         CiphernodeRegistrySolReader::attach(bus, provider, contract_address).await?;
         Ok(())
     }

--- a/packages/ciphernode/evm/src/ciphernode_registry_sol.rs
+++ b/packages/ciphernode/evm/src/ciphernode_registry_sol.rs
@@ -1,4 +1,4 @@
-use crate::EvmEventReader;
+use crate::{helpers::ReadonlyProvider, EvmEventReader};
 use actix::Addr;
 use alloy::{
     primitives::{LogData, B256},
@@ -97,18 +97,18 @@ pub struct CiphernodeRegistrySolReader;
 impl CiphernodeRegistrySolReader {
     pub async fn attach(
         bus: &Addr<EventBus>,
-        rpc_url: &str,
+        provider: &ReadonlyProvider,
         contract_address: &str,
     ) -> Result<Addr<EvmEventReader>> {
-        let addr = EvmEventReader::attach(bus, rpc_url, extractor, contract_address).await?;
+        let addr = EvmEventReader::attach(bus, provider, extractor, contract_address).await?;
         Ok(addr)
     }
 }
 
 pub struct CiphernodeRegistrySol;
 impl CiphernodeRegistrySol {
-    pub async fn attach(bus: &Addr<EventBus>, rpc_url: &str, contract_address: &str) -> Result<()> {
-        CiphernodeRegistrySolReader::attach(bus, rpc_url, contract_address).await?;
+    pub async fn attach(bus: &Addr<EventBus>, provider: &ReadonlyProvider, contract_address: &str) -> Result<()> {
+        CiphernodeRegistrySolReader::attach(bus, provider, contract_address).await?;
         Ok(())
     }
 }

--- a/packages/ciphernode/evm/src/enclave_sol.rs
+++ b/packages/ciphernode/evm/src/enclave_sol.rs
@@ -1,6 +1,10 @@
 use std::sync::Arc;
 
-use crate::{enclave_sol_reader::EnclaveSolReader, enclave_sol_writer::EnclaveSolWriter};
+use crate::{
+    enclave_sol_reader::EnclaveSolReader,
+    enclave_sol_writer::EnclaveSolWriter,
+    helpers::{ReadonlyProvider, SignerProvider},
+};
 use actix::Addr;
 use alloy::signers::local::PrivateKeySigner;
 use anyhow::Result;
@@ -10,12 +14,13 @@ pub struct EnclaveSol;
 impl EnclaveSol {
     pub async fn attach(
         bus: &Addr<EventBus>,
-        rpc_url: &str,
+        read_provider: &ReadonlyProvider,
+        write_provider: &SignerProvider,
         contract_address: &str,
         signer: &Arc<PrivateKeySigner>,
     ) -> Result<()> {
-        EnclaveSolReader::attach(bus, rpc_url, contract_address).await?;
-        EnclaveSolWriter::attach(bus, rpc_url, contract_address, signer).await?;
+        EnclaveSolReader::attach(bus, read_provider, contract_address).await?;
+        EnclaveSolWriter::attach(bus, write_provider, contract_address, signer).await?;
         Ok(())
     }
 }

--- a/packages/ciphernode/evm/src/enclave_sol.rs
+++ b/packages/ciphernode/evm/src/enclave_sol.rs
@@ -1,12 +1,9 @@
-use std::sync::Arc;
-
 use crate::{
     enclave_sol_reader::EnclaveSolReader,
     enclave_sol_writer::EnclaveSolWriter,
     helpers::{ReadonlyProvider, SignerProvider},
 };
 use actix::Addr;
-use alloy::signers::local::PrivateKeySigner;
 use anyhow::Result;
 use enclave_core::EventBus;
 
@@ -17,10 +14,9 @@ impl EnclaveSol {
         read_provider: &ReadonlyProvider,
         write_provider: &SignerProvider,
         contract_address: &str,
-        signer: &Arc<PrivateKeySigner>,
     ) -> Result<()> {
         EnclaveSolReader::attach(bus, read_provider, contract_address).await?;
-        EnclaveSolWriter::attach(bus, write_provider, contract_address, signer).await?;
+        EnclaveSolWriter::attach(bus, write_provider, contract_address).await?;
         Ok(())
     }
 }

--- a/packages/ciphernode/evm/src/enclave_sol_reader.rs
+++ b/packages/ciphernode/evm/src/enclave_sol_reader.rs
@@ -1,3 +1,4 @@
+use crate::helpers::ReadonlyProvider;
 use crate::EvmEventReader;
 use actix::Addr;
 use alloy::primitives::{LogData, B256};
@@ -82,10 +83,10 @@ pub struct EnclaveSolReader;
 impl EnclaveSolReader {
     pub async fn attach(
         bus: &Addr<EventBus>,
-        rpc_url: &str,
+        provider: &ReadonlyProvider,
         contract_address: &str,
     ) -> Result<Addr<EvmEventReader>> {
-        let addr = EvmEventReader::attach(bus, rpc_url, extractor, contract_address).await?;
+        let addr = EvmEventReader::attach(bus, provider, extractor, contract_address).await?;
         Ok(addr)
     }
 }

--- a/packages/ciphernode/evm/src/enclave_sol_writer.rs
+++ b/packages/ciphernode/evm/src/enclave_sol_writer.rs
@@ -1,18 +1,12 @@
-use std::sync::Arc;
-
-use crate::helpers::create_provider_with_signer;
-use crate::helpers::ensure_http_rpc;
 use crate::helpers::SignerProvider;
 use actix::prelude::*;
 use actix::Addr;
-use alloy::signers::local::PrivateKeySigner;
 use alloy::{primitives::Address, sol};
 use alloy::{
     primitives::{Bytes, U256},
     rpc::types::TransactionReceipt,
 };
 use anyhow::Result;
-use data::DataStore;
 use enclave_core::Shutdown;
 use enclave_core::{BusError, E3id, EnclaveErrorType, PlaintextAggregated, Subscribe};
 use enclave_core::{EnclaveEvent, EventBus};
@@ -36,7 +30,6 @@ impl EnclaveSolWriter {
         bus: &Addr<EventBus>,
         provider: &SignerProvider,
         contract_address: Address,
-        signer: &Arc<PrivateKeySigner>,
     ) -> Result<Self> {
         Ok(Self {
             provider: provider.clone(),
@@ -49,9 +42,8 @@ impl EnclaveSolWriter {
         bus: &Addr<EventBus>,
         provider: &SignerProvider,
         contract_address: &str,
-        signer: &Arc<PrivateKeySigner>,
     ) -> Result<Addr<EnclaveSolWriter>> {
-        let addr = EnclaveSolWriter::new(bus, provider, contract_address.parse()?, signer)
+        let addr = EnclaveSolWriter::new(bus, provider, contract_address.parse()?)
             .await?
             .start();
         bus.send(Subscribe::new("PlaintextAggregated", addr.clone().into()))

--- a/packages/ciphernode/evm/src/enclave_sol_writer.rs
+++ b/packages/ciphernode/evm/src/enclave_sol_writer.rs
@@ -34,12 +34,12 @@ pub struct EnclaveSolWriter {
 impl EnclaveSolWriter {
     pub async fn new(
         bus: &Addr<EventBus>,
-        rpc_url: &str,
+        provider: &SignerProvider,
         contract_address: Address,
         signer: &Arc<PrivateKeySigner>,
     ) -> Result<Self> {
         Ok(Self {
-            provider: create_provider_with_signer(&ensure_http_rpc(rpc_url), signer).await?,
+            provider: provider.clone(),
             contract_address,
             bus: bus.clone(),
         })
@@ -47,11 +47,11 @@ impl EnclaveSolWriter {
 
     pub async fn attach(
         bus: &Addr<EventBus>,
-        rpc_url: &str,
+        provider: &SignerProvider,
         contract_address: &str,
         signer: &Arc<PrivateKeySigner>,
     ) -> Result<Addr<EnclaveSolWriter>> {
-        let addr = EnclaveSolWriter::new(bus, rpc_url, contract_address.parse()?, signer)
+        let addr = EnclaveSolWriter::new(bus, provider, contract_address.parse()?, signer)
             .await?
             .start();
         bus.send(Subscribe::new("PlaintextAggregated", addr.clone().into()))

--- a/packages/ciphernode/evm/src/event_reader.rs
+++ b/packages/ciphernode/evm/src/event_reader.rs
@@ -23,15 +23,14 @@ pub struct EvmEventReader {
 impl EvmEventReader {
     pub async fn new(
         bus: &Addr<EventBus>,
-        rpc_url: &str,
+        provider: &ReadonlyProvider,
         extractor: ExtractorFn,
         contract_address: Address,
     ) -> Result<Self> {
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
-        let provider = create_readonly_provider(&ensure_ws_rpc(rpc_url)).await?;
         Ok(Self {
             contract_address,
-            provider: Some(provider),
+            provider: Some(provider.clone()),
             extractor,
             bus: bus.clone().into(),
             shutdown_rx: Some(shutdown_rx),
@@ -41,11 +40,11 @@ impl EvmEventReader {
 
     pub async fn attach(
         bus: &Addr<EventBus>,
-        rpc_url: &str,
+        provider: &ReadonlyProvider,
         extractor: ExtractorFn,
         contract_address: &str,
     ) -> Result<Addr<Self>> {
-        let addr = EvmEventReader::new(bus, rpc_url, extractor, contract_address.parse()?)
+        let addr = EvmEventReader::new(bus, provider, extractor, contract_address.parse()?)
             .await?
             .start();
 

--- a/packages/ciphernode/evm/src/helpers.rs
+++ b/packages/ciphernode/evm/src/helpers.rs
@@ -66,6 +66,9 @@ pub async fn stream_from_evm<P: Provider>(
     info!("Exiting stream loop");
 }
 
+
+/// We need to cache the chainId so we can easily use it in a non-async situation
+/// This wrapper just stores the chain_id with the Provider
 #[derive(Clone)]
 pub struct WithChainId<P>
 where

--- a/packages/ciphernode/evm/src/helpers.rs
+++ b/packages/ciphernode/evm/src/helpers.rs
@@ -66,7 +66,6 @@ pub async fn stream_from_evm<P: Provider>(
     info!("Exiting stream loop");
 }
 
-
 /// We need to cache the chainId so we can easily use it in a non-async situation
 /// This wrapper just stores the chain_id with the Provider
 #[derive(Clone)]

--- a/packages/ciphernode/evm/src/registry_filter_sol.rs
+++ b/packages/ciphernode/evm/src/registry_filter_sol.rs
@@ -29,12 +29,11 @@ pub struct RegistryFilterSolWriter {
 impl RegistryFilterSolWriter {
     pub async fn new(
         bus: &Addr<EventBus>,
-        rpc_url: &str,
+        provider: &SignerProvider,
         contract_address: Address,
-        signer: &Arc<PrivateKeySigner>,
     ) -> Result<Self> {
         Ok(Self {
-            provider: create_provider_with_signer(&ensure_http_rpc(rpc_url), signer).await?,
+            provider: provider.clone(),
             contract_address,
             bus: bus.clone(),
         })
@@ -42,11 +41,10 @@ impl RegistryFilterSolWriter {
 
     pub async fn attach(
         bus: &Addr<EventBus>,
-        rpc_url: &str,
+        provider: &SignerProvider,
         contract_address: &str,
-        signer: &Arc<PrivateKeySigner>,
     ) -> Result<Addr<RegistryFilterSolWriter>> {
-        let addr = RegistryFilterSolWriter::new(bus, rpc_url, contract_address.parse()?, signer)
+        let addr = RegistryFilterSolWriter::new(bus, provider, contract_address.parse()?)
             .await?
             .start();
         let _ = bus
@@ -132,11 +130,10 @@ pub struct RegistryFilterSol;
 impl RegistryFilterSol {
     pub async fn attach(
         bus: &Addr<EventBus>,
-        rpc_url: &str,
+        provider: &SignerProvider,
         contract_address: &str,
-        signer: &Arc<PrivateKeySigner>,
     ) -> Result<()> {
-        RegistryFilterSolWriter::attach(bus, rpc_url, contract_address, signer).await?;
+        RegistryFilterSolWriter::attach(bus, provider, contract_address).await?;
         Ok(())
     }
 }

--- a/packages/ciphernode/evm/src/registry_filter_sol.rs
+++ b/packages/ciphernode/evm/src/registry_filter_sol.rs
@@ -1,9 +1,8 @@
-use crate::helpers::{create_provider_with_signer, ensure_http_rpc, SignerProvider};
+use crate::helpers::SignerProvider;
 use actix::prelude::*;
 use alloy::{
     primitives::{Address, Bytes, U256},
     rpc::types::TransactionReceipt,
-    signers::local::PrivateKeySigner,
     sol,
 };
 use anyhow::Result;
@@ -11,7 +10,6 @@ use enclave_core::{
     BusError, E3id, EnclaveErrorType, EnclaveEvent, EventBus, OrderedSet, PublicKeyAggregated,
     Shutdown, Subscribe,
 };
-use std::sync::Arc;
 use tracing::info;
 
 sol!(


### PR DESCRIPTION
closes: #167  

This creates one readonly websocket provider and one http write provider per instance and passes them down the stack instead of creating multiple providers or multiple websocket connections.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new provider types (`ReadonlyProvider` and `SignerProvider`) for improved handling of blockchain interactions.
	- Added methods for creating these providers, enhancing the structure of provider management.

- **Bug Fixes**
	- Enhanced error handling in event extraction logic for improved clarity and logging.

- **Refactor**
	- Updated multiple method signatures to replace RPC URL parameters with provider parameters, streamlining interactions with blockchain contracts.

- **Documentation**
	- Improved readability and maintainability of the codebase through structural changes in provider handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->