### PR TITLE
Use multistage to reduce test image size

### DIFF
--- a/packages/ciphernode/net/tests/Dockerfile
+++ b/packages/ciphernode/net/tests/Dockerfile
@@ -1,6 +1,20 @@
-FROM rust:1.81
-RUN apt-get update && apt-get install -y iptables
+# Stage 1: Build
+FROM rust:1.81 AS builder
+
 WORKDIR /app
-COPY ./net/tests/entrypoint.sh entrypoint.sh
 COPY . .
-RUN cargo build --bin p2p_test
+RUN cargo build --release --bin p2p_test
+
+# Stage 2: Runtime
+FROM debian:bookworm-slim
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends iptables ca-certificates && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /app/target/release/p2p_test /app/
+COPY net/tests/entrypoint.sh /app/
+RUN chmod +x /app/entrypoint.sh
+
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/packages/ciphernode/net/tests/docker-compose.yaml
+++ b/packages/ciphernode/net/tests/docker-compose.yaml
@@ -1,55 +1,50 @@
 services:
   alice:
-    build: 
+    build:
       dockerfile: net/tests/Dockerfile
       context: ../..
+    image: p2p-test-image
     networks:
       app_net:
         ipv4_address: 172.16.238.10
-    command: cargo run --bin p2p_test alice
+    command: ["/app/p2p_test", "alice"]
     environment:
       QUIC_PORT: 9091
       DIAL_TO: "/ip4/172.16.238.12/udp/9091/quic-v1"
-      BLOCK_MDNS: ${BLOCK_MDNS:-false}
+      BLOCK_MDNS: "${BLOCK_MDNS:-false}"
     entrypoint: ["/app/entrypoint.sh"]
     cap_add:
       - NET_ADMIN
       - NET_RAW
 
   bob:
-    build: 
-      dockerfile: net/tests/Dockerfile
-      context: ../..
+    image: p2p-test-image
     networks:
       app_net:
         ipv4_address: 172.16.238.11
-    command: cargo run --bin p2p_test bob
+    command: ["/app/p2p_test", "bob"]
     environment:
       QUIC_PORT: 9091
       DIAL_TO: "/ip4/172.16.238.12/udp/9091/quic-v1"
-      BLOCK_MDNS: ${BLOCK_MDNS:-false}
+      BLOCK_MDNS: "${BLOCK_MDNS:-false}"
     entrypoint: ["/app/entrypoint.sh"]
     cap_add:
       - NET_ADMIN
       - NET_RAW
 
-
   charlie:
-    build: 
-      dockerfile: net/tests/Dockerfile
-      context: ../..
+    image: p2p-test-image
     networks:
       app_net:
         ipv4_address: 172.16.238.12
-    command: cargo run --bin p2p_test charlie
+    command: ["/app/p2p_test", "charlie"]
     environment:
       QUIC_PORT: 9091
-      BLOCK_MDNS: ${BLOCK_MDNS:-false}
+      BLOCK_MDNS: "${BLOCK_MDNS:-false}"
     entrypoint: ["/app/entrypoint.sh"]
     cap_add:
       - NET_ADMIN
       - NET_RAW
-
 
 networks:
   app_net:

--- a/packages/ciphernode/net/tests/run.sh
+++ b/packages/ciphernode/net/tests/run.sh
@@ -3,6 +3,11 @@
 set -e
 
 echo ""
+echo "Building docker image"
+echo ""
+docker compose build
+
+echo ""
 echo "TEST 1: Using MDNS with separate IP addresses"
 echo ""
 docker compose up --build --abort-on-container-exit


### PR DESCRIPTION
Uses a multistage build to reduce the Docker image size from 3.5 GB to 100 MB.
I also noticed that it was creating three separate images for the same build because each service in the Docker Compose file had its own build context. Instead, only one image should be built and shared across all the services, with each service simply instantiating its own container from that shared image.

Building the image first and then referencing it in the services resolves this issue.