### PR TITLE
Add Persistable State Container

### DIFF
--- a/packages/ciphernode/Cargo.lock
+++ b/packages/ciphernode/Cargo.lock
@@ -5306,6 +5306,7 @@ dependencies = [
  "async-trait",
  "bincode",
  "cipher 0.1.0",
+ "config",
  "data",
  "enclave-core",
  "evm",

--- a/packages/ciphernode/Cargo.lock
+++ b/packages/ciphernode/Cargo.lock
@@ -1706,6 +1706,7 @@ dependencies = [
  "alloy",
  "anyhow",
  "dirs",
+ "enclave-core",
  "figment",
  "serde",
  "shellexpand",

--- a/packages/ciphernode/Cargo.toml
+++ b/packages/ciphernode/Cargo.toml
@@ -38,6 +38,7 @@ base64 = "0.22.1"
 clap = { version = "4.5.17", features = ["derive"] }
 cipher = { path = "./cipher" }
 compile-time = "0.2.0"
+config = { path = "./config" }
 dirs = "5.0.1"
 data = { path = "./data" }
 enclave-core = { path = "./core" }

--- a/packages/ciphernode/Cargo.toml
+++ b/packages/ciphernode/Cargo.toml
@@ -40,6 +40,7 @@ cipher = { path = "./cipher" }
 compile-time = "0.2.0"
 dirs = "5.0.1"
 data = { path = "./data" }
+enclave-core = { path = "./core" }
 shellexpand = "3.1.0"
 figment = { version = "0.10.19", features = ["yaml", "test"] }
 fhe_rs = { package = "fhe", git = "https://github.com/gnosisguild/fhe.rs", version = "0.1.0-beta.7" }

--- a/packages/ciphernode/aggregator/src/plaintext_aggregator.rs
+++ b/packages/ciphernode/aggregator/src/plaintext_aggregator.rs
@@ -1,8 +1,6 @@
 use actix::prelude::*;
 use anyhow::Result;
-use async_trait::async_trait;
 use data::Persistable;
-use data::{Checkpoint, FromSnapshotWithParams, Repository, Snapshot};
 use enclave_core::{
     DecryptionshareCreated, Die, E3id, EnclaveEvent, EventBus, OrderedSet, PlaintextAggregated,
     Seed,

--- a/packages/ciphernode/aggregator/src/plaintext_aggregator.rs
+++ b/packages/ciphernode/aggregator/src/plaintext_aggregator.rs
@@ -221,8 +221,8 @@ impl Handler<Die> for PlaintextAggregator {
 impl Snapshot for PlaintextAggregator {
     type Snapshot = PlaintextAggregatorState;
 
-    fn snapshot(&self) -> Self::Snapshot {
-        self.state.clone()
+    fn snapshot(&self) -> Result<Self::Snapshot> {
+        Ok(self.state.clone())
     }
 }
 

--- a/packages/ciphernode/aggregator/src/plaintext_aggregator.rs
+++ b/packages/ciphernode/aggregator/src/plaintext_aggregator.rs
@@ -1,6 +1,7 @@
 use actix::prelude::*;
 use anyhow::Result;
 use async_trait::async_trait;
+use data::Persistable;
 use data::{Checkpoint, FromSnapshotWithParams, Repository, Snapshot};
 use enclave_core::{
     DecryptionshareCreated, Die, E3id, EnclaveEvent, EventBus, OrderedSet, PlaintextAggregated,
@@ -50,28 +51,28 @@ struct ComputeAggregate {
 pub struct PlaintextAggregator {
     fhe: Arc<Fhe>,
     bus: Addr<EventBus>,
-    store: Repository<PlaintextAggregatorState>,
     sortition: Addr<Sortition>,
     e3_id: E3id,
-    state: PlaintextAggregatorState,
+    state: Persistable<PlaintextAggregatorState>,
     src_chain_id: u64,
 }
 
 pub struct PlaintextAggregatorParams {
     pub fhe: Arc<Fhe>,
     pub bus: Addr<EventBus>,
-    pub store: Repository<PlaintextAggregatorState>,
     pub sortition: Addr<Sortition>,
     pub e3_id: E3id,
     pub src_chain_id: u64,
 }
 
 impl PlaintextAggregator {
-    pub fn new(params: PlaintextAggregatorParams, state: PlaintextAggregatorState) -> Self {
+    pub fn new(
+        params: PlaintextAggregatorParams,
+        state: Persistable<PlaintextAggregatorState>,
+    ) -> Self {
         PlaintextAggregator {
             fhe: params.fhe,
             bus: params.bus,
-            store: params.store,
             sortition: params.sortition,
             e3_id: params.e3_id,
             src_chain_id: params.src_chain_id,
@@ -79,36 +80,40 @@ impl PlaintextAggregator {
         }
     }
 
-    pub fn add_share(&mut self, share: Vec<u8>) -> Result<PlaintextAggregatorState> {
-        let PlaintextAggregatorState::Collecting {
-            threshold_m,
-            shares,
-            ciphertext_output,
-            ..
-        } = &mut self.state
-        else {
-            return Err(anyhow::anyhow!("Can only add share in Collecting state"));
-        };
+    pub fn add_share(&mut self, share: Vec<u8>) -> Result<()> {
+        self.state.try_mutate(|mut state| {
+            let PlaintextAggregatorState::Collecting {
+                threshold_m,
+                shares,
+                ciphertext_output,
+                ..
+            } = &mut state
+            else {
+                return Err(anyhow::anyhow!("Can only add share in Collecting state"));
+            };
 
-        shares.insert(share);
-        if shares.len() == *threshold_m {
-            return Ok(PlaintextAggregatorState::Computing {
-                shares: shares.clone(),
-                ciphertext_output: ciphertext_output.to_vec(),
-            });
-        }
+            shares.insert(share);
 
-        Ok(self.state.clone())
+            if shares.len() == *threshold_m {
+                return Ok(PlaintextAggregatorState::Computing {
+                    shares: shares.clone(),
+                    ciphertext_output: ciphertext_output.to_vec(),
+                });
+            }
+
+            Ok(state)
+        })
     }
 
-    pub fn set_decryption(&mut self, decrypted: Vec<u8>) -> Result<PlaintextAggregatorState> {
-        let PlaintextAggregatorState::Computing { shares, .. } = &mut self.state else {
-            return Ok(self.state.clone());
-        };
+    pub fn set_decryption(&mut self, decrypted: Vec<u8>) -> Result<()> {
+        self.state.try_mutate(|mut state| {
+            let PlaintextAggregatorState::Computing { shares, .. } = &mut state else {
+                return Ok(state.clone());
+            };
+            let shares = shares.to_owned();
 
-        let shares = shares.to_owned();
-
-        Ok(PlaintextAggregatorState::Complete { decrypted, shares })
+            Ok(PlaintextAggregatorState::Complete { decrypted, shares })
+        })
     }
 }
 
@@ -131,9 +136,9 @@ impl Handler<DecryptionshareCreated> for PlaintextAggregator {
     type Result = ResponseActFuture<Self, Result<()>>;
 
     fn handle(&mut self, event: DecryptionshareCreated, _: &mut Self::Context) -> Self::Result {
-        let PlaintextAggregatorState::Collecting {
+        let Some(PlaintextAggregatorState::Collecting {
             threshold_m, seed, ..
-        } = self.state
+        }) = self.state.get()
         else {
             error!(state=?self.state, "Aggregator has been closed for collecting.");
             return Box::pin(fut::ready(Ok(())));
@@ -165,14 +170,13 @@ impl Handler<DecryptionshareCreated> for PlaintextAggregator {
                     }
 
                     // add the keyshare and
-                    act.state = act.add_share(decryption_share)?;
-                    act.checkpoint();
+                    act.add_share(decryption_share)?;
 
                     // Check the state and if it has changed to the computing
-                    if let PlaintextAggregatorState::Computing {
+                    if let Some(PlaintextAggregatorState::Computing {
                         shares,
                         ciphertext_output,
-                    } = &act.state
+                    }) = &act.state.get()
                     {
                         ctx.notify(ComputeAggregate {
                             shares: shares.clone(),
@@ -195,8 +199,7 @@ impl Handler<ComputeAggregate> for PlaintextAggregator {
         })?;
 
         // Update the local state
-        self.state = self.set_decryption(decrypted_output.clone())?;
-        self.checkpoint();
+        self.set_decryption(decrypted_output.clone())?;
 
         // Dispatch the PlaintextAggregated event
         let event = EnclaveEvent::from(PlaintextAggregated {
@@ -215,28 +218,5 @@ impl Handler<Die> for PlaintextAggregator {
     type Result = ();
     fn handle(&mut self, _: Die, ctx: &mut Self::Context) -> Self::Result {
         ctx.stop()
-    }
-}
-
-impl Snapshot for PlaintextAggregator {
-    type Snapshot = PlaintextAggregatorState;
-
-    fn snapshot(&self) -> Result<Self::Snapshot> {
-        Ok(self.state.clone())
-    }
-}
-
-#[async_trait]
-impl FromSnapshotWithParams for PlaintextAggregator {
-    type Params = PlaintextAggregatorParams;
-
-    async fn from_snapshot(params: Self::Params, snapshot: Self::Snapshot) -> Result<Self> {
-        Ok(PlaintextAggregator::new(params, snapshot))
-    }
-}
-
-impl Checkpoint for PlaintextAggregator {
-    fn repository(&self) -> &Repository<PlaintextAggregatorState> {
-        &self.store
     }
 }

--- a/packages/ciphernode/aggregator/src/publickey_aggregator.rs
+++ b/packages/ciphernode/aggregator/src/publickey_aggregator.rs
@@ -1,7 +1,6 @@
 use actix::prelude::*;
 use anyhow::Result;
-use async_trait::async_trait;
-use data::{Checkpoint, FromSnapshotWithParams, Repository, Snapshot};
+use data::Persistable;
 use enclave_core::{
     Die, E3id, EnclaveEvent, EventBus, KeyshareCreated, OrderedSet, PublicKeyAggregated, Seed,
 };
@@ -53,17 +52,15 @@ struct NotifyNetwork {
 pub struct PublicKeyAggregator {
     fhe: Arc<Fhe>,
     bus: Addr<EventBus>,
-    store: Repository<PublicKeyAggregatorState>,
     sortition: Addr<Sortition>,
     e3_id: E3id,
-    state: PublicKeyAggregatorState,
+    state: Persistable<PublicKeyAggregatorState>,
     src_chain_id: u64,
 }
 
 pub struct PublicKeyAggregatorParams {
     pub fhe: Arc<Fhe>,
     pub bus: Addr<EventBus>,
-    pub store: Repository<PublicKeyAggregatorState>,
     pub sortition: Addr<Sortition>,
     pub e3_id: E3id,
     pub src_chain_id: u64,
@@ -76,11 +73,13 @@ pub struct PublicKeyAggregatorParams {
 /// It is expected to change this mechanism as we work through adversarial scenarios and write tests
 /// for them.
 impl PublicKeyAggregator {
-    pub fn new(params: PublicKeyAggregatorParams, state: PublicKeyAggregatorState) -> Self {
+    pub fn new(
+        params: PublicKeyAggregatorParams,
+        state: Persistable<PublicKeyAggregatorState>,
+    ) -> Self {
         PublicKeyAggregator {
             fhe: params.fhe,
             bus: params.bus,
-            store: params.store,
             sortition: params.sortition,
             e3_id: params.e3_id,
             src_chain_id: params.src_chain_id,
@@ -88,35 +87,39 @@ impl PublicKeyAggregator {
         }
     }
 
-    pub fn add_keyshare(&mut self, keyshare: Vec<u8>) -> Result<PublicKeyAggregatorState> {
-        let PublicKeyAggregatorState::Collecting {
-            threshold_m,
-            keyshares,
-            ..
-        } = &mut self.state
-        else {
-            return Err(anyhow::anyhow!("Can only add keyshare in Collecting state"));
-        };
-        keyshares.insert(keyshare);
-        if keyshares.len() == *threshold_m {
-            return Ok(PublicKeyAggregatorState::Computing {
-                keyshares: keyshares.clone(),
-            });
-        }
+    pub fn add_keyshare(&mut self, keyshare: Vec<u8>) -> Result<()> {
+        self.state.try_mutate(|mut state| {
+            let PublicKeyAggregatorState::Collecting {
+                threshold_m,
+                keyshares,
+                ..
+            } = &mut state
+            else {
+                return Err(anyhow::anyhow!("Can only add keyshare in Collecting state"));
+            };
+            keyshares.insert(keyshare);
+            if keyshares.len() == *threshold_m {
+                return Ok(PublicKeyAggregatorState::Computing {
+                    keyshares: keyshares.clone(),
+                });
+            }
 
-        Ok(self.state.clone())
+            Ok(state)
+        })
     }
 
-    pub fn set_pubkey(&mut self, pubkey: Vec<u8>) -> Result<PublicKeyAggregatorState> {
-        let PublicKeyAggregatorState::Computing { keyshares } = &mut self.state else {
-            return Ok(self.state.clone());
-        };
+    pub fn set_pubkey(&mut self, pubkey: Vec<u8>) -> Result<()> {
+        self.state.try_mutate(|mut state| {
+            let PublicKeyAggregatorState::Computing { keyshares } = &mut state else {
+                return Ok(state);
+            };
 
-        let keyshares = keyshares.to_owned();
+            let keyshares = keyshares.to_owned();
 
-        Ok(PublicKeyAggregatorState::Complete {
-            public_key: pubkey,
-            keyshares,
+            Ok(PublicKeyAggregatorState::Complete {
+                public_key: pubkey,
+                keyshares,
+            })
         })
     }
 }
@@ -140,9 +143,9 @@ impl Handler<KeyshareCreated> for PublicKeyAggregator {
     type Result = ResponseActFuture<Self, Result<()>>;
 
     fn handle(&mut self, event: KeyshareCreated, _: &mut Self::Context) -> Self::Result {
-        let PublicKeyAggregatorState::Collecting {
+        let Some(PublicKeyAggregatorState::Collecting {
             threshold_m, seed, ..
-        } = self.state.clone()
+        }) = self.state.get()
         else {
             error!(state=?self.state, "Aggregator has been closed for collecting keyshares.");
             return Box::pin(fut::ready(Ok(())));
@@ -176,11 +179,12 @@ impl Handler<KeyshareCreated> for PublicKeyAggregator {
                     }
 
                     // add the keyshare and
-                    act.state = act.add_keyshare(pubkey)?;
-                    act.checkpoint();
+                    act.add_keyshare(pubkey)?;
 
                     // Check the state and if it has changed to the computing
-                    if let PublicKeyAggregatorState::Computing { keyshares } = &act.state {
+                    if let Some(PublicKeyAggregatorState::Computing { keyshares }) =
+                        &act.state.get()
+                    {
                         ctx.notify(ComputeAggregate {
                             keyshares: keyshares.clone(),
                             e3_id,
@@ -202,8 +206,7 @@ impl Handler<ComputeAggregate> for PublicKeyAggregator {
         })?;
 
         // Update the local state
-        self.state = self.set_pubkey(pubkey.clone())?;
-        self.checkpoint();
+        self.set_pubkey(pubkey.clone())?;
 
         ctx.notify(NotifyNetwork {
             pubkey,
@@ -240,28 +243,5 @@ impl Handler<Die> for PublicKeyAggregator {
     type Result = ();
     fn handle(&mut self, _: Die, ctx: &mut Self::Context) -> Self::Result {
         ctx.stop()
-    }
-}
-
-impl Snapshot for PublicKeyAggregator {
-    type Snapshot = PublicKeyAggregatorState;
-
-    fn snapshot(&self) -> Result<Self::Snapshot> {
-        Ok(self.state.clone())
-    }
-}
-
-#[async_trait]
-impl FromSnapshotWithParams for PublicKeyAggregator {
-    type Params = PublicKeyAggregatorParams;
-
-    async fn from_snapshot(params: Self::Params, snapshot: Self::Snapshot) -> Result<Self> {
-        Ok(PublicKeyAggregator::new(params, snapshot))
-    }
-}
-
-impl Checkpoint for PublicKeyAggregator {
-    fn repository(&self) -> &Repository<PublicKeyAggregatorState> {
-        &self.store
     }
 }

--- a/packages/ciphernode/aggregator/src/publickey_aggregator.rs
+++ b/packages/ciphernode/aggregator/src/publickey_aggregator.rs
@@ -246,8 +246,8 @@ impl Handler<Die> for PublicKeyAggregator {
 impl Snapshot for PublicKeyAggregator {
     type Snapshot = PublicKeyAggregatorState;
 
-    fn snapshot(&self) -> Self::Snapshot {
-        self.state.clone()
+    fn snapshot(&self) -> Result<Self::Snapshot> {
+        Ok(self.state.clone())
     }
 }
 

--- a/packages/ciphernode/config/Cargo.toml
+++ b/packages/ciphernode/config/Cargo.toml
@@ -11,6 +11,7 @@ figment = { workspace = true }
 alloy = { workspace = true }
 shellexpand = { workspace = true }
 url = { workspace = true }
+enclave-core = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/packages/ciphernode/config/src/lib.rs
+++ b/packages/ciphernode/config/src/lib.rs
@@ -1,5 +1,5 @@
 mod app_config;
-mod yaml;
 mod store_keys;
+mod yaml;
 
 pub use app_config::*;

--- a/packages/ciphernode/config/src/lib.rs
+++ b/packages/ciphernode/config/src/lib.rs
@@ -1,3 +1,5 @@
 mod app_config;
 mod yaml;
+mod store_keys;
+
 pub use app_config::*;

--- a/packages/ciphernode/config/src/lib.rs
+++ b/packages/ciphernode/config/src/lib.rs
@@ -3,3 +3,4 @@ mod store_keys;
 mod yaml;
 
 pub use app_config::*;
+pub use store_keys::*;

--- a/packages/ciphernode/config/src/store_keys.rs
+++ b/packages/ciphernode/config/src/store_keys.rs
@@ -1,0 +1,53 @@
+use enclave_core::E3id;
+
+pub struct StoreKeys;
+
+impl StoreKeys {
+    pub fn keyshare(e3_id: &E3id) -> String {
+        format!("//keyshare/{e3_id}")
+    }
+
+    pub fn plaintext(e3_id: &E3id) -> String {
+        format!("//plaintext/{e3_id}")
+    }
+
+    pub fn publickey(e3_id: &E3id) -> String {
+        format!("//publickey/{e3_id}")
+    }
+
+    pub fn fhe(e3_id: &E3id) -> String {
+        format!("//fhe/{e3_id}")
+    }
+
+    pub fn meta(e3_id: &E3id) -> String {
+        format!("//meta/{e3_id}")
+    }
+
+    pub fn context(e3_id: &E3id) -> String {
+        format!("//context/{e3_id}")
+    }
+
+    pub fn router() -> String {
+        String::from("//router")
+    }
+
+    pub fn sortition() -> String {
+        String::from("//sortition")
+    }
+
+    pub fn eth_private_key() -> String {
+        String::from("//eth_private_key")
+    }
+
+    pub fn libp2p_keypair() -> String {
+        String::from("//libp2p/keypair")
+    }
+
+    pub fn enclave_sol_reader(chain_id: u64) -> String {
+        format!("//evm_readers/enclave/{chain_id}")
+    }
+
+    pub fn ciphernode_registry_reader(chain_id: u64) -> String {
+        format!("//evm_readers/ciphernode_registry/{chain_id}")
+    }
+}

--- a/packages/ciphernode/data/README.md
+++ b/packages/ciphernode/data/README.md
@@ -1,0 +1,140 @@
+# On Persistence patterns
+
+_The way persistence is managed within this codebase has a few elements to it. So here is the story as to how this works and why it has been done like this_
+
+Persistence within an Actor Model tends to be based around the idea that actors need to be able to have their state persistable and hydratable upon restart. This enables in an ideal scenario any actor to be able to just crash on error and restart as required.
+
+We started persistence by creating an Actor that wraps the database which is good practice within an Actor Model. This has advantages because we can interleave database writes to become a stream of events enabling high throughput. We can create delivery guarantees by storing events in a persistent queue at a later point if need be.
+
+```mermaid
+graph LR
+    DB[(SledDB)]
+    Client --insert--> SledStore
+    SledStore --insert--> DB
+    SledStore -.retry.-> SledStore
+```
+
+## DataStore
+
+Next we needed a way to polymorphically pick between a real database and an in memory database for testing - to do this we utilize Actix's `Recipient<Message>` trait which means we can accept any actor that is happy to receive an `Insert` or a `Get` message. This means we can create a Key Value Store struct and pass in either a `SledStore` or an `InMemStore` Actor to the `DataStore` actor to accomplish this.
+
+```rust
+let store = DataStore::from(SledStore::from(SledDb::new()));
+```
+
+or for testing:
+
+```rust
+let store = DataStore::from(InMemStore::new());
+```
+
+```mermaid
+graph LR
+    DB[(SledDB)]
+    Client --> DataStore
+    DataStore -.-> SledStore
+    DataStore -.-> InMemStore
+    InMemStore -.-> BTreeMap
+    SledStore --> DB
+```
+
+The `DataStore` actor also has some convenience methods within it where it is possible to scope the keys so that you can consider the information you are storing as more of a tree structure as opposed to a flat list.
+
+```rust
+let store = DataStore::from(&addr);
+let scoped = store.scope("//foo/bar/baz");
+scoped.write(some_data);
+```
+
+## Repository
+
+There was an attempt to use the `DataStore` throughout the app but it became apparent this was causing the knowledge of where and how the data was saved to be spread throughout the codebase. What we needed was for the components not to really care how their data was saved but for us to be able to easily have a sense of the different keys under which data was being saved in a centralized place.
+
+Also `DataStore` can take any type of serializable data to save at a key location but this means the data in the DataStore was effectively untyped.
+
+To solve this it made sense to create a typed `Repository<T>` interface to encapsulate saving of data from within an actor or routine and in theory the repository could use whatever underlying mechanism requires to save the data. This could even be a SQL DB or the filesystem if required. Whatever it's type T the Repository knows how to save it.
+
+The tradeoff is we get a slightly deeper stack but each layer adds a responsibility to the data saving stack:
+
+```mermaid
+graph LR
+    R["Repository&lt;T&gt;"]
+    DB[(SledDB)]
+    Client --"write()"--> R
+    R --> D[DataStore]
+    D -.-> SledStore
+    D -.-> InMemStore
+    InMemStore -.-> BTreeMap
+    SledStore --> DB
+```
+
+
+| Layer               | Functionality                                                                                                                   |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `Repository<T>`     | Strongly typed Data persistence for a single item. Configured to know how to save its data.                                     |
+| `DataStore`         | Flexible KV store. Client can scope to specific namespace. Can be backed by polymorphic data actor to handle testing scenarios. |
+| `{InMem,Sled}Store` | Actor to receive `Insert` and `Get` requests can only save raw bytes.                                                           |
+
+## Snapshotting
+
+We had a way to save bytes data with the `DataStore` and had a way to specify where that could be saved but actors need to be restartable and be able to be hydrated and we needed a standard way to accomplish this. To do this in typical Rust fashion we created a set of traits:
+
+- [`Snapshot`](https://github.com/gnosisguild/enclave/blob/main/packages/ciphernode/data/src/snapshot.rs) for defining how an object can create a snapshot of it's state
+- [`Checkpoint`](https://github.com/gnosisguild/enclave/blob/main/packages/ciphernode/data/src/snapshot.rs) for defining how to save that snapshot to a repository
+- [`FromSnapshot`](https://github.com/gnosisguild/enclave/blob/main/packages/ciphernode/data/src/snapshot.rs) and [`FromSnapshotWithParams`](https://github.com/gnosisguild/enclave/blob/main/packages/ciphernode/data/src/snapshot.rs) for defining how an object could be reconstituted from a snapshot
+
+This worked well especially for objects who's persistable state needs to be derived from a subset of the saved state however there are a couple of problems:
+
+- `self.checkpoint()` needs to be called everytime you want to save the state
+- Using these traits is very verbose and repeditive - especially for situations where the state was just a field on the actor which it often is.
+- These traits mean you need to mix some persistence API within your business logic API unless you create a separate struct just for persistence.
+
+## Enter Persistable
+
+Persistable is a struct that connects a repository and some in memory state and ensures that every time the in memory state is mutated that the state is saved to the repository.
+
+This has several benefits:
+
+- Less verbose
+- Centralized batching point for logical operations
+- Can remove complex "snapshot" traits
+- Simpler initialization
+- No need to consider the underlying data saving mechanism - logic can be [persistence ignorant](https://www.linkedin.com/pulse/persistence-ignorance-domain-driven-design-ilkay-polat-atmae).
+
+```rust
+
+// Some how we get a repository for a type
+let repo:Repository<Vec<String>> = get_repo();
+
+// We can use the load to create a persistable object from the contents of the persistance layer that the repository encapsulates
+let persistable:Persistable<Vec<String>> = repo.load().await?;
+
+// If we add a name to the list the list is automatically synced to the database
+persistable.try_mutate(|mut list| {
+  list.push("Fred");
+  Ok(list)
+})?;
+
+// We can set new state
+persistable.set(vec![String::from("Hello")]);
+
+// We can try and get the data if it is set on the object
+if persistable.try_get()?.len() > 0 {
+    println!("Repo has names!")
+}
+
+// We an clear the object which will clear the repo
+persistable.clear();
+
+assert_eq!(persistable.get(), None);
+```
+
+To use it we can just have it as a field on a struct or actor:
+
+```rust
+struct MyActor {
+  state: Persistable<Vec<String>>
+}
+```
+
+We have also extracted the key calculation mechanism to a [`StoreKeys`](https://github.com/gnosisguild/enclave/blob/main/packages/ciphernode/config/src/store_keys.rs) struct. This is used in various places when creating repsitory factories for example [here](https://github.com/gnosisguild/enclave/blob/main/packages/ciphernode/aggregator/src/repositories.rs)

--- a/packages/ciphernode/data/src/data_store.rs
+++ b/packages/ciphernode/data/src/data_store.rs
@@ -68,6 +68,11 @@ impl DataStore {
             return Ok(None);
         };
 
+        // If we get a null value return None as this doesn't deserialize correctly
+        if bytes == [0] {
+            return Ok(None);
+        }
+
         Ok(Some(bincode::deserialize(&bytes)?))
     }
 

--- a/packages/ciphernode/data/src/data_store.rs
+++ b/packages/ciphernode/data/src/data_store.rs
@@ -49,7 +49,8 @@ impl Remove {
     }
 }
 
-/// Generate proxy for the DB
+/// Generate proxy for the DB / KV store
+/// DataStore is scopable
 #[derive(Clone, Debug)]
 pub struct DataStore {
     scope: Vec<u8>,

--- a/packages/ciphernode/data/src/lib.rs
+++ b/packages/ciphernode/data/src/lib.rs
@@ -9,6 +9,7 @@ mod snapshot;
 pub use data_store::*;
 pub use in_mem::*;
 pub use into_key::IntoKey;
+pub use persistable::*;
 pub use repository::*;
 pub use sled_store::*;
 pub use snapshot::*;

--- a/packages/ciphernode/data/src/lib.rs
+++ b/packages/ciphernode/data/src/lib.rs
@@ -1,10 +1,10 @@
 mod data_store;
 mod in_mem;
 mod into_key;
+mod persistable;
 mod repository;
 mod sled_store;
 mod snapshot;
-mod persistable;
 
 pub use data_store::*;
 pub use in_mem::*;

--- a/packages/ciphernode/data/src/lib.rs
+++ b/packages/ciphernode/data/src/lib.rs
@@ -3,6 +3,7 @@ mod in_mem;
 mod into_key;
 mod persistable;
 mod repository;
+mod repository_factory;
 mod sled_store;
 mod snapshot;
 

--- a/packages/ciphernode/data/src/lib.rs
+++ b/packages/ciphernode/data/src/lib.rs
@@ -4,6 +4,7 @@ mod into_key;
 mod repository;
 mod sled_store;
 mod snapshot;
+mod persistable;
 
 pub use data_store::*;
 pub use in_mem::*;

--- a/packages/ciphernode/data/src/persistable.rs
+++ b/packages/ciphernode/data/src/persistable.rs
@@ -1,0 +1,431 @@
+use crate::{Checkpoint, FromSnapshotWithParams, Repository, Snapshot};
+use anyhow::*;
+use async_trait::async_trait;
+use serde::{de::DeserializeOwned, Serialize};
+
+pub trait PersistableData: Serialize + DeserializeOwned + Clone + Send + Sync + 'static {}
+impl<T> PersistableData for T where T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static {}
+
+/// AutoPersist enables a repository to generate a persistable container
+#[async_trait]
+pub trait AutoPersist<T>
+where
+    T: PersistableData,
+{
+    /// Load the data from the repository into an auto persist container
+    async fn load(&self) -> Result<Persistable<T>>;
+    /// Create a new auto persist container and set some data on it to send back to the repository
+    fn send(&self, data: Option<T>) -> Persistable<T>;
+    /// Load the data from the repository into an auto persist container. If there is no persisted data then persist the given default data  
+    async fn load_or_default(&self, default: T) -> Result<Persistable<T>>;
+    /// Load the data from the repository into an auto persist container. If there is no persisted data then persist the given default data  
+    async fn load_or_else<F>(&self, f: F) -> Result<Persistable<T>>
+    where
+        F: Send + FnOnce() -> Result<T>;
+}
+
+#[async_trait]
+impl<T> AutoPersist<T> for Repository<T>
+where
+    T: PersistableData,
+{
+    /// Load the data from the repository into an auto persist container
+    async fn load(&self) -> Result<Persistable<T>> {
+        Ok(Persistable::load(self).await?)
+    }
+
+    /// Create a new auto persist container and set some data on it to send back to the repository
+    fn send(&self, data: Option<T>) -> Persistable<T> {
+        Persistable::new(data, self).save()
+    }
+
+    /// Load the data from the repository into an auto persist container. If there is no persisted data then persist the given default data  
+    async fn load_or_default(&self, default: T) -> Result<Persistable<T>> {
+        Ok(Persistable::load_or_default(self, default).await?)
+    }
+
+    /// Load the data from the repository into an auto persist container. If there is no persisted data then persist the result of the callback
+    async fn load_or_else<F>(&self, f: F) -> Result<Persistable<T>>
+    where
+        F: Send + FnOnce() -> Result<T>,
+    {
+        Ok(Persistable::load_or_else(self, f).await?)
+    }
+}
+
+/// A container that automatically persists it's content every time it is mutated or changed.
+#[derive(Debug)]
+pub struct Persistable<T> {
+    data: Option<T>,
+    repo: Repository<T>,
+}
+
+impl<T> Persistable<T>
+where
+    T: PersistableData,
+{
+    /// Create a new container with the given option data and repository
+    pub fn new(data: Option<T>, repo: &Repository<T>) -> Self {
+        Self {
+            data,
+            repo: repo.clone(),
+        }
+    }
+
+    /// Load data from the repository to the container
+    pub async fn load(repo: &Repository<T>) -> Result<Self> {
+        let data = repo.read().await?;
+
+        Ok(Self::new(data, repo))
+    }
+
+    /// Load the data from the repo or save and sync the given default value
+    pub async fn load_or_default(repo: &Repository<T>, default: T) -> Result<Self> {
+        let instance = Self::new(Some(repo.read().await?.unwrap_or(default)), repo);
+
+        Ok(instance.save())
+    }
+
+    /// Load the data from the repo or save and sync the result of the given callback
+    pub async fn load_or_else<F>(repo: &Repository<T>, f: F) -> Result<Self>
+    where
+        F: FnOnce() -> Result<T>,
+    {
+        let data = repo
+            .read()
+            .await?
+            .ok_or_else(|| anyhow!("Not found"))
+            .or_else(|_| f())?;
+
+        let instance = Self::new(Some(data), repo);
+        Ok(instance.save())
+    }
+
+    /// Save the data in the container to the database
+    pub fn save(self) -> Self {
+        self.checkpoint();
+        self
+    }
+
+    /// Mutate the content if it is available or return an error if either the mutator function
+    /// fails or if the data has not been set.
+    pub fn try_mutate<F>(&mut self, mutator: F) -> Result<()>
+    where
+        F: FnOnce(T) -> Result<T>,
+    {
+        let content = self.data.clone().ok_or(anyhow!("Data has not been set"))?;
+        self.data = Some(mutator(content)?);
+        self.checkpoint();
+        Ok(())
+    }
+
+    /// Set the data on both the persistable and the repository.
+    pub fn set(&mut self, data: T) {
+        self.data = Some(data);
+        self.checkpoint();
+    }
+
+    /// Clear the data from both the persistable and the repository.
+    pub fn clear(&mut self) {
+        self.data = None;
+        self.clear_checkpoint();
+    }
+
+    /// Get the data currently stored on the container as an Option<T>
+    pub fn get(&self) -> Option<T> {
+        self.data.clone()
+    }
+
+    /// Get the data from the container or return an error.
+    pub fn try_get(&self) -> Result<T> {
+        self.data
+            .clone()
+            .ok_or(anyhow!("Data was not set on container."))
+    }
+
+    /// Returns true if there is data on the container and false if there is not.
+    pub fn has(&self) -> bool {
+        self.data.is_some()
+    }
+
+    /// Get an immutable reference to the data on the container if the data is not set on the
+    /// container return an error
+    pub fn try_with<F, U>(&self, f: F) -> Result<U>
+    where
+        F: FnOnce(&T) -> Result<U>,
+    {
+        match &self.data {
+            Some(data) => f(data),
+            None => Err(anyhow!("Data was not set on container.")),
+        }
+    }
+}
+
+impl<T> Snapshot for Persistable<T>
+where
+    T: PersistableData,
+{
+    type Snapshot = T;
+    fn snapshot(&self) -> Result<Self::Snapshot> {
+        Ok(self
+            .data
+            .clone()
+            .ok_or(anyhow!("No data stored on container"))?)
+    }
+}
+
+impl<T> Checkpoint for Persistable<T>
+where
+    T: PersistableData,
+{
+    fn repository(&self) -> &Repository<Self::Snapshot> {
+        &self.repo
+    }
+}
+
+#[async_trait]
+impl<T> FromSnapshotWithParams for Persistable<T>
+where
+    T: PersistableData,
+{
+    type Params = Repository<T>;
+    async fn from_snapshot(params: Repository<T>, snapshot: T) -> Result<Self> {
+        Ok(Persistable::new(Some(snapshot), &params))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{AutoPersist, DataStore, GetLog, InMemStore, Repository};
+    use actix::{Actor, Addr};
+    use anyhow::{anyhow, Result};
+
+    fn get_repo<T>() -> (Repository<T>, Addr<InMemStore>) {
+        let addr = InMemStore::new(true).start();
+        let store = DataStore::from(&addr).scope("/");
+        let repo: Repository<T> = Repository::new(store);
+        (repo, addr)
+    }
+
+    #[actix::test]
+    async fn persistable_loads_with_default() -> Result<()> {
+        let (repo, addr) = get_repo::<Vec<String>>();
+        let container = repo
+            .clone()
+            .load_or_default(vec!["berlin".to_string()])
+            .await?;
+
+        assert_eq!(addr.send(GetLog).await?.len(), 1);
+        assert_eq!(repo.read().await?, Some(vec!["berlin".to_string()]));
+        assert_eq!(container.get(), Some(vec!["berlin".to_string()]));
+        Ok(())
+    }
+
+    #[actix::test]
+    async fn persistable_loads_with_default_override() -> Result<()> {
+        let (repo, _) = get_repo::<Vec<String>>();
+        repo.write(&vec!["berlin".to_string()]);
+        let container = repo
+            .clone()
+            .load_or_default(vec!["amsterdam".to_string()])
+            .await?;
+
+        assert_eq!(repo.read().await?, Some(vec!["berlin".to_string()]));
+        assert_eq!(container.get(), Some(vec!["berlin".to_string()]));
+        Ok(())
+    }
+
+    #[actix::test]
+    async fn persistable_load() -> Result<()> {
+        let (repo, _) = get_repo::<Vec<String>>();
+        repo.write(&vec!["berlin".to_string()]);
+        let container = repo.clone().load().await?;
+
+        assert_eq!(repo.read().await?, Some(vec!["berlin".to_string()]));
+        assert_eq!(container.get(), Some(vec!["berlin".to_string()]));
+        Ok(())
+    }
+
+    #[actix::test]
+    async fn persistable_send() -> Result<()> {
+        let (repo, _) = get_repo::<Vec<String>>();
+        repo.write(&vec!["amsterdam".to_string()]);
+        let container = repo.clone().send(Some(vec!["berlin".to_string()]));
+
+        assert_eq!(repo.read().await?, Some(vec!["berlin".to_string()]));
+        assert_eq!(container.get(), Some(vec!["berlin".to_string()]));
+        Ok(())
+    }
+
+    #[actix::test]
+    async fn persistable_mutate() -> Result<()> {
+        let (repo, addr) = get_repo::<Vec<String>>();
+
+        let mut container = repo.clone().send(Some(vec!["berlin".to_string()]));
+
+        container.try_mutate(|mut list| {
+            list.push(String::from("amsterdam"));
+            Ok(list)
+        })?;
+
+        assert_eq!(
+            repo.read().await?,
+            Some(vec!["berlin".to_string(), "amsterdam".to_string()])
+        );
+
+        assert_eq!(addr.send(GetLog).await?.len(), 2);
+
+        Ok(())
+    }
+
+    #[actix::test]
+    async fn test_clear_persistable() -> Result<()> {
+        let (repo, _) = get_repo::<Vec<String>>();
+        let repo_ref = &repo;
+        let mut container = repo_ref.send(Some(vec!["berlin".to_string()]));
+
+        assert!(container.has());
+        container.clear();
+        assert!(!container.has());
+        assert_eq!(repo_ref.read().await?, None);
+        Ok(())
+    }
+
+    #[actix::test]
+    async fn test_set_persistable() -> Result<()> {
+        let (repo, _) = get_repo::<Vec<String>>();
+        let mut container = repo.clone().send(None);
+
+        container.set(vec!["amsterdam".to_string()]);
+
+        assert!(container.has());
+        assert_eq!(repo.read().await?, Some(vec!["amsterdam".to_string()]));
+        Ok(())
+    }
+
+    #[actix::test]
+    async fn test_try_get_with_data() -> Result<()> {
+        let (repo, _) = get_repo::<Vec<String>>();
+        let container = repo.clone().send(Some(vec!["berlin".to_string()]));
+
+        let result = container.try_get()?;
+        assert_eq!(result, vec!["berlin".to_string()]);
+        Ok(())
+    }
+
+    #[actix::test]
+    async fn test_try_get_without_data() {
+        let (repo, _) = get_repo::<Vec<String>>();
+        let container = repo.clone().send(None);
+
+        assert!(container.try_get().is_err());
+    }
+
+    #[actix::test]
+    async fn test_try_with_success() -> Result<()> {
+        let (repo, _) = get_repo::<Vec<String>>();
+        let container = repo.clone().send(Some(vec!["berlin".to_string()]));
+
+        let length = container.try_with(|data| Ok(data.len()))?;
+        assert_eq!(length, 1);
+        Ok(())
+    }
+
+    #[actix::test]
+    async fn test_try_with_failure() {
+        let (repo, _) = get_repo::<Vec<String>>();
+        let container = repo.clone().send(None);
+
+        let result = container.try_with(|data| Ok(data.len()));
+        assert!(result.is_err());
+    }
+
+    #[actix::test]
+    async fn test_try_mutate_failure() {
+        let (repo, _) = get_repo::<Vec<String>>();
+        let mut container = repo.clone().send(None);
+
+        let result = container.try_mutate(|mut list| {
+            list.push(String::from("amsterdam"));
+            Ok(list)
+        });
+        assert!(result.is_err());
+    }
+
+    #[actix::test]
+    async fn test_mutate_with_error() -> Result<()> {
+        let (repo, _) = get_repo::<Vec<String>>();
+        let mut container = repo.clone().send(Some(vec!["berlin".to_string()]));
+
+        let result =
+            container.try_mutate(|_| -> Result<Vec<String>> { Err(anyhow!("Mutation failed")) });
+
+        assert!(result.is_err());
+        // Original data should remain unchanged
+        assert_eq!(container.try_get()?, vec!["berlin".to_string()]);
+        Ok(())
+    }
+
+    #[actix::test]
+    async fn test_load_or_else_success_with_empty_repo() -> Result<()> {
+        let (repo, _) = get_repo::<Vec<String>>();
+
+        let container = repo
+            .clone()
+            .load_or_else(|| Ok(vec!["amsterdam".to_string()]))
+            .await?;
+
+        assert_eq!(container.try_get()?, vec!["amsterdam".to_string()]);
+        assert_eq!(repo.read().await?, Some(vec!["amsterdam".to_string()]));
+        Ok(())
+    }
+
+    #[actix::test]
+    async fn test_load_or_else_skips_callback_when_data_exists() -> Result<()> {
+        let (repo, _) = get_repo::<Vec<String>>();
+        repo.write(&vec!["berlin".to_string()]);
+
+        let container = repo
+            .clone()
+            .load_or_else(|| {
+                panic!("This callback should not be called!");
+                #[allow(unreachable_code)]
+                Ok(vec!["amsterdam".to_string()])
+            })
+            .await?;
+
+        assert_eq!(container.try_get()?, vec!["berlin".to_string()]);
+        Ok(())
+    }
+
+    #[actix::test]
+    async fn test_load_or_else_propagates_callback_error() -> Result<()> {
+        let (repo, _) = get_repo::<Vec<String>>();
+
+        let result = repo
+            .clone()
+            .load_or_else(|| Err(anyhow!("Failed to create default data")))
+            .await;
+
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Failed to create default data"));
+        assert_eq!(repo.read().await?, None);
+        Ok(())
+    }
+
+    #[actix::test]
+    async fn test_load_or_else_custom_error_message() -> Result<()> {
+        let (repo, _) = get_repo::<Vec<String>>();
+        let error_msg = "Custom initialization error";
+
+        let result = repo.load_or_else(|| Err(anyhow!(error_msg))).await;
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains(error_msg));
+        Ok(())
+    }
+
+}

--- a/packages/ciphernode/data/src/persistable.rs
+++ b/packages/ciphernode/data/src/persistable.rs
@@ -427,5 +427,4 @@ mod tests {
         assert!(result.unwrap_err().to_string().contains(error_msg));
         Ok(())
     }
-
 }

--- a/packages/ciphernode/data/src/repository.rs
+++ b/packages/ciphernode/data/src/repository.rs
@@ -20,13 +20,6 @@ impl<S> Repository<S> {
     }
 }
 
-impl<S> Deref for Repository<S> {
-    type Target = DataStore;
-    fn deref(&self) -> &Self::Target {
-        &self.store
-    }
-}
-
 impl<S> From<Repository<S>> for DataStore {
     fn from(value: Repository<S>) -> Self {
         value.store

--- a/packages/ciphernode/data/src/repository.rs
+++ b/packages/ciphernode/data/src/repository.rs
@@ -6,7 +6,8 @@ use crate::DataStore;
 
 #[derive(Debug)]
 pub struct Repository<S> {
-    store: DataStore,
+    /// store is currently set to be a scopeable key value store
+    store: DataStore, // this could change and be abstracted if need be
     _p: PhantomData<S>,
 }
 
@@ -56,11 +57,15 @@ where
         self.store.read().await
     }
 
+    pub async fn has(&self) -> bool {
+        self.read().await.ok().flatten().is_some()
+    }
+
     pub fn write(&self, value: &T) {
-        self.store.write(value);
+        self.store.write(value)
     }
 
     pub fn clear(&self) {
-        self.store.clear();
+        self.store.write::<Option<T>>(None)
     }
 }

--- a/packages/ciphernode/data/src/repository_factory.rs
+++ b/packages/ciphernode/data/src/repository_factory.rs
@@ -1,0 +1,48 @@
+use crate::{DataStore, Repository};
+
+pub struct Repositories {
+    pub store: DataStore,
+}
+
+impl From<DataStore> for Repositories {
+    fn from(value: DataStore) -> Self {
+        Repositories { store: value }
+    }
+}
+impl From<&DataStore> for Repositories {
+    fn from(value: &DataStore) -> Self {
+        Repositories {
+            store: value.clone(),
+        }
+    }
+}
+
+impl Repositories {
+    pub fn new(store: DataStore) -> Self {
+        Repositories { store }
+    }
+}
+
+impl<T> From<Repository<T>> for Repositories {
+    fn from(value: Repository<T>) -> Self {
+        let store: DataStore = value.into();
+        store.into()
+    }
+}
+
+pub trait RepositoriesFactory {
+    fn repositories(&self) -> Repositories;
+}
+
+impl RepositoriesFactory for DataStore {
+    fn repositories(&self) -> Repositories {
+        self.into()
+    }
+}
+
+impl<T> RepositoriesFactory for Repository<T> {
+    fn repositories(&self) -> Repositories {
+        let store: DataStore = self.into();
+        store.repositories()
+    }
+}

--- a/packages/ciphernode/data/src/repository_factory.rs
+++ b/packages/ciphernode/data/src/repository_factory.rs
@@ -1,5 +1,6 @@
 use crate::{DataStore, Repository};
 
+// TODO: Naming here is confusing
 pub struct Repositories {
     pub store: DataStore,
 }

--- a/packages/ciphernode/evm/src/event_reader.rs
+++ b/packages/ciphernode/evm/src/event_reader.rs
@@ -8,8 +8,7 @@ use alloy::providers::Provider;
 use alloy::rpc::types::Filter;
 use alloy::transports::{BoxTransport, Transport};
 use anyhow::{anyhow, Result};
-use async_trait::async_trait;
-use data::{Checkpoint, FromSnapshotWithParams, Repository, Snapshot};
+use data::{AutoPersist, Persistable, Repository};
 use enclave_core::{
     get_tag, BusError, EnclaveErrorType, EnclaveEvent, EventBus, EventId, Subscribe,
 };
@@ -50,7 +49,7 @@ where
     contract_address: Address,
     start_block: Option<u64>,
     bus: Addr<EventBus>,
-    repository: Repository<EvmEventReaderState>,
+    state: Persistable<EvmEventReaderState>,
 }
 
 #[derive(Default, serde::Serialize, serde::Deserialize, Clone)]
@@ -80,10 +79,8 @@ where
     start_block: Option<u64>,
     /// Event bus for error propagation
     bus: Addr<EventBus>,
-    /// The in memory state of the event reader
-    state: EvmEventReaderState,
-    /// Repository to save the state of the event reader
-    repository: Repository<EvmEventReaderState>,
+    /// The auto persistable state of the event reader
+    state: Persistable<EvmEventReaderState>,
 }
 
 impl<P, T> EvmEventReader<P, T>
@@ -101,20 +98,8 @@ where
             shutdown_tx: Some(shutdown_tx),
             start_block: params.start_block,
             bus: params.bus,
-            state: EvmEventReaderState::default(),
-            repository: params.repository,
+            state: params.state,
         }
-    }
-
-    #[instrument(name="evm_event_reader", skip_all, fields(id = get_tag()))]
-    pub async fn load(params: EvmEventReaderParams<P, T>) -> Result<Self> {
-        Ok(if let Some(snapshot) = params.repository.read().await? {
-            info!("Loading from snapshot");
-            Self::from_snapshot(params, snapshot).await?
-        } else {
-            info!("Loading from params");
-            Self::new(params)
-        })
     }
 
     pub async fn attach(
@@ -125,15 +110,20 @@ where
         bus: &Addr<EventBus>,
         repository: &Repository<EvmEventReaderState>,
     ) -> Result<Addr<Self>> {
+        let sync_state = repository
+            .clone()
+            .load_or_default(EvmEventReaderState::default())
+            .await?;
+
         let params = EvmEventReaderParams {
             provider: provider.clone(),
             extractor,
             contract_address: contract_address.parse()?,
             start_block,
             bus: bus.clone(),
-            repository: repository.clone(),
+            state: sync_state,
         };
-        let addr = EvmEventReader::load(params).await?.start();
+        let addr = EvmEventReader::new(params).start();
 
         bus.do_send(Subscribe::new("Shutdown", addr.clone().into()));
 
@@ -284,69 +274,33 @@ where
 
     #[instrument(name="evm_event_reader", skip_all, fields(id = get_tag()))]
     fn handle(&mut self, wrapped: EnclaveEvmEvent, _: &mut Self::Context) -> Self::Result {
-        let event_id = wrapped.get_id();
-        info!("Processing event: {}", event_id);
-        info!("cache length: {}", self.state.ids.len());
-        if self.state.ids.contains(&event_id) {
-            error!(
-                "Event id {} has already been seen and was not forwarded to the bus",
-                &event_id
-            );
-            return;
+        match self.state.try_mutate(|mut state| {
+            let event_id = wrapped.get_id();
+            info!("Processing event: {}", event_id);
+            info!("cache length: {}", state.ids.len());
+            if state.ids.contains(&event_id) {
+                error!(
+                    "Event id {} has already been seen and was not forwarded to the bus",
+                    &event_id
+                );
+                return Ok(state);
+            }
+
+            let event_type = wrapped.event.event_type();
+
+            // Forward everything else to the event bus
+            self.bus.do_send(wrapped.event);
+
+            // Save processed ids
+            info!("Storing event(EVM) in cache {}({})", event_type, event_id);
+
+            state.ids.insert(event_id);
+            state.last_block = wrapped.block;
+
+            Ok(state)
+        }) {
+            Ok(_) => (),
+            Err(err) => self.bus.err(EnclaveErrorType::Evm, err),
         }
-        let event_type = wrapped.event.event_type();
-
-        // Forward everything else to the event bus
-        self.bus.do_send(wrapped.event);
-
-        // Save processed ids
-        info!("Storing event(EVM) in cache {}({})", event_type, event_id);
-        self.state.ids.insert(event_id);
-        self.state.last_block = wrapped.block;
-        self.checkpoint();
-    }
-}
-
-impl<P, T> Snapshot for EvmEventReader<P, T>
-where
-    P: Provider<T> + Clone + 'static,
-    T: Transport + Clone + Unpin,
-{
-    type Snapshot = EvmEventReaderState;
-    fn snapshot(&self) -> Result<Self::Snapshot> {
-        Ok(self.state.clone())
-    }
-}
-
-impl<P, T> Checkpoint for EvmEventReader<P, T>
-where
-    P: Provider<T> + Clone + 'static,
-    T: Transport + Clone + Unpin,
-{
-    fn repository(&self) -> &Repository<Self::Snapshot> {
-        &self.repository
-    }
-}
-
-#[async_trait]
-impl<P, T> FromSnapshotWithParams for EvmEventReader<P, T>
-where
-    P: Provider<T> + Clone + 'static,
-    T: Transport + Clone + Unpin,
-{
-    type Params = EvmEventReaderParams<P, T>;
-    async fn from_snapshot(params: Self::Params, snapshot: Self::Snapshot) -> Result<Self> {
-        let (shutdown_tx, shutdown_rx) = oneshot::channel();
-        Ok(Self {
-            contract_address: params.contract_address,
-            provider: Some(params.provider),
-            extractor: params.extractor,
-            shutdown_rx: Some(shutdown_rx),
-            shutdown_tx: Some(shutdown_tx),
-            start_block: params.start_block,
-            bus: params.bus,
-            state: snapshot,
-            repository: params.repository,
-        })
     }
 }

--- a/packages/ciphernode/evm/src/event_reader.rs
+++ b/packages/ciphernode/evm/src/event_reader.rs
@@ -313,8 +313,8 @@ where
     T: Transport + Clone + Unpin,
 {
     type Snapshot = EvmEventReaderState;
-    fn snapshot(&self) -> Self::Snapshot {
-        self.state.clone()
+    fn snapshot(&self) -> Result<Self::Snapshot> {
+        Ok(self.state.clone())
     }
 }
 

--- a/packages/ciphernode/fhe/src/fhe.rs
+++ b/packages/ciphernode/fhe/src/fhe.rs
@@ -127,11 +127,11 @@ impl Fhe {
 
 impl Snapshot for Fhe {
     type Snapshot = FheSnapshot;
-    fn snapshot(&self) -> Self::Snapshot {
-        FheSnapshot {
+    fn snapshot(&self) -> Result<Self::Snapshot> {
+        Ok(FheSnapshot {
             crp: self.crp.to_bytes(),
             params: self.params.to_bytes(),
-        }
+        })
     }
 }
 

--- a/packages/ciphernode/keyshare/src/keyshare.rs
+++ b/packages/ciphernode/keyshare/src/keyshare.rs
@@ -1,6 +1,5 @@
 use actix::prelude::*;
 use anyhow::{anyhow, Result};
-use async_trait::async_trait;
 use cipher::Cipher;
 use data::Persistable;
 use enclave_core::{
@@ -8,7 +7,6 @@ use enclave_core::{
     E3RequestComplete, EnclaveErrorType, EnclaveEvent, EventBus, FromError, KeyshareCreated,
 };
 use fhe::{DecryptCiphertext, Fhe};
-use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tracing::warn;
 
@@ -30,11 +28,6 @@ pub struct KeyshareParams {
     pub fhe: Arc<Fhe>,
     pub address: String,
     pub cipher: Arc<Cipher>,
-}
-
-#[derive(Serialize, Deserialize)]
-pub struct KeyshareState {
-    secret: Option<Vec<u8>>,
 }
 
 impl Keyshare {

--- a/packages/ciphernode/keyshare/src/keyshare.rs
+++ b/packages/ciphernode/keyshare/src/keyshare.rs
@@ -77,10 +77,10 @@ impl Keyshare {
 impl Snapshot for Keyshare {
     type Snapshot = KeyshareState;
 
-    fn snapshot(&self) -> Self::Snapshot {
-        KeyshareState {
+    fn snapshot(&self) -> Result<Self::Snapshot> {
+        Ok(KeyshareState {
             secret: self.secret.clone(),
-        }
+        })
     }
 }
 

--- a/packages/ciphernode/router/Cargo.toml
+++ b/packages/ciphernode/router/Cargo.toml
@@ -14,6 +14,7 @@ aggregator = { path = "../aggregator" }
 evm = { path = "../evm" }
 anyhow = { workspace = true }
 serde = { workspace = true }
+config = { workspace = true }
 cipher = { path = "../cipher" }
 bincode = { workspace = true }
 async-trait = { workspace = true }

--- a/packages/ciphernode/router/src/context.rs
+++ b/packages/ciphernode/router/src/context.rs
@@ -151,15 +151,15 @@ impl RepositoriesFactory for E3RequestContext {
 impl Snapshot for E3RequestContext {
     type Snapshot = E3RequestContextSnapshot;
 
-    fn snapshot(&self) -> Self::Snapshot {
-        Self::Snapshot {
+    fn snapshot(&self) -> Result<Self::Snapshot> {
+        Ok(Self::Snapshot {
             e3_id: self.e3_id.clone(),
             meta: self.meta.is_some(),
             fhe: self.fhe.is_some(),
             publickey: self.publickey.is_some(),
             plaintext: self.plaintext.is_some(),
             keyshare: self.keyshare.is_some(),
-        }
+        })
     }
 }
 

--- a/packages/ciphernode/router/src/e3_request_router.rs
+++ b/packages/ciphernode/router/src/e3_request_router.rs
@@ -178,14 +178,14 @@ pub struct E3RequestRouterSnapshot {
 
 impl Snapshot for E3RequestRouter {
     type Snapshot = E3RequestRouterSnapshot;
-    fn snapshot(&self) -> Self::Snapshot {
+    fn snapshot(&self) -> Result<Self::Snapshot> {
         let contexts = self.contexts.keys().cloned().collect();
         let completed = self.completed.clone();
 
-        Self::Snapshot {
+        Ok(Self::Snapshot {
             completed,
             contexts,
-        }
+        })
     }
 }
 

--- a/packages/ciphernode/router/src/hooks.rs
+++ b/packages/ciphernode/router/src/hooks.rs
@@ -57,7 +57,14 @@ impl E3Feature for FheFeature {
         let fhe = Arc::new(fhe_inner);
 
         // FHE doesn't implement Checkpoint so we are going to store it manually
-        ctx.repositories().fhe(&e3_id).write(&fhe.snapshot());
+        let Ok(snapshot) = fhe.snapshot() else {
+            self.bus.err(
+                EnclaveErrorType::KeyGeneration,
+                anyhow!("Failed to get snapshot"),
+            );
+            return;
+        };
+        ctx.repositories().fhe(&e3_id).write(&snapshot);
 
         let _ = ctx.set_fhe(fhe);
     }

--- a/packages/ciphernode/router/src/repositories.rs
+++ b/packages/ciphernode/router/src/repositories.rs
@@ -1,5 +1,6 @@
 use crate::{CommitteeMeta, E3RequestContextSnapshot, E3RequestRouterSnapshot};
 use aggregator::{PlaintextAggregatorState, PublicKeyAggregatorState};
+use config::StoreKeys;
 use data::{DataStore, Repository};
 use enclave_core::E3id;
 use evm::EvmEventReaderState;
@@ -38,55 +39,52 @@ impl<T> From<Repository<T>> for Repositories {
 
 impl Repositories {
     pub fn keyshare(&self, e3_id: &E3id) -> Repository<Vec<u8>> {
-        Repository::new(self.store.scope(format!("//keyshare/{e3_id}")))
+        Repository::new(self.store.scope(StoreKeys::keyshare(e3_id)))
     }
 
     pub fn plaintext(&self, e3_id: &E3id) -> Repository<PlaintextAggregatorState> {
-        Repository::new(self.store.scope(format!("//plaintext/{e3_id}")))
+        Repository::new(self.store.scope(StoreKeys::plaintext(e3_id)))
     }
 
     pub fn publickey(&self, e3_id: &E3id) -> Repository<PublicKeyAggregatorState> {
-        Repository::new(self.store.scope(format!("//publickey/{e3_id}")))
+        Repository::new(self.store.scope(StoreKeys::publickey(e3_id)))
     }
 
     pub fn fhe(&self, e3_id: &E3id) -> Repository<FheSnapshot> {
-        Repository::new(self.store.scope(format!("//fhe/{e3_id}")))
+        Repository::new(self.store.scope(StoreKeys::fhe(e3_id)))
     }
 
     pub fn meta(&self, e3_id: &E3id) -> Repository<CommitteeMeta> {
-        Repository::new(self.store.scope(format!("//meta/{e3_id}")))
+        Repository::new(self.store.scope(StoreKeys::meta(e3_id)))
     }
 
     pub fn context(&self, e3_id: &E3id) -> Repository<E3RequestContextSnapshot> {
-        Repository::new(self.store.scope(format!("//context/{e3_id}")))
+        Repository::new(self.store.scope(StoreKeys::context(e3_id)))
     }
 
     pub fn router(&self) -> Repository<E3RequestRouterSnapshot> {
-        Repository::new(self.store.scope(format!("//router")))
+        Repository::new(self.store.scope(StoreKeys::router()))
     }
 
     pub fn sortition(&self) -> Repository<SortitionModule> {
-        Repository::new(self.store.scope(format!("//sortition")))
+        Repository::new(self.store.scope(StoreKeys::sortition()))
     }
 
     pub fn eth_private_key(&self) -> Repository<Vec<u8>> {
-        Repository::new(self.store.scope(format!("//eth_private_key")))
+        Repository::new(self.store.scope(StoreKeys::eth_private_key()))
     }
 
     pub fn libp2p_keypair(&self) -> Repository<Vec<u8>> {
-        Repository::new(self.store.scope(format!("//libp2p/keypair")))
+        Repository::new(self.store.scope(StoreKeys::libp2p_keypair()))
     }
 
     pub fn enclave_sol_reader(&self, chain_id: u64) -> Repository<EvmEventReaderState> {
-        Repository::new(
-            self.store
-                .scope(format!("//evm_readers/enclave/{chain_id}")),
-        )
+        Repository::new(self.store.scope(StoreKeys::enclave_sol_reader(chain_id)))
     }
     pub fn ciphernode_registry_reader(&self, chain_id: u64) -> Repository<EvmEventReaderState> {
         Repository::new(
             self.store
-                .scope(format!("//evm_readers/ciphernode_registry/{chain_id}")),
+                .scope(StoreKeys::ciphernode_registry_reader(chain_id)),
         )
     }
 }

--- a/packages/ciphernode/router/src/repositories.rs
+++ b/packages/ciphernode/router/src/repositories.rs
@@ -4,7 +4,6 @@ use data::{DataStore, Repository};
 use enclave_core::E3id;
 use evm::EvmEventReaderState;
 use fhe::FheSnapshot;
-use keyshare::KeyshareState;
 use sortition::SortitionModule;
 
 pub struct Repositories {
@@ -38,7 +37,7 @@ impl<T> From<Repository<T>> for Repositories {
 }
 
 impl Repositories {
-    pub fn keyshare(&self, e3_id: &E3id) -> Repository<KeyshareState> {
+    pub fn keyshare(&self, e3_id: &E3id) -> Repository<Vec<u8>> {
         Repository::new(self.store.scope(format!("//keyshare/{e3_id}")))
     }
 

--- a/packages/ciphernode/sortition/src/sortition.rs
+++ b/packages/ciphernode/sortition/src/sortition.rs
@@ -2,8 +2,7 @@ use crate::DistanceSortition;
 use actix::prelude::*;
 use alloy::primitives::Address;
 use anyhow::{anyhow, Result};
-use async_trait::async_trait;
-use data::{Checkpoint, FromSnapshotWithParams, Repository, Snapshot};
+use data::{AutoPersist, Persistable, Repository};
 use enclave_core::{
     get_tag, BusError, CiphernodeAdded, CiphernodeRemoved, EnclaveErrorType, EnclaveEvent,
     EventBus, Seed, Subscribe,
@@ -87,23 +86,21 @@ impl SortitionList<String> for SortitionModule {
 pub struct GetNodes;
 
 pub struct Sortition {
-    list: SortitionModule,
+    list: Persistable<SortitionModule>,
     bus: Addr<EventBus>,
-    store: Repository<SortitionModule>,
 }
 
 #[derive(Debug)]
 pub struct SortitionParams {
-    pub bus: Addr<EventBus>,
-    pub store: Repository<SortitionModule>,
+    bus: Addr<EventBus>,
+    list: Persistable<SortitionModule>,
 }
 
 impl Sortition {
     pub fn new(params: SortitionParams) -> Self {
         Self {
-            list: SortitionModule::new(),
+            list: params.list,
             bus: params.bus,
-            store: params.store,
         }
     }
 
@@ -112,66 +109,23 @@ impl Sortition {
         bus: &Addr<EventBus>,
         store: Repository<SortitionModule>,
     ) -> Result<Addr<Sortition>> {
-        let addr = Sortition::load(SortitionParams {
+        let list = store.load_or_default(SortitionModule::default()).await?;
+        let addr = Sortition::new(SortitionParams {
             bus: bus.clone(),
-            store,
+            list,
         })
-        .await?
         .start();
         bus.do_send(Subscribe::new("CiphernodeAdded", addr.clone().into()));
         Ok(addr)
     }
 
-    #[instrument(name="sortition", skip_all, fields(id = get_tag()))]
-    pub async fn load(params: SortitionParams) -> Result<Self> {
-        Ok(if let Some(snapshot) = params.store.read().await? {
-            info!("Loading from snapshot");
-            Self::from_snapshot(params, snapshot).await?
-        } else {
-            info!("Loading from params");
-            Self::new(params)
-        })
-    }
-
     pub fn get_nodes(&self) -> Vec<String> {
-        self.list.nodes.clone().into_iter().collect()
+        self.list.get().unwrap().nodes.clone().into_iter().collect()
     }
 }
 
 impl Actor for Sortition {
     type Context = actix::Context<Self>;
-}
-
-impl Snapshot for Sortition {
-    type Snapshot = SortitionModule;
-    fn snapshot(&self) -> Result<Self::Snapshot> {
-        Ok(self.list.clone())
-    }
-}
-
-#[async_trait]
-impl FromSnapshotWithParams for Sortition {
-    type Params = SortitionParams;
-
-    #[instrument(name="sortition", skip_all, fields(id = get_tag()))]
-    async fn from_snapshot(params: Self::Params, snapshot: Self::Snapshot) -> Result<Self> {
-        info!("Loaded snapshot with {} nodes", snapshot.nodes().len());
-        info!(
-            "Nodes:\n\n{:?}\n",
-            snapshot.nodes().into_iter().collect::<Vec<_>>()
-        );
-        Ok(Sortition {
-            bus: params.bus,
-            store: params.store,
-            list: snapshot,
-        })
-    }
-}
-
-impl Checkpoint for Sortition {
-    fn repository(&self) -> &Repository<SortitionModule> {
-        &self.store
-    }
 }
 
 impl Handler<EnclaveEvent> for Sortition {
@@ -191,8 +145,13 @@ impl Handler<CiphernodeAdded> for Sortition {
     #[instrument(name="sortition", skip_all, fields(id = get_tag()))]
     fn handle(&mut self, msg: CiphernodeAdded, _ctx: &mut Self::Context) -> Self::Result {
         info!("Adding node: {}", msg.address);
-        self.list.add(msg.address);
-        self.checkpoint();
+        match self.list.try_mutate(|mut list| {
+            list.add(msg.address);
+            Ok(list)
+        }) {
+            Err(err) => self.bus.err(EnclaveErrorType::Sortition, err),
+            _ => (),
+        };
     }
 }
 
@@ -202,8 +161,13 @@ impl Handler<CiphernodeRemoved> for Sortition {
     #[instrument(name="sortition", skip_all, fields(id = get_tag()))]
     fn handle(&mut self, msg: CiphernodeRemoved, _ctx: &mut Self::Context) -> Self::Result {
         info!("Removing node: {}", msg.address);
-        self.list.remove(msg.address);
-        self.checkpoint();
+        match self.list.try_mutate(|mut list| {
+            list.remove(msg.address);
+            Ok(list)
+        }) {
+            Err(err) => self.bus.err(EnclaveErrorType::Sortition, err),
+            _ => (),
+        };
     }
 }
 
@@ -212,13 +176,12 @@ impl Handler<GetHasNode> for Sortition {
 
     #[instrument(name="sortition", skip_all, fields(id = get_tag()))]
     fn handle(&mut self, msg: GetHasNode, _ctx: &mut Self::Context) -> Self::Result {
-        match self.list.contains(msg.seed, msg.size, msg.address) {
-            Ok(val) => val,
-            Err(err) => {
+        self.list
+            .try_with(|list| list.contains(msg.seed, msg.size, msg.address))
+            .unwrap_or_else(|err| {
                 self.bus.err(EnclaveErrorType::Sortition, err);
                 false
-            }
-        }
+            })
     }
 }
 

--- a/packages/ciphernode/sortition/src/sortition.rs
+++ b/packages/ciphernode/sortition/src/sortition.rs
@@ -144,8 +144,8 @@ impl Actor for Sortition {
 
 impl Snapshot for Sortition {
     type Snapshot = SortitionModule;
-    fn snapshot(&self) -> Self::Snapshot {
-        self.list.clone()
+    fn snapshot(&self) -> Result<Self::Snapshot> {
+        Ok(self.list.clone())
     }
 }
 


### PR DESCRIPTION
Closes: #194

Read justification [here](https://github.com/gnosisguild/enclave/blob/7bd04adeb6e12336d5b4344a11d6c9f2c51f3a26/packages/ciphernode/data/README.md).

- Remove `Snapshot` and `Checkpoint` traits from everywhere it is not necessary 
- Add `Persistable<T>` as an automatic state persistence container to:
    - `PlaintextAggregator`
    - `PublickeyAggregator`
    - `EventReader`
    - `KeyShare`
    - `Sortition`
- Extract `StoreKeys` in preparation for refactor that sees `Repositories` moved to separate crates.
- Deliberately avoiding adding persistable to `E3RequestRouter` and `E3RequestContext` because the snapshot state is derived which would add complexity around how we track state changes there and that feels out of the scope of this PR. We can tackle this after refactoring the router package in #215 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new dependency `config` for enhanced functionality.
	- Added `StoreKeys` struct for centralized key path generation.
	- Implemented `Persistable` type for improved state management across various modules.
	- Enhanced error handling in snapshot methods for `E3RequestContext` and `E3RequestRouter`.

- **Bug Fixes**
	- Improved error handling for snapshot retrieval across multiple features.

- **Refactor**
	- Updated state management in `Keyshare`, `Sortition`, `PlaintextAggregator`, and `PublicKeyAggregator` to use `Persistable`.
	- Removed outdated snapshot and checkpoint implementations in several components.

- **Documentation**
	- Enhanced README to provide a comprehensive overview of persistence patterns and state management strategies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->