### PR TITLE
Extract events

### DIFF
--- a/packages/ciphernode/events/src/e3id.rs
+++ b/packages/ciphernode/events/src/e3id.rs
@@ -1,0 +1,43 @@
+use alloy::primitives::U256;
+use alloy_primitives::ruint::ParseError;
+use core::fmt;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct E3id(pub String);
+impl fmt::Display for E3id {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl E3id {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+}
+
+impl From<u32> for E3id {
+    fn from(value: u32) -> Self {
+        E3id::new(value.to_string())
+    }
+}
+
+impl From<String> for E3id {
+    fn from(value: String) -> Self {
+        E3id::new(value)
+    }
+}
+
+impl From<&str> for E3id {
+    fn from(value: &str) -> Self {
+        E3id::new(value)
+    }
+}
+
+impl TryFrom<E3id> for U256 {
+    type Error = ParseError;
+    fn try_from(value: E3id) -> Result<Self, Self::Error> {
+        U256::from_str_radix(&value.0, 10)
+    }
+}

--- a/packages/ciphernode/events/src/enclave_event/ciphernode_added.rs
+++ b/packages/ciphernode/events/src/enclave_event/ciphernode_added.rs
@@ -1,0 +1,21 @@
+use actix::Message;
+use serde::{Deserialize, Serialize};
+use std::fmt::{self, Display};
+
+#[derive(Message, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[rtype(result = "()")]
+pub struct CiphernodeAdded {
+    pub address: String,
+    pub index: usize,
+    pub num_nodes: usize,
+}
+
+impl Display for CiphernodeAdded {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "address: {}, index: {}, num_nodes: {}",
+            self.address, self.index, self.num_nodes
+        )
+    }
+}

--- a/packages/ciphernode/events/src/enclave_event/ciphernode_removed.rs
+++ b/packages/ciphernode/events/src/enclave_event/ciphernode_removed.rs
@@ -1,0 +1,21 @@
+use actix::Message;
+use serde::{Deserialize, Serialize};
+use std::fmt::{self, Display};
+
+#[derive(Message, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[rtype(result = "()")]
+pub struct CiphernodeRemoved {
+    pub address: String,
+    pub index: usize,
+    pub num_nodes: usize,
+}
+
+impl Display for CiphernodeRemoved {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "address: {}, index: {}, num_nodes: {}",
+            self.address, self.index, self.num_nodes
+        )
+    }
+}

--- a/packages/ciphernode/events/src/enclave_event/ciphernode_selected.rs
+++ b/packages/ciphernode/events/src/enclave_event/ciphernode_selected.rs
@@ -1,0 +1,21 @@
+use crate::E3id;
+use actix::Message;
+use serde::{Deserialize, Serialize};
+use std::fmt::{self, Display};
+
+#[derive(Message, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[rtype(result = "()")]
+pub struct CiphernodeSelected {
+    pub e3_id: E3id,
+    pub threshold_m: usize,
+}
+
+impl Display for CiphernodeSelected {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "e3_id: {}, threshold_m: {}",
+            self.e3_id, self.threshold_m,
+        )
+    }
+}

--- a/packages/ciphernode/events/src/enclave_event/ciphertext_output_published.rs
+++ b/packages/ciphernode/events/src/enclave_event/ciphertext_output_published.rs
@@ -1,0 +1,17 @@
+use crate::E3id;
+use actix::Message;
+use serde::{Deserialize, Serialize};
+use std::fmt::{self, Display};
+
+#[derive(Message, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[rtype(result = "()")]
+pub struct CiphertextOutputPublished {
+    pub e3_id: E3id,
+    pub ciphertext_output: Vec<u8>,
+}
+
+impl Display for CiphertextOutputPublished {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "e3_id: {}", self.e3_id,)
+    }
+}

--- a/packages/ciphernode/events/src/enclave_event/decryptionshare_created.rs
+++ b/packages/ciphernode/events/src/enclave_event/decryptionshare_created.rs
@@ -1,0 +1,18 @@
+use crate::E3id;
+use actix::Message;
+use serde::{Deserialize, Serialize};
+use std::fmt::{self, Display};
+
+#[derive(Message, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[rtype(result = "anyhow::Result<()>")]
+pub struct DecryptionshareCreated {
+    pub decryption_share: Vec<u8>,
+    pub e3_id: E3id,
+    pub node: String,
+}
+
+impl Display for DecryptionshareCreated {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "e3_id: {}, node: {}", self.e3_id, self.node,)
+    }
+}

--- a/packages/ciphernode/events/src/enclave_event/die.rs
+++ b/packages/ciphernode/events/src/enclave_event/die.rs
@@ -1,0 +1,12 @@
+use actix::Message;
+use serde::{Deserialize, Serialize};
+use std::fmt::{self, Display};
+
+#[derive(Message, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[rtype(result = "()")]
+pub struct Die;
+impl Display for Die {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Die",)
+    }
+}

--- a/packages/ciphernode/events/src/enclave_event/e3_request_complete.rs
+++ b/packages/ciphernode/events/src/enclave_event/e3_request_complete.rs
@@ -1,0 +1,17 @@
+use crate::E3id;
+use actix::Message;
+use serde::{Deserialize, Serialize};
+use std::fmt::{self, Display};
+
+/// E3RequestComplete event is a local only event
+#[derive(Message, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[rtype(result = "()")]
+pub struct E3RequestComplete {
+    pub e3_id: E3id,
+}
+
+impl Display for E3RequestComplete {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "e3_id: {}", self.e3_id)
+    }
+}

--- a/packages/ciphernode/events/src/enclave_event/e3_requested.rs
+++ b/packages/ciphernode/events/src/enclave_event/e3_requested.rs
@@ -1,0 +1,24 @@
+use crate::{E3id, Seed};
+use actix::Message;
+use serde::{Deserialize, Serialize};
+use std::fmt::{self, Display};
+
+#[derive(Message, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[rtype(result = "()")]
+pub struct E3Requested {
+    pub e3_id: E3id,
+    pub threshold_m: usize,
+    pub seed: Seed,
+    pub params: Vec<u8>,
+    pub src_chain_id: u64,
+}
+
+impl Display for E3Requested {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "e3_id: {}, threshold_m: {}, src_chain_id: {}, seed: {}, params: <omitted>",
+            self.e3_id, self.threshold_m, self.src_chain_id, self.seed
+        )
+    }
+}

--- a/packages/ciphernode/events/src/enclave_event/enclave_error.rs
+++ b/packages/ciphernode/events/src/enclave_event/enclave_error.rs
@@ -1,0 +1,52 @@
+use actix::Message;
+use serde::{Deserialize, Serialize};
+use std::fmt::{self, Display};
+
+pub trait FromError {
+    type Error;
+    fn from_error(err_type: EnclaveErrorType, error: Self::Error) -> Self;
+}
+
+#[derive(Message, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[rtype(result = "()")]
+pub struct EnclaveError {
+    pub err_type: EnclaveErrorType,
+    pub message: String,
+}
+
+impl Display for EnclaveError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum EnclaveErrorType {
+    Evm,
+    KeyGeneration,
+    PublickeyAggregation,
+    IO,
+    PlaintextAggregation,
+    Decryption,
+    Sortition,
+    Data,
+}
+
+impl EnclaveError {
+    pub fn new(err_type: EnclaveErrorType, message: &str) -> Self {
+        Self {
+            err_type,
+            message: message.to_string(),
+        }
+    }
+}
+
+impl FromError for EnclaveError {
+    type Error = anyhow::Error;
+    fn from_error(err_type: EnclaveErrorType, error: Self::Error) -> Self {
+        Self {
+            err_type,
+            message: error.to_string(),
+        }
+    }
+}

--- a/packages/ciphernode/events/src/enclave_event/keyshare_created.rs
+++ b/packages/ciphernode/events/src/enclave_event/keyshare_created.rs
@@ -1,0 +1,19 @@
+use crate::E3id;
+use actix::Message;
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::fmt::Display;
+
+#[derive(Message, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[rtype(result = "anyhow::Result<()>")]
+pub struct KeyshareCreated {
+    pub pubkey: Vec<u8>,
+    pub e3_id: E3id,
+    pub node: String,
+}
+
+impl Display for KeyshareCreated {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "e3_id: {}, node: {}", self.e3_id, self.node,)
+    }
+}

--- a/packages/ciphernode/events/src/enclave_event/mod.rs
+++ b/packages/ciphernode/events/src/enclave_event/mod.rs
@@ -26,7 +26,7 @@ pub use keyshare_created::*;
 pub use plaintext_aggregated::*;
 pub use publickey_aggregated::*;
 pub use shutdown::*;
-use test_event::TestEvent;
+pub use test_event::*;
 
 use crate::{E3id, EventId};
 use actix::Message;
@@ -36,6 +36,7 @@ use std::{
     hash::Hash,
 };
 
+/// Macro to help define From traits for EnclaveEvent
 macro_rules! impl_from_event {
     ($($variant:ident),*) => {
         $(

--- a/packages/ciphernode/events/src/enclave_event/mod.rs
+++ b/packages/ciphernode/events/src/enclave_event/mod.rs
@@ -36,6 +36,21 @@ use std::{
     hash::Hash,
 };
 
+macro_rules! impl_from_event {
+    ($($variant:ident),*) => {
+        $(
+            impl From<$variant> for EnclaveEvent {
+                fn from(data: $variant) -> Self {
+                    EnclaveEvent::$variant {
+                        id: EventId::hash(data.clone()),
+                        data: data.clone(),
+                    }
+                }
+            }
+        )*
+    };
+}
+
 #[derive(Message, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[rtype(result = "()")]
 pub enum EnclaveEvent {
@@ -178,122 +193,21 @@ impl EnclaveEvent {
     }
 }
 
-impl From<KeyshareCreated> for EnclaveEvent {
-    fn from(data: KeyshareCreated) -> Self {
-        EnclaveEvent::KeyshareCreated {
-            id: EventId::hash(data.clone()),
-            data: data.clone(),
-        }
-    }
-}
-
-impl From<E3Requested> for EnclaveEvent {
-    fn from(data: E3Requested) -> Self {
-        EnclaveEvent::E3Requested {
-            id: EventId::hash(data.clone()),
-            data: data.clone(),
-        }
-    }
-}
-
-impl From<PublicKeyAggregated> for EnclaveEvent {
-    fn from(data: PublicKeyAggregated) -> Self {
-        EnclaveEvent::PublicKeyAggregated {
-            id: EventId::hash(data.clone()),
-            data: data.clone(),
-        }
-    }
-}
-
-impl From<CiphertextOutputPublished> for EnclaveEvent {
-    fn from(data: CiphertextOutputPublished) -> Self {
-        EnclaveEvent::CiphertextOutputPublished {
-            id: EventId::hash(data.clone()),
-            data: data.clone(),
-        }
-    }
-}
-
-impl From<DecryptionshareCreated> for EnclaveEvent {
-    fn from(data: DecryptionshareCreated) -> Self {
-        EnclaveEvent::DecryptionshareCreated {
-            id: EventId::hash(data.clone()),
-            data: data.clone(),
-        }
-    }
-}
-
-impl From<PlaintextAggregated> for EnclaveEvent {
-    fn from(data: PlaintextAggregated) -> Self {
-        EnclaveEvent::PlaintextAggregated {
-            id: EventId::hash(data.clone()),
-            data: data.clone(),
-        }
-    }
-}
-
-impl From<E3RequestComplete> for EnclaveEvent {
-    fn from(data: E3RequestComplete) -> Self {
-        EnclaveEvent::E3RequestComplete {
-            id: EventId::hash(data.clone()),
-            data: data.clone(),
-        }
-    }
-}
-
-impl From<CiphernodeSelected> for EnclaveEvent {
-    fn from(data: CiphernodeSelected) -> Self {
-        EnclaveEvent::CiphernodeSelected {
-            id: EventId::hash(data.clone()),
-            data: data.clone(),
-        }
-    }
-}
-
-impl From<CiphernodeAdded> for EnclaveEvent {
-    fn from(data: CiphernodeAdded) -> Self {
-        EnclaveEvent::CiphernodeAdded {
-            id: EventId::hash(data.clone()),
-            data: data.clone(),
-        }
-    }
-}
-
-impl From<CiphernodeRemoved> for EnclaveEvent {
-    fn from(data: CiphernodeRemoved) -> Self {
-        EnclaveEvent::CiphernodeRemoved {
-            id: EventId::hash(data.clone()),
-            data: data.clone(),
-        }
-    }
-}
-
-impl From<EnclaveError> for EnclaveEvent {
-    fn from(data: EnclaveError) -> Self {
-        EnclaveEvent::EnclaveError {
-            id: EventId::hash(data.clone()),
-            data: data.clone(),
-        }
-    }
-}
-
-impl From<Shutdown> for EnclaveEvent {
-    fn from(data: Shutdown) -> Self {
-        EnclaveEvent::Shutdown {
-            id: EventId::hash(data.clone()),
-            data: data.clone(),
-        }
-    }
-}
-
-impl From<TestEvent> for EnclaveEvent {
-    fn from(value: TestEvent) -> Self {
-        EnclaveEvent::TestEvent {
-            id: EventId::hash(value.clone()),
-            data: value.clone(),
-        }
-    }
-}
+impl_from_event!(
+    KeyshareCreated,
+    E3Requested,
+    PublicKeyAggregated,
+    CiphertextOutputPublished,
+    DecryptionshareCreated,
+    PlaintextAggregated,
+    E3RequestComplete,
+    CiphernodeSelected,
+    CiphernodeAdded,
+    CiphernodeRemoved,
+    EnclaveError,
+    Shutdown,
+    TestEvent
+);
 
 impl FromError for EnclaveEvent {
     type Error = anyhow::Error;

--- a/packages/ciphernode/events/src/enclave_event/plaintext_aggregated.rs
+++ b/packages/ciphernode/events/src/enclave_event/plaintext_aggregated.rs
@@ -1,0 +1,22 @@
+use crate::E3id;
+use actix::Message;
+use serde::{Deserialize, Serialize};
+use std::fmt::{self, Display};
+
+#[derive(Message, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[rtype(result = "()")]
+pub struct PlaintextAggregated {
+    pub e3_id: E3id,
+    pub decrypted_output: Vec<u8>,
+    pub src_chain_id: u64,
+}
+
+impl Display for PlaintextAggregated {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "e3_id: {}, src_chain_id: {}",
+            self.e3_id, self.src_chain_id
+        )
+    }
+}

--- a/packages/ciphernode/events/src/enclave_event/publickey_aggregated.rs
+++ b/packages/ciphernode/events/src/enclave_event/publickey_aggregated.rs
@@ -1,0 +1,23 @@
+use crate::{E3id, OrderedSet};
+use actix::Message;
+use serde::{Deserialize, Serialize};
+use std::fmt::{self, Display};
+
+#[derive(Message, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[rtype(result = "()")]
+pub struct PublicKeyAggregated {
+    pub pubkey: Vec<u8>,
+    pub e3_id: E3id,
+    pub nodes: OrderedSet<String>,
+    pub src_chain_id: u64,
+}
+
+impl Display for PublicKeyAggregated {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "e3_id: {}, src_chain_id: {}, nodes: <omitted>, pubkey: <omitted>",
+            self.e3_id, self.src_chain_id,
+        )
+    }
+}

--- a/packages/ciphernode/events/src/enclave_event/shutdown.rs
+++ b/packages/ciphernode/events/src/enclave_event/shutdown.rs
@@ -1,0 +1,13 @@
+use actix::Message;
+use serde::{Deserialize, Serialize};
+use std::fmt::{self, Display};
+
+/// Represents a shutdown event triggered by SIG TERM
+#[derive(Message, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[rtype(result = "()")]
+pub struct Shutdown;
+impl Display for Shutdown {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Shutdown",)
+    }
+}

--- a/packages/ciphernode/events/src/enclave_event/test_event.rs
+++ b/packages/ciphernode/events/src/enclave_event/test_event.rs
@@ -1,0 +1,17 @@
+use actix::Message;
+use serde::{Deserialize, Serialize};
+use std::fmt::{self, Display};
+
+#[derive(Message, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[rtype(result = "()")]
+pub struct TestEvent {
+    pub msg: String,
+    pub entropy: u64,
+}
+
+#[cfg(test)]
+impl Display for TestEvent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "TestEvent(msg: {})", self.msg)
+    }
+}

--- a/packages/ciphernode/events/src/event_id.rs
+++ b/packages/ciphernode/events/src/event_id.rs
@@ -1,0 +1,27 @@
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::{
+    fmt,
+    hash::{DefaultHasher, Hash, Hasher},
+};
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct EventId(pub [u8; 32]);
+
+impl EventId {
+    pub fn hash<T: Hash>(value: T) -> Self {
+        let mut hasher = Sha256::new();
+        let mut std_hasher = DefaultHasher::new();
+        value.hash(&mut std_hasher);
+        hasher.update(std_hasher.finish().to_le_bytes());
+        let result = hasher.finalize();
+        EventId(result.into())
+    }
+}
+
+impl fmt::Display for EventId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let base58_string = bs58::encode(&self.0).into_string();
+        write!(f, "evt:{}", &base58_string[0..8])
+    }
+}

--- a/packages/ciphernode/events/src/eventbus.rs
+++ b/packages/ciphernode/events/src/eventbus.rs
@@ -1,9 +1,9 @@
 use actix::prelude::*;
 use std::collections::{HashMap, HashSet};
 
-use crate::{EnclaveError, EnclaveErrorType};
+use crate::{EnclaveError, EnclaveErrorType, EventId};
 
-use super::events::{EnclaveEvent, EventId, FromError};
+use super::enclave_event::{EnclaveEvent, FromError};
 
 #[derive(Message, Debug)]
 #[rtype(result = "()")]

--- a/packages/ciphernode/events/src/lib.rs
+++ b/packages/ciphernode/events/src/lib.rs
@@ -1,9 +1,15 @@
+mod e3id;
+mod enclave_event;
+mod event_id;
 mod eventbus;
-mod events;
 mod ordered_set;
+mod seed;
 mod tag;
 
+pub use e3id::*;
+pub use enclave_event::*;
+pub use event_id::*;
 pub use eventbus::*;
-pub use events::*;
 pub use ordered_set::*;
+pub use seed::*;
 pub use tag::*;

--- a/packages/ciphernode/events/src/seed.rs
+++ b/packages/ciphernode/events/src/seed.rs
@@ -1,0 +1,30 @@
+use alloy::hex;
+use alloy_primitives::Uint;
+use serde::{Deserialize, Serialize};
+use std::fmt::{self, Display};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct Seed(pub [u8; 32]);
+impl From<Seed> for u64 {
+    fn from(value: Seed) -> Self {
+        u64::from_le_bytes(value.0[..8].try_into().unwrap())
+    }
+}
+
+impl From<Seed> for [u8; 32] {
+    fn from(value: Seed) -> Self {
+        value.0
+    }
+}
+
+impl From<Uint<256, 4>> for Seed {
+    fn from(value: Uint<256, 4>) -> Self {
+        Seed(value.to_le_bytes())
+    }
+}
+
+impl Display for Seed {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Seed(0x{})", hex::encode(self.0))
+    }
+}


### PR DESCRIPTION
- Extract events out to their own files
- Use macro to remove some boilerplate from `enclave_event`

Note: It would be possible to use macros to magic away the boilerplate around `enclave_event` but I don't think it is wise as it makes it harder to grok what is happening when you are new to the codebase  