### PR TITLE
Ensure nodes can find each other when using a VPN

### DIFF
--- a/tests/integration/lib/ag/config.yaml
+++ b/tests/integration/lib/ag/config.yaml
@@ -3,6 +3,11 @@ data_dir: .
 address: "0x8626a6940E2eb28930eFb4CeF49B2d1F2C9C1199"
 quic_port: 9095
 enable_mdns: true
+peers:
+  - "/ip4/127.0.0.1/udp/9091/quic-v1"
+  - "/ip4/127.0.0.1/udp/9092/quic-v1"
+  - "/ip4/127.0.0.1/udp/9093/quic-v1"
+  - "/ip4/127.0.0.1/udp/9094/quic-v1"
 chains:
   - name: "hardhat"
     rpc_url: "ws://localhost:8545"

--- a/tests/integration/lib/cn1/config.yaml
+++ b/tests/integration/lib/cn1/config.yaml
@@ -3,6 +3,11 @@ data_dir: .
 address: "0x2546BcD3c84621e976D8185a91A922aE77ECEc30"
 quic_port: 9091
 enable_mdns: true
+peers:
+  - "/ip4/127.0.0.1/udp/9092/quic-v1"
+  - "/ip4/127.0.0.1/udp/9093/quic-v1"
+  - "/ip4/127.0.0.1/udp/9094/quic-v1"
+  - "/ip4/127.0.0.1/udp/9095/quic-v1"
 chains:
   - name: "hardhat"
     rpc_url: "ws://localhost:8545"

--- a/tests/integration/lib/cn2/config.yaml
+++ b/tests/integration/lib/cn2/config.yaml
@@ -3,6 +3,11 @@ data_dir: .
 address: "0xbDA5747bFD65F08deb54cb465eB87D40e51B197E"
 quic_port: 9092
 enable_mdns: true
+peers:
+  - "/ip4/127.0.0.1/udp/9091/quic-v1"
+  - "/ip4/127.0.0.1/udp/9093/quic-v1"
+  - "/ip4/127.0.0.1/udp/9094/quic-v1"
+  - "/ip4/127.0.0.1/udp/9095/quic-v1"
 chains:
   - name: "hardhat"
     rpc_url: "ws://localhost:8545"

--- a/tests/integration/lib/cn3/config.yaml
+++ b/tests/integration/lib/cn3/config.yaml
@@ -3,6 +3,11 @@ data_dir: .
 address: "0xdD2FD4581271e230360230F9337D5c0430Bf44C0"
 quic_port: 9093
 enable_mdns: true
+peers:
+  - "/ip4/127.0.0.1/udp/9091/quic-v1"
+  - "/ip4/127.0.0.1/udp/9092/quic-v1"
+  - "/ip4/127.0.0.1/udp/9094/quic-v1"
+  - "/ip4/127.0.0.1/udp/9095/quic-v1"
 chains:
   - name: "hardhat"
     rpc_url: "ws://localhost:8545"

--- a/tests/integration/lib/cn4/config.yaml
+++ b/tests/integration/lib/cn4/config.yaml
@@ -3,6 +3,11 @@ data_dir: .
 address: "0x8626f6940E2eb28930eFb4CeF49B2d1F2C9C1199"
 quic_port: 9094
 enable_mdns: true
+peers:
+  - "/ip4/127.0.0.1/udp/9091/quic-v1"
+  - "/ip4/127.0.0.1/udp/9092/quic-v1"
+  - "/ip4/127.0.0.1/udp/9093/quic-v1"
+  - "/ip4/127.0.0.1/udp/9095/quic-v1"
 chains:
   - name: "hardhat"
     rpc_url: "ws://localhost:8545"


### PR DESCRIPTION
Closes: #310 

Found after munch constirnation that mDNS doesn't work over a VPN so setting the peers in the peer list will get the network going for the test.

This PR enables local integration tests to now work locally even when you are connected to a VPN.

![image](https://github.com/user-attachments/assets/13a75bfc-72be-4e48-880f-a06295e56769)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded network configuration options by introducing a dedicated section for specifying multiple peer connection endpoints using the QUIC protocol.
  - Added several peer addresses, each with unique UDP port settings, enhancing flexibility for network communications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->