### PR TITLE
`autopassword`, `autonetkey` & `autowallet`

### DIFF
--- a/examples/CRISP/enclave.config.yaml
+++ b/examples/CRISP/enclave.config.yaml
@@ -10,14 +10,22 @@ nodes:
   cn1:
     address: "0xbDA5747bFD65F08deb54cb465eB87D40e51B197E"
     quic_port: 9201
+    autonetkey: true
+    autopassword: true
   cn2:
     address: "0xdD2FD4581271e230360230F9337D5c0430Bf44C0"
     quic_port: 9202
+    autonetkey: true
+    autopassword: true
   cn3:
     address: "0x2546BcD3c84621e976D8185a91A922aE77ECEc30"
     quic_port: 9203
+    autonetkey: true
+    autopassword: true
   ag:
     address: "0x8626f6940E2eb28930eFb4CeF49B2d1F2C9C1199"
     quic_port: 9094
+    autonetkey: true
+    autopassword: true
     role:
       type: aggregator

--- a/examples/CRISP/scripts/tasks/dev_cipher.sh
+++ b/examples/CRISP/scripts/tasks/dev_cipher.sh
@@ -2,7 +2,6 @@
 
 set -euo pipefail
 
-PASSWORD="This is a password"
 PRIVATE_KEY="0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
 
 enclave wallet set --name ag --private-key "$PRIVATE_KEY" 

--- a/examples/CRISP/scripts/tasks/dev_cipher.sh
+++ b/examples/CRISP/scripts/tasks/dev_cipher.sh
@@ -5,16 +5,6 @@ set -euo pipefail
 PASSWORD="This is a password"
 PRIVATE_KEY="0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
 
-
-# TODO: automate this
-enclave password create --name cn1 --password "$PASSWORD"
-enclave password create --name cn2 --password "$PASSWORD"
-enclave password create --name cn3 --password "$PASSWORD"
-enclave password create --name ag --password "$PASSWORD"
-enclave net generate-key --name cn1
-enclave net generate-key --name cn2
-enclave net generate-key --name cn3
-enclave net generate-key --name ag
 enclave wallet set --name ag --private-key "$PRIVATE_KEY" 
 
 enclave nodes up -v

--- a/packages/ciphernode/Cargo.lock
+++ b/packages/ciphernode/Cargo.lock
@@ -2490,6 +2490,7 @@ dependencies = [
  "events",
  "evm",
  "fhe 0.1.0",
+ "hex",
  "keyshare",
  "libp2p",
  "logger",

--- a/packages/ciphernode/Cargo.lock
+++ b/packages/ciphernode/Cargo.lock
@@ -2141,8 +2141,10 @@ dependencies = [
  "async-trait",
  "bincode",
  "events",
+ "once_cell",
  "serde",
  "sled",
+ "tempfile",
  "tracing",
 ]
 

--- a/packages/ciphernode/Cargo.lock
+++ b/packages/ciphernode/Cargo.lock
@@ -2606,7 +2606,7 @@ dependencies = [
  "bincode",
  "bs58",
  "futures-util",
- "lazy_static",
+ "once_cell",
  "serde",
  "sha2",
 ]

--- a/packages/ciphernode/Cargo.toml
+++ b/packages/ciphernode/Cargo.toml
@@ -60,6 +60,7 @@ lazy_static = "1.5.0"
 logger = { path = "./logger" }
 num = "0.4.3"
 net = { path = "./net" }
+once_cell = "1.19.0"
 opentelemetry = { version = "0.29.1" }
 opentelemetry-otlp = { version = "0.29.0", features = ["grpc-tonic"] }
 opentelemetry_sdk = "0.29.0"

--- a/packages/ciphernode/data/Cargo.toml
+++ b/packages/ciphernode/data/Cargo.toml
@@ -14,4 +14,5 @@ sled = { workspace = true }
 bincode = { workspace = true }
 tracing = { workspace = true }
 async-trait = { workspace = true }
-
+once_cell = { workspace = true }
+tempfile = { workspace = true }

--- a/packages/ciphernode/data/src/data_store.rs
+++ b/packages/ciphernode/data/src/data_store.rs
@@ -116,14 +116,14 @@ impl DataStore {
     }
 
     /// Writes data syncronously to the scope location
-    pub fn write_sync<T: Serialize>(&self, value: T) -> Result<()> {
+    pub async fn write_sync<T: Serialize>(&self, value: T) -> Result<()> {
         let serialized = bincode::serialize(&value).with_context(|| {
             let str_key = self.get_scope().unwrap_or(Cow::Borrowed("<bad key>"));
             anyhow!("Could not serialize value passed to {}", str_key)
         })?;
 
         let msg = InsertSync::new(&self.scope, serialized);
-        self.insert_sync.try_send(msg)?;
+        self.insert_sync.send(msg).await??;
         Ok(())
     }
 

--- a/packages/ciphernode/data/src/data_store.rs
+++ b/packages/ciphernode/data/src/data_store.rs
@@ -2,6 +2,8 @@ use std::borrow::Cow;
 
 use crate::{InMemStore, IntoKey, SledStore};
 use actix::{Addr, Message, Recipient};
+use anyhow::anyhow;
+use anyhow::Context;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use tracing::error;
@@ -20,6 +22,29 @@ impl Insert {
 
     pub fn value(&self) -> &Vec<u8> {
         &self.1
+    }
+}
+
+#[derive(Message, Clone, Debug, PartialEq, Eq, Hash)]
+#[rtype(result = "Result<()>")]
+pub struct InsertSync(pub Vec<u8>, pub Vec<u8>);
+impl InsertSync {
+    pub fn new<K: IntoKey>(key: K, value: Vec<u8>) -> Self {
+        Self(key.into_key(), value)
+    }
+
+    pub fn key(&self) -> &Vec<u8> {
+        &self.0
+    }
+
+    pub fn value(&self) -> &Vec<u8> {
+        &self.1
+    }
+}
+
+impl From<InsertSync> for Insert {
+    fn from(value: InsertSync) -> Self {
+        Insert::new(value.key(), value.value().clone())
     }
 }
 
@@ -56,6 +81,7 @@ pub struct DataStore {
     scope: Vec<u8>,
     get: Recipient<Get>,
     insert: Recipient<Insert>,
+    insert_sync: Recipient<InsertSync>,
     remove: Recipient<Remove>,
 }
 
@@ -87,6 +113,18 @@ impl DataStore {
         };
         let msg = Insert::new(&self.scope, serialized);
         self.insert.do_send(msg)
+    }
+
+    /// Writes data syncronously to the scope location
+    pub fn write_sync<T: Serialize>(&self, value: T) -> Result<()> {
+        let serialized = bincode::serialize(&value).with_context(|| {
+            let str_key = self.get_scope().unwrap_or(Cow::Borrowed("<bad key>"));
+            anyhow!("Could not serialize value passed to {}", str_key)
+        })?;
+
+        let msg = InsertSync::new(&self.scope, serialized);
+        self.insert_sync.try_send(msg)?;
+        Ok(())
     }
 
     /// Removes data from the scope location
@@ -128,6 +166,7 @@ impl DataStore {
         Self {
             get: self.get.clone(),
             insert: self.insert.clone(),
+            insert_sync: self.insert_sync.clone(),
             remove: self.remove.clone(),
             scope,
         }
@@ -137,6 +176,7 @@ impl DataStore {
         Self {
             get: self.get.clone(),
             insert: self.insert.clone(),
+            insert_sync: self.insert_sync.clone(),
             remove: self.remove.clone(),
             scope: key.into_key(),
         }
@@ -148,6 +188,7 @@ impl From<&Addr<SledStore>> for DataStore {
         Self {
             get: addr.clone().recipient(),
             insert: addr.clone().recipient(),
+            insert_sync: addr.clone().recipient(),
             remove: addr.clone().recipient(),
             scope: vec![],
         }
@@ -159,6 +200,7 @@ impl From<&Addr<InMemStore>> for DataStore {
         Self {
             get: addr.clone().recipient(),
             insert: addr.clone().recipient(),
+            insert_sync: addr.clone().recipient(),
             remove: addr.clone().recipient(),
             scope: vec![],
         }

--- a/packages/ciphernode/data/src/in_mem.rs
+++ b/packages/ciphernode/data/src/in_mem.rs
@@ -1,7 +1,7 @@
+use crate::{Get, Insert, InsertSync, Remove};
 use actix::{Actor, Context, Handler, Message};
+use anyhow::Result;
 use std::collections::BTreeMap;
-
-use crate::{Get, Insert, Remove};
 
 #[derive(Message, Clone, Debug, PartialEq, Eq, Hash)]
 #[rtype(result = "Vec<DataOp>")]
@@ -42,6 +42,18 @@ impl Handler<Insert> for InMemStore {
         if self.capture {
             self.log.push(DataOp::Insert(event));
         }
+    }
+}
+
+impl Handler<InsertSync> for InMemStore {
+    type Result = Result<()>;
+
+    fn handle(&mut self, event: InsertSync, _: &mut Self::Context) -> Self::Result {
+        self.db.insert(event.key().to_vec(), event.value().to_vec());
+        if self.capture {
+            self.log.push(DataOp::Insert(event.into()));
+        }
+        Ok(())
     }
 }
 

--- a/packages/ciphernode/data/src/repository.rs
+++ b/packages/ciphernode/data/src/repository.rs
@@ -58,6 +58,10 @@ where
         self.store.write(value)
     }
 
+    pub async fn write_sync(&self, value: &T) -> Result<()> {
+        self.store.write_sync(value).await
+    }
+
     pub fn clear(&self) {
         self.store.write::<Option<T>>(None)
     }

--- a/packages/ciphernode/data/src/sled_store.rs
+++ b/packages/ciphernode/data/src/sled_store.rs
@@ -1,4 +1,4 @@
-use crate::{Get, Insert, Remove};
+use crate::{Get, Insert, InsertSync, Remove};
 use actix::{Actor, ActorContext, Addr, Handler};
 use anyhow::{Context, Result};
 use events::{BusError, EnclaveErrorType, EnclaveEvent, EventBus, EventBusConfig, Subscribe};
@@ -58,6 +58,18 @@ impl Handler<Insert> for SledStore {
                 _ => (),
             }
         }
+    }
+}
+
+impl Handler<InsertSync> for SledStore {
+    type Result = Result<()>;
+
+    fn handle(&mut self, event: InsertSync, _: &mut Self::Context) -> Self::Result {
+        if let Some(ref mut db) = &mut self.db {
+            db.insert(event.into())
+                .map_err(|e| anyhow::anyhow!("{}", e.to_string()))?
+        }
+        Ok(())
     }
 }
 

--- a/packages/ciphernode/data/src/sled_store.rs
+++ b/packages/ciphernode/data/src/sled_store.rs
@@ -1,10 +1,14 @@
-use std::path::PathBuf;
-
 use crate::{Get, Insert, Remove};
 use actix::{Actor, ActorContext, Addr, Handler};
 use anyhow::{Context, Result};
 use events::{BusError, EnclaveErrorType, EnclaveEvent, EventBus, EventBusConfig, Subscribe};
+use once_cell::sync::Lazy;
 use sled::Db;
+use std::{
+    collections::HashMap,
+    path::PathBuf,
+    sync::{Arc, Mutex},
+};
 use tracing::{error, info};
 
 pub struct SledStore {
@@ -19,7 +23,7 @@ impl Actor for SledStore {
 impl SledStore {
     pub fn new(bus: &Addr<EventBus<EnclaveEvent>>, path: &PathBuf) -> Result<Addr<Self>> {
         info!("Starting SledStore");
-        let db = SledDb::new(path)?;
+        let db = SledDb::new(PathBuf::from(path))?;
 
         let store = Self {
             db: Some(db),
@@ -103,14 +107,38 @@ pub struct SledDb {
     db: Db,
 }
 
+// Global static cache
+pub static SLED_CACHE: Lazy<Arc<Mutex<HashMap<String, Db>>>> =
+    Lazy::new(|| Arc::new(Mutex::new(HashMap::new())));
+
+fn get_cached_db(path: &PathBuf) -> Option<Db> {
+    let key = path.to_string_lossy().to_string();
+    let cache_lock = SLED_CACHE.lock().unwrap();
+    let maybe_db = cache_lock.get(&key).cloned();
+    maybe_db
+}
+
+fn set_cached_db(path: PathBuf, db: Db) {
+    let key = path.to_string_lossy().to_string();
+    let mut cache_lock = SLED_CACHE.lock().unwrap();
+    cache_lock.insert(key, db);
+}
+
 impl SledDb {
-    pub fn new(path: &PathBuf) -> Result<Self> {
-        let db = sled::open(path).with_context(|| {
+    pub fn new(path: PathBuf) -> Result<Self> {
+        let maybe_db = get_cached_db(&path);
+        if let Some(db) = maybe_db {
+            return Ok(Self { db });
+        };
+
+        let db = sled::open(&path).with_context(|| {
             format!(
                 "Could not open database at path '{}'",
                 path.to_string_lossy()
             )
         })?;
+
+        set_cached_db(path, db.clone());
         Ok(Self { db })
     }
 
@@ -138,5 +166,75 @@ impl SledDb {
             .context(format!("Failed to fetch {}", str_key))?;
 
         Ok(res.map(|v| v.to_vec()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sled_db_caching() -> Result<()> {
+        use tempfile::tempdir;
+
+        // Section 1: Test basic cache functionality
+        let temp_dir = tempdir().expect("Failed to create temporary directory");
+        let db_path = temp_dir.path().join("test_cache.db");
+
+        // Create first instance and insert data
+        let mut db1 = SledDb::new(db_path.clone())?;
+        db1.insert(Insert::new(b"test_key".to_vec(), b"test_value".to_vec()))?;
+
+        // Create second instance to same path and verify data access
+        let mut db2 = SledDb::new(db_path.clone())?;
+        let result = db2.get(Get::new(b"test_key".to_vec()))?;
+        assert_eq!(
+            result.unwrap(),
+            b"test_value".to_vec(),
+            "Values from db2 should match"
+        );
+
+        // Cross-modify and verify (db1 writes, db2 reads)
+        db1.insert(Insert::new(b"key2".to_vec(), b"value2".to_vec()))?;
+        assert_eq!(
+            db2.get(Get::new(b"key2".to_vec()))?.unwrap(),
+            b"value2".to_vec(),
+            "db2 should see changes from db1"
+        );
+
+        // Section 2: Test cross-instance operations (db2 writes, db1 reads)
+        db2.insert(Insert::new(b"key3".to_vec(), b"value3".to_vec()))?;
+        assert_eq!(
+            db1.get(Get::new(b"key3".to_vec()))?.unwrap(),
+            b"value3".to_vec(),
+            "db1 should see changes from db2"
+        );
+
+        // Section 3: Test cache with different path
+        let second_path = temp_dir.path().join("different_cache.db");
+        let mut db3 = SledDb::new(second_path.clone())?;
+        db3.insert(Insert::new(b"db3_key".to_vec(), b"db3_value".to_vec()))?;
+
+        // Create another instance to the second path
+        let mut db4 = SledDb::new(second_path)?;
+        assert_eq!(
+            db4.get(Get::new(b"db3_key".to_vec()))?.unwrap(),
+            b"db3_value".to_vec(),
+            "db4 should see db3's data"
+        );
+
+        // Verify first path data isn't in second path
+        assert!(
+            db4.get(Get::new(b"test_key".to_vec()))?.is_none(),
+            "db4 should not see data from db1/db2"
+        );
+
+        // Verify second path data isn't in first path
+        assert!(
+            db1.get(Get::new(b"db3_key".to_vec()))?.is_none(),
+            "db1 should not see data from db3/db4"
+        );
+
+        Ok(())
     }
 }

--- a/packages/ciphernode/enclave/src/cli.rs
+++ b/packages/ciphernode/enclave/src/cli.rs
@@ -10,6 +10,7 @@ use anyhow::Result;
 use clap::{command, ArgAction, Parser, Subcommand};
 use config::validation::ValidUrl;
 use config::{load_config, AppConfig};
+use enclave_core::helpers::datastore::close_all_connections;
 use tracing::{info, instrument, Level};
 
 #[derive(Parser, Debug)]
@@ -99,6 +100,8 @@ impl Cli {
             Commands::Wallet { command } => wallet::execute(command, config).await?,
             Commands::Net { command } => net::execute(command, &config).await?,
         }
+
+        close_all_connections();
 
         Ok(())
     }

--- a/packages/ciphernode/enclave/src/cli.rs
+++ b/packages/ciphernode/enclave/src/cli.rs
@@ -11,6 +11,7 @@ use clap::{command, ArgAction, Parser, Subcommand};
 use config::validation::ValidUrl;
 use config::{load_config, AppConfig};
 use enclave_core::helpers::datastore::close_all_connections;
+use enclave_core::{net_generate, password_create, wallet_set};
 use tracing::{info, instrument, Level};
 
 #[derive(Parser, Debug)]
@@ -71,8 +72,20 @@ impl Cli {
     pub async fn execute(self) -> Result<()> {
         let config = self.load_config()?;
         setup_tracing(&config, self.log_level())?;
-
         info!("Config loaded from: {:?}", config.config_file());
+
+        if config.autopassword() {
+            password_create::autopassword(&config).await?;
+        }
+
+        if config.autonetkey() {
+            net_generate::autonetkey(&config).await?;
+        }
+
+        if config.autowallet() {
+            wallet_set::autowallet(&config).await?;
+        }
+
         match self.command {
             Commands::Start { peers } => start::execute(config, peers).await?,
             Commands::Init {

--- a/packages/ciphernode/enclave/src/start.rs
+++ b/packages/ciphernode/enclave/src/start.rs
@@ -18,18 +18,6 @@ pub async fn execute(mut config: AppConfig, peers: Vec<String>) -> Result<()> {
     // add cli peers to the config
     config.add_peers(peers);
 
-    if config.autopassword() {
-        password_create::autopassword(&config).await?;
-    }
-
-    if config.autonetkey() {
-        net_generate::autonetkey(&config).await?;
-    }
-
-    if config.autowallet() {
-        wallet_set::autowallet(&config).await?;
-    }
-
     let (bus, handle, peer_id) = match config.role() {
         // Launch in aggregator configuration
         NodeRole::Aggregator {

--- a/packages/ciphernode/enclave_core/Cargo.toml
+++ b/packages/ciphernode/enclave_core/Cargo.toml
@@ -21,6 +21,7 @@ dirs = { workspace = true }
 events = { workspace = true }
 evm = { workspace = true }
 fhe = { workspace = true }
+hex = { workspace = true }
 keyshare = { workspace = true }
 logger = { workspace = true }
 libp2p = { workspace = true }

--- a/packages/ciphernode/enclave_core/src/aggregator_start.rs
+++ b/packages/ciphernode/enclave_core/src/aggregator_start.rs
@@ -5,7 +5,7 @@ use config::AppConfig;
 use crypto::Cipher;
 use data::RepositoriesFactory;
 use e3_request::E3Router;
-use events::{EnclaveEvent, EventBus, EventBusConfig};
+use events::{get_enclave_event_bus, EnclaveEvent, EventBus, EventBusConfig};
 use evm::{
     helpers::{get_signer_from_repository, ProviderConfig},
     CiphernodeRegistryReaderRepositoryFactory, CiphernodeRegistrySol, EnclaveSol,
@@ -32,11 +32,7 @@ pub async fn execute(
     pubkey_write_path: Option<PathBuf>,
     plaintext_write_path: Option<PathBuf>,
 ) -> Result<(Addr<EventBus<EnclaveEvent>>, JoinHandle<Result<()>>, String)> {
-    let bus = EventBus::<EnclaveEvent>::new(EventBusConfig {
-        capture_history: true,
-        deduplicate: true,
-    })
-    .start();
+    let bus = get_enclave_event_bus();
     let rng = Arc::new(Mutex::new(ChaCha20Rng::from_rng(OsRng)?));
     let store = setup_datastore(config, &bus)?;
     let repositories = store.repositories();

--- a/packages/ciphernode/enclave_core/src/helpers/datastore.rs
+++ b/packages/ciphernode/enclave_core/src/helpers/datastore.rs
@@ -3,9 +3,9 @@ use std::path::PathBuf;
 use actix::{Actor, Addr};
 use anyhow::Result;
 use config::AppConfig;
-use data::{DataStore, InMemStore, SledStore};
+use data::{DataStore, InMemStore, SledDb, SledStore};
 use data::{Repositories, RepositoriesFactory};
-use events::{EnclaveEvent, EventBus};
+use events::{get_enclave_event_bus, EnclaveEvent, EventBus};
 
 pub fn get_sled_store(bus: &Addr<EventBus<EnclaveEvent>>, db_file: &PathBuf) -> Result<DataStore> {
     Ok((&SledStore::new(bus, db_file)?).into())
@@ -27,10 +27,12 @@ pub fn setup_datastore(
     Ok(store)
 }
 
-pub fn get_repositories(
-    config: &AppConfig,
-    bus: &Addr<EventBus<EnclaveEvent>>,
-) -> Result<Repositories> {
+pub fn get_repositories(config: &AppConfig) -> Result<Repositories> {
+    let bus = get_enclave_event_bus();
     let store = setup_datastore(config, &bus)?;
     Ok(store.repositories())
+}
+
+pub fn close_all_connections() {
+    SledDb::close_all_connections();
 }

--- a/packages/ciphernode/enclave_core/src/helpers/mod.rs
+++ b/packages/ciphernode/enclave_core/src/helpers/mod.rs
@@ -1,4 +1,5 @@
 pub mod datastore;
+pub mod rand;
 pub mod shutdown;
 pub mod swarm;
 pub mod swarm_client;

--- a/packages/ciphernode/enclave_core/src/helpers/rand.rs
+++ b/packages/ciphernode/enclave_core/src/helpers/rand.rs
@@ -1,0 +1,7 @@
+use rand::{thread_rng, RngCore};
+
+pub fn generate_random_bytes(len: usize) -> Vec<u8> {
+    let mut bytes = vec![0u8; len];
+    thread_rng().fill_bytes(&mut bytes);
+    bytes
+}

--- a/packages/ciphernode/enclave_core/src/net_generate.rs
+++ b/packages/ciphernode/enclave_core/src/net_generate.rs
@@ -19,3 +19,11 @@ pub async fn execute(config: &AppConfig) -> Result<PeerId> {
 
     Ok(peer_id)
 }
+
+pub async fn autonetkey(config: &AppConfig) -> Result<()> {
+    let repositories = get_repositories(config)?;
+    if !repositories.libp2p_keypair().has().await {
+        execute(config).await?;
+    }
+    Ok(())
+}

--- a/packages/ciphernode/enclave_core/src/net_generate.rs
+++ b/packages/ciphernode/enclave_core/src/net_generate.rs
@@ -1,8 +1,6 @@
-use actix::Actor;
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use config::AppConfig;
 use crypto::Cipher;
-use events::{EnclaveEvent, EventBus, EventBusConfig, GetErrors};
 use libp2p::{identity::Keypair, PeerId};
 use net::NetRepositoryFactory;
 use zeroize::Zeroize;
@@ -15,17 +13,9 @@ pub async fn execute(config: &AppConfig) -> Result<PeerId> {
     let mut bytes = kp.try_into_ed25519()?.to_bytes().to_vec();
     let cipher = Cipher::from_config(config).await?;
     let encrypted = cipher.encrypt_data(&mut bytes.clone())?;
-    let bus = EventBus::<EnclaveEvent>::new(EventBusConfig {
-        capture_history: true,
-        deduplicate: true,
-    })
-    .start();
-    let repositories = get_repositories(&config, &bus)?;
+    let repositories = get_repositories(config)?;
     bytes.zeroize();
-    repositories.libp2p_keypair().write(&encrypted);
-    if let Some(error) = bus.send(GetErrors::<EnclaveEvent>::new()).await?.first() {
-        return Err(anyhow!(error.clone()));
-    }
+    repositories.libp2p_keypair().write_sync(&encrypted).await?;
 
     Ok(peer_id)
 }

--- a/packages/ciphernode/enclave_core/src/net_purge.rs
+++ b/packages/ciphernode/enclave_core/src/net_purge.rs
@@ -1,17 +1,10 @@
 use crate::helpers::datastore::get_repositories;
-use actix::Actor;
 use anyhow::*;
 use config::AppConfig;
-use events::{EnclaveEvent, EventBus, EventBusConfig};
 use net::NetRepositoryFactory;
 
 pub async fn execute(config: &AppConfig) -> Result<()> {
-    let bus = EventBus::<EnclaveEvent>::new(EventBusConfig {
-        capture_history: true,
-        deduplicate: true,
-    })
-    .start();
-    let repositories = get_repositories(&config, &bus)?;
+    let repositories = get_repositories(config)?;
     repositories.libp2p_keypair().clear();
     Ok(())
 }

--- a/packages/ciphernode/enclave_core/src/net_set.rs
+++ b/packages/ciphernode/enclave_core/src/net_set.rs
@@ -1,9 +1,7 @@
-use actix::Actor;
 use alloy::primitives::hex;
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use config::AppConfig;
 use crypto::Cipher;
-use events::{EnclaveEvent, EventBus, EventBusConfig, GetErrors};
 use libp2p::identity::Keypair;
 use net::NetRepositoryFactory;
 
@@ -24,19 +22,7 @@ pub async fn execute(config: &AppConfig, value: String) -> Result<()> {
     let mut secret = kp.try_into_ed25519()?.to_bytes().to_vec();
     let cipher = Cipher::from_config(config).await?;
     let encrypted = cipher.encrypt_data(&mut secret)?;
-
-    // TODO: Tighten this up by removing external use of bus as it is confusing
-    let bus = EventBus::<EnclaveEvent>::new(EventBusConfig {
-        capture_history: true,
-        deduplicate: true,
-    })
-    .start();
-    let repositories = get_repositories(&config, &bus)?;
-    repositories.libp2p_keypair().write(&encrypted);
-
-    if let Some(error) = bus.send(GetErrors::<EnclaveEvent>::new()).await?.first() {
-        return Err(anyhow!(error.clone()));
-    }
-
+    let repositories = get_repositories(config)?;
+    repositories.libp2p_keypair().write_sync(&encrypted).await?;
     Ok(())
 }

--- a/packages/ciphernode/enclave_core/src/password_create.rs
+++ b/packages/ciphernode/enclave_core/src/password_create.rs
@@ -3,6 +3,8 @@ use config::AppConfig;
 use crypto::{FilePasswordManager, PasswordManager};
 use zeroize::Zeroizing;
 
+use crate::helpers::rand::generate_random_bytes;
+
 pub async fn preflight(config: &AppConfig, overwrite: bool) -> Result<()> {
     let key_file = config.key_file();
     let pm = FilePasswordManager::new(key_file);
@@ -24,5 +26,15 @@ pub async fn execute(config: &AppConfig, pw: Zeroizing<Vec<u8>>, overwrite: bool
 
     pm.set_key(pw).await?;
 
+    Ok(())
+}
+
+pub async fn autopassword(config: &AppConfig) -> Result<()> {
+    let key_file = config.key_file();
+    let pm = FilePasswordManager::new(key_file);
+    if !pm.is_set() {
+        let pw = generate_random_bytes(128);
+        execute(config, pw.into(), false).await?;
+    }
     Ok(())
 }

--- a/packages/ciphernode/enclave_core/src/start.rs
+++ b/packages/ciphernode/enclave_core/src/start.rs
@@ -5,7 +5,8 @@ use config::AppConfig;
 use crypto::Cipher;
 use data::RepositoriesFactory;
 use e3_request::E3Router;
-use events::{EnclaveEvent, EventBus, EventBusConfig};
+use events::get_enclave_event_bus;
+use events::{EnclaveEvent, EventBus};
 use evm::{
     helpers::ProviderConfig, CiphernodeRegistryReaderRepositoryFactory, CiphernodeRegistrySol,
     EnclaveSolReader, EnclaveSolReaderRepositoryFactory,
@@ -31,11 +32,8 @@ pub async fn execute(
     address: Address,
 ) -> Result<(Addr<EventBus<EnclaveEvent>>, JoinHandle<Result<()>>, String)> {
     let rng = Arc::new(Mutex::new(rand_chacha::ChaCha20Rng::from_rng(OsRng)?));
-    let bus = EventBus::<EnclaveEvent>::new(EventBusConfig {
-        capture_history: true,
-        deduplicate: true,
-    })
-    .start();
+
+    let bus = get_enclave_event_bus();
     let cipher = Arc::new(Cipher::from_config(&config).await?);
     let store = setup_datastore(&config, &bus)?;
 

--- a/packages/ciphernode/enclave_core/src/wallet_set.rs
+++ b/packages/ciphernode/enclave_core/src/wallet_set.rs
@@ -4,7 +4,7 @@ use config::AppConfig;
 use crypto::Cipher;
 use evm::EthPrivateKeyRepositoryFactory;
 
-use crate::helpers::datastore::get_repositories;
+use crate::helpers::{datastore::get_repositories, rand::generate_random_bytes};
 
 pub fn validate_private_key(input: &String) -> Result<()> {
     let bytes =
@@ -22,5 +22,12 @@ pub async fn execute(config: &AppConfig, input: String) -> Result<()> {
         .eth_private_key()
         .write_sync(&encrypted)
         .await?;
+    Ok(())
+}
+
+pub async fn autowallet(config: &AppConfig) -> Result<()> {
+    let bytes = generate_random_bytes(128);
+    let input = hex::encode(&bytes);
+    execute(config, input).await?;
     Ok(())
 }

--- a/packages/ciphernode/events/Cargo.toml
+++ b/packages/ciphernode/events/Cargo.toml
@@ -19,4 +19,4 @@ alloy = { workspace = true }
 alloy-primitives = { workspace = true }
 alloy-sol-types = { workspace = true }
 anyhow = { workspace = true }
-lazy_static = { workspace = true }
+once_cell = { workspace = true }

--- a/packages/ciphernode/events/src/eventbus.rs
+++ b/packages/ciphernode/events/src/eventbus.rs
@@ -9,7 +9,7 @@ use std::marker::PhantomData;
 
 /// Trait that must be implemented by events used with EventBus
 pub trait Event: Message<Result = ()> + Clone + Send + Sync + Unpin + 'static {
-    type Id: Hash + Eq + Clone + Unpin;
+    type Id: Hash + Eq + Clone + Unpin + Send + Sync;
     fn event_type(&self) -> String;
     fn event_id(&self) -> Self::Id;
 }

--- a/packages/ciphernode/events/src/eventbus_factory.rs
+++ b/packages/ciphernode/events/src/eventbus_factory.rs
@@ -1,0 +1,57 @@
+use actix::Actor;
+use actix::Addr;
+use once_cell::sync::Lazy;
+use std::any::Any;
+use std::any::TypeId;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use crate::EnclaveEvent;
+use crate::Event;
+use crate::EventBus;
+use crate::EventBusConfig;
+
+// The singleton factory using once_cell
+pub struct EventBusFactory {
+    instances: Mutex<HashMap<TypeId, Box<dyn Any + Send + Sync>>>,
+}
+
+impl EventBusFactory {
+    // Get the singleton instance of the factory
+    pub fn instance() -> &'static EventBusFactory {
+        static INSTANCE: Lazy<EventBusFactory> = Lazy::new(|| EventBusFactory {
+            instances: Mutex::new(HashMap::new()),
+        });
+
+        &INSTANCE
+    }
+
+    // Get or create a singleton EventBus for the specific event type
+    pub fn get_event_bus<E: Event>(&self, config: EventBusConfig) -> Addr<EventBus<E>> {
+        let type_id = TypeId::of::<E>();
+        let mut instances = self.instances.lock().unwrap();
+
+        // If we already have this type of EventBus, return it
+        if let Some(instance) = instances.get(&type_id) {
+            return instance
+                .downcast_ref::<Addr<EventBus<E>>>()
+                .expect("Type mismatch in EventBusFactory")
+                .clone();
+        }
+
+        // Create a new EventBus for this event type
+        let event_bus = EventBus::<E>::new(config).start();
+
+        // Store it in our HashMap
+        instances.insert(type_id, Box::new(event_bus.clone()));
+
+        event_bus
+    }
+}
+
+pub fn get_enclave_event_bus() -> Addr<EventBus<EnclaveEvent>> {
+    EventBusFactory::instance().get_event_bus::<EnclaveEvent>(EventBusConfig {
+        deduplicate: true,
+        capture_history: true,
+    })
+}

--- a/packages/ciphernode/events/src/lib.rs
+++ b/packages/ciphernode/events/src/lib.rs
@@ -2,6 +2,7 @@ mod e3id;
 mod enclave_event;
 mod event_id;
 mod eventbus;
+mod eventbus_factory;
 mod ordered_set;
 mod seed;
 
@@ -9,5 +10,6 @@ pub use e3id::*;
 pub use enclave_event::*;
 pub use event_id::*;
 pub use eventbus::*;
+pub use eventbus_factory::*;
 pub use ordered_set::*;
 pub use seed::*;

--- a/tests/integration/base.sh
+++ b/tests/integration/base.sh
@@ -16,22 +16,10 @@ until curl -f -s "http://localhost:8545" > /dev/null; do
   sleep 1
 done
 
-# Set the password for all ciphernodes
-enclave_password_create cn1 "$CIPHERNODE_SECRET"
-enclave_password_create cn2 "$CIPHERNODE_SECRET"
-enclave_password_create cn3 "$CIPHERNODE_SECRET"
-enclave_password_create cn4 "$CIPHERNODE_SECRET"
-enclave_password_create ag "$CIPHERNODE_SECRET"
+# set wallet to ag specifically
 enclave_wallet_set ag "$PRIVATE_KEY"
 
-# Set the network private key for all ciphernodes
-enclave_net_set_key cn1 "$NETWORK_PRIVATE_KEY_1"
-enclave_net_set_key cn2 "$NETWORK_PRIVATE_KEY_2"
-enclave_net_set_key cn3 "$NETWORK_PRIVATE_KEY_3"
-enclave_net_set_key cn4 "$NETWORK_PRIVATE_KEY_4"
-enclave_net_set_key ag "$NETWORK_PRIVATE_KEY_AG"
-
-# Launch 4 ciphernodes
+# start swarm
 enclave_nodes_up
 
 echo "waiting on binaries and utilities..."

--- a/tests/integration/enclave.config.yaml
+++ b/tests/integration/enclave.config.yaml
@@ -10,18 +10,28 @@ nodes:
   cn1:
     address: "0x2546BcD3c84621e976D8185a91A922aE77ECEc30"
     quic_port: 9091
+    autonetkey: true
+    autopassword: true
   cn2:
     address: "0xbDA5747bFD65F08deb54cb465eB87D40e51B197E"
     quic_port: 9092
+    autonetkey: true
+    autopassword: true
   cn3:
     address: "0xdD2FD4581271e230360230F9337D5c0430Bf44C0"
     quic_port: 9093
+    autonetkey: true
+    autopassword: true
   cn4:
     address: "0x8626f6940E2eb28930eFb4CeF49B2d1F2C9C1199"
     quic_port: 9094
+    autonetkey: true
+    autopassword: true
   ag:
     address: "0x8626f6940E2eb28930eFb4CeF49B2d1F2C9C1199"
     quic_port: 9095
+    autonetkey: true
+    autopassword: true
     role:
       type: aggregator
       pubkey_write_path: "./output/pubkey.bin"

--- a/tests/integration/persist.sh
+++ b/tests/integration/persist.sh
@@ -16,22 +16,10 @@ until curl -f -s "http://localhost:8545" > /dev/null; do
   sleep 1
 done
 
-# Set the password for all ciphernodes
-enclave_password_create cn1 "$CIPHERNODE_SECRET"
-enclave_password_create cn2 "$CIPHERNODE_SECRET"
-enclave_password_create cn3 "$CIPHERNODE_SECRET"
-enclave_password_create cn4 "$CIPHERNODE_SECRET"
-enclave_password_create ag "$CIPHERNODE_SECRET"
+# set wallet to ag specifically
 enclave_wallet_set ag "$PRIVATE_KEY"
 
-# Set the network private key for all ciphernodes
-enclave_net_set_key cn1 "$NETWORK_PRIVATE_KEY_1"
-enclave_net_set_key cn2 "$NETWORK_PRIVATE_KEY_2"
-enclave_net_set_key cn3 "$NETWORK_PRIVATE_KEY_3"
-enclave_net_set_key cn4 "$NETWORK_PRIVATE_KEY_4"
-enclave_net_set_key ag "$NETWORK_PRIVATE_KEY_AG"
-
-# Launch 4 ciphernodes
+# start swarm
 enclave_nodes_up
 
 waiton-files "$ROOT_DIR/packages/ciphernode/target/debug/enclave" "$ROOT_DIR/packages/ciphernode/target/debug/fake_encrypt"


### PR DESCRIPTION
This adds automatic generation flags that allow us to have a much smoother configuration and allow developers to be able to easily use the new `enclave nodes up` functionality

- [x] refactor datastore to use singletons to allow `write_sync` method - this was an important technical debt task we need to do to be able to be flexible with the way we write data.
- [x] add automatic flags to automatically generate keys if they don't exist

This drastically simplifies the code to run the nodes:
```bash
# Still need to set this as it is specific to the demo
enclave wallet set --name ag --private-key "$PRIVATE_KEY" 

enclave nodes up -v
```

```yaml
chains:
  - name: "hardhat"
    rpc_url: "ws://localhost:8545"
    contracts:
      enclave: "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0"
      ciphernode_registry: "0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9"
      filter_registry: "0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9"

nodes:
  cn1:
    address: "0xbDA5747bFD65F08deb54cb465eB87D40e51B197E"
    quic_port: 9201
    autonetkey: true
    autopassword: true
  cn2:
    address: "0xdD2FD4581271e230360230F9337D5c0430Bf44C0"
    quic_port: 9202
    autonetkey: true
    autopassword: true
  cn3:
    address: "0x2546BcD3c84621e976D8185a91A922aE77ECEc30"
    quic_port: 9203
    autonetkey: true
    autopassword: true
  ag:
    address: "0x8626f6940E2eb28930eFb4CeF49B2d1F2C9C1199"
    quic_port: 9094
    autonetkey: true
    autopassword: true
    role:
      type: aggregator
```