### PR TITLE
Update `rust-toolchain` for `fmt` CI bug

### DIFF
--- a/packages/ciphernode/rust-toolchain.toml
+++ b/packages/ciphernode/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "1.81"
+components = ["rustfmt"]


### PR DESCRIPTION
FIx fmt bug

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Rust toolchain configuration to include the Rust formatter tool for improved development consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->