### PR TITLE
Allow Owner to set the Guest Program IMAGE_ID & Verifer Address

### DIFF
--- a/examples/CRISP/contracts/CRISPProgram.sol
+++ b/examples/CRISP/contracts/CRISPProgram.sol
@@ -95,6 +95,12 @@ contract CRISPProgram is IE3Program, Ownable {
         imageId = _imageId;
     }
 
+    /// @notice Set the RISC Zero verifier address
+    /// @param _verifier The new RISC Zero verifier address
+    function setVerifier(IRiscZeroVerifier _verifier) external onlyOwner {
+        verifier = _verifier;
+    }
+
     /// @notice Register a Member to the semaphore group
     /// @param e3Id The E3 program ID
     /// @param identityCommitment The identity commitment

--- a/examples/CRISP/deploy/Deploy.s.sol
+++ b/examples/CRISP/deploy/Deploy.s.sol
@@ -32,6 +32,7 @@ import {ISemaphoreVerifier} from "@semaphore-protocol/contracts/interfaces/ISema
 import {CRISPCheckerFactory} from "../contracts/CRISPCheckerFactory.sol";
 import {CRISPPolicyFactory} from "../contracts/CRISPPolicyFactory.sol";
 import {CRISPInputValidatorFactory} from "../contracts/CRISPInputValidatorFactory.sol";
+import {ImageID} from "../contracts/ImageID.sol";
 
 /// @notice Deployment script for the RISC Zero starter project.
 /// @dev Use the following environment variable to control the deployment:
@@ -182,7 +183,8 @@ contract CRISPProgramDeploy is Script {
             semaphore,
             checkerFactory,
             policyFactory,
-            inputValidatorFactory
+            inputValidatorFactory,
+            ImageID.VOTING_ID
         );
         console2.log("Deployed CRISPProgram to", address(crisp));
     }


### PR DESCRIPTION
Edit: now also allows to set the verifier address after an upgrade.
---
This PR refactors the management of the RISC Zero guest program's `IMAGE_ID` within the `CRISPProgram contract` to reduce the need for contract redeployments.

Previously, the `IMAGE_ID` was defined as a constant. This meant that any change to the guest program or its deps would cause the image ID to change and would necessitate redeploying the CRISPProgram contract.

The key changes in this PR are:
- The constant IMAGE_ID has been replaced with a public state variable imageId.
- The initial value for imageId is now set via a parameter in the constructor during contract deployment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added the ability to configure and update the image ID and verifier address at runtime, restricted to the contract owner.

- **Improvements**
	- The image ID used in proof verification is now dynamic and can be modified after deployment, providing greater flexibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->