### PR TITLE
Remove redundant peers and simplify aggregator startup

### DIFF
--- a/deploy/agg.yaml
+++ b/deploy/agg.yaml
@@ -1,11 +1,12 @@
 node:
   address: "${ADDRESS}"
   quic_port: ${QUIC_PORT}
+  role:
+    type: aggregator
   peers:
     - "/dns4/cn1/udp/9091/quic-v1"
     - "/dns4/cn2/udp/9092/quic-v1"
     - "/dns4/cn3/udp/9093/quic-v1"
-    - "/dns4/aggregator/udp/9094/quic-v1"
 chains:
   - name: "sepolia"
     rpc_url: "${RPC_URL}"

--- a/deploy/cn1.yaml
+++ b/deploy/cn1.yaml
@@ -1,11 +1,6 @@
 node:
   address: "${ADDRESS}"
   quic_port: ${QUIC_PORT}
-  peers:
-    - "/dns4/cn1/udp/9091/quic-v1"
-    - "/dns4/cn1/udp/9092/quic-v1"
-    - "/dns4/cn1/udp/9093/quic-v1"
-    - "/dns4/cn1/udp/9094/quic-v1"
 chains:
   - name: "sepolia"
     rpc_url: "${RPC_URL}"

--- a/deploy/cn2.yaml
+++ b/deploy/cn2.yaml
@@ -3,7 +3,6 @@ node:
   quic_port: ${QUIC_PORT}
   peers:
     - "/dns4/cn1/udp/9091/quic-v1"
-    - "/dns4/cn2/udp/9092/quic-v1"
     - "/dns4/cn3/udp/9093/quic-v1"
     - "/dns4/aggregator/udp/9094/quic-v1"
 chains:

--- a/deploy/cn3.yaml
+++ b/deploy/cn3.yaml
@@ -4,7 +4,6 @@ node:
   peers:
     - "/dns4/cn1/udp/9091/quic-v1"
     - "/dns4/cn2/udp/9092/quic-v1"
-    - "/dns4/cn3/udp/9093/quic-v1"
     - "/dns4/aggregator/udp/9094/quic-v1"
 chains:
   - name: "sepolia"

--- a/examples/CRISP/foundry.toml
+++ b/examples/CRISP/foundry.toml
@@ -16,6 +16,6 @@ libraries = [
 
 [profile.sepolia]
 libraries = [
-    "poseidon-solidity/PoseidonT3.sol:PoseidonT3:<ADDRESS_ON_SEPOLIA>"
+    "poseidon-solidity/PoseidonT3.sol:PoseidonT3:0x3333333C0A88F9BE4fd23ed0536F9B6c427e3B93"
 ]
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/packages/ciphernode/ciphernode-entrypoint.sh
+++ b/packages/ciphernode/ciphernode-entrypoint.sh
@@ -40,7 +40,7 @@ if [ "$AGGREGATOR" = "true" ]; then
     enclave wallet set --config "$CONFIG_FILE" --private-key "$PRIVATE_KEY"
 
     echo "Starting aggregator"
-    exec enclave aggregator start -v --config "$CONFIG_FILE"
+    exec enclave start -v --config "$CONFIG_FILE"
 else
     echo "Starting Ciphernode"
     exec enclave start -v --config "$CONFIG_FILE"


### PR DESCRIPTION
This PR:
* Removes duplicate or unnecessary `peers` entries from deployment YAMLs
* Updates the Sepolia `PoseidonT3` library address in `foundry.toml`
* Replaces `enclave aggregator start` with `enclave start` in the aggregator entrypoint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated configuration files to adjust peer lists and node roles for improved deployment settings.
	- Replaced a placeholder with a specific Ethereum address in the example configuration for better deployment accuracy.
	- Modified startup script logic to unify aggregator and non-aggregator start commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->