### PR TITLE
Create event listener for shared indexer

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Rust 1.81.0
+      - name: Install Rust 1.85.0
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.81.0
+          toolchain: 1.85.0
           override: true
 
         # We must install foundry in order to be able to test anvil

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -49,15 +49,13 @@ jobs:
       - name: "Compile the contracts and generate the TypeChain bindings"
         run: "pnpm typechain"
 
-        # Now we can check rust formatting and run tests
-      - name: Checking code format
+      - name: Checking code format sdk
         run: cd ./packages/enclave-sdk && cargo fmt -- --check
 
       - name: Run tests
         run: "pnpm sdk:test"
 
-        # Now we can check rust formatting and run tests
-      - name: Checking code format
+      - name: Checking code format ciphernode
         run: cd ./packages/ciphernode && cargo fmt -- --check
 
       - name: Run tests

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -50,13 +50,13 @@ jobs:
         run: "pnpm typechain"
 
       - name: Checking code format sdk
-        run: cd ./packages/enclave-sdk && cargo fmt -- --check
+        run: pnpm sdk:lint
 
       - name: Run tests
         run: "pnpm sdk:test"
 
       - name: Checking code format ciphernode
-        run: cd ./packages/ciphernode && cargo fmt -- --check
+        run: pnpm ciphernode:lint
 
       - name: Run tests
         run: "pnpm ciphernode:test"

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -51,6 +51,13 @@ jobs:
 
         # Now we can check rust formatting and run tests
       - name: Checking code format
+        run: cd ./packages/enclave-sdk && cargo fmt -- --check
+
+      - name: Run tests
+        run: "pnpm sdk:test"
+
+        # Now we can check rust formatting and run tests
+      - name: Checking code format
         run: cd ./packages/ciphernode && cargo fmt -- --check
 
       - name: Run tests

--- a/examples/CRISP/apps/server/Cargo.lock
+++ b/examples/CRISP/apps/server/Cargo.lock
@@ -270,6 +270,7 @@ dependencies = [
  "alloy-eips 0.8.3",
  "alloy-genesis 0.8.3",
  "alloy-network 0.8.3",
+ "alloy-node-bindings",
  "alloy-provider 0.8.3",
  "alloy-pubsub",
  "alloy-rpc-client 0.8.3",
@@ -688,6 +689,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-node-bindings"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef9849fb8bbb28f69f2cbdb4b0dac2f0e35c04f6078a00dfb8486469aed02de"
+dependencies = [
+ "alloy-genesis 0.8.3",
+ "alloy-primitives",
+ "k256",
+ "rand 0.8.5",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.12",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "alloy-primitives"
 version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -726,10 +744,14 @@ dependencies = [
  "alloy-json-rpc 0.8.3",
  "alloy-network 0.8.3",
  "alloy-network-primitives 0.8.3",
+ "alloy-node-bindings",
  "alloy-primitives",
  "alloy-pubsub",
  "alloy-rpc-client 0.8.3",
+ "alloy-rpc-types-anvil",
  "alloy-rpc-types-eth 0.8.3",
+ "alloy-signer 0.8.3",
+ "alloy-signer-local 0.8.3",
  "alloy-transport 0.8.3",
  "alloy-transport-http 0.8.3",
  "alloy-transport-ipc",
@@ -905,6 +927,18 @@ dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth 0.12.6",
  "alloy-serde 0.12.6",
+ "serde",
+]
+
+[[package]]
+name = "alloy-rpc-types-anvil"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed06bd8a5fc57b352a6cbac24eec52a4760f08ae2c1eb56ac49c8ed4b02c351"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rpc-types-eth 0.8.3",
+ "alloy-serde 0.8.3",
  "serde",
 ]
 
@@ -2849,6 +2883,8 @@ dependencies = [
  "eyre",
  "fhe",
  "fhe-traits",
+ "futures",
+ "tokio",
 ]
 
 [[package]]

--- a/examples/CRISP/apps/wasm-crypto/Cargo.lock
+++ b/examples/CRISP/apps/wasm-crypto/Cargo.lock
@@ -77,6 +77,7 @@ dependencies = [
  "alloy-core",
  "alloy-eips",
  "alloy-network",
+ "alloy-node-bindings",
  "alloy-provider",
  "alloy-pubsub",
  "alloy-rpc-client",
@@ -225,6 +226,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-genesis"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2a4cf7b70f3495788e74ce1c765260ffe38820a2a774ff4aacb62e31ea73f9"
+dependencies = [
+ "alloy-primitives",
+ "alloy-serde",
+ "alloy-trie",
+ "serde",
+]
+
+[[package]]
 name = "alloy-json-abi"
 version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -289,6 +302,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-node-bindings"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef9849fb8bbb28f69f2cbdb4b0dac2f0e35c04f6078a00dfb8486469aed02de"
+dependencies = [
+ "alloy-genesis",
+ "alloy-primitives",
+ "k256",
+ "rand",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.12",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "alloy-primitives"
 version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -327,11 +357,16 @@ dependencies = [
  "alloy-json-rpc",
  "alloy-network",
  "alloy-network-primitives",
+ "alloy-node-bindings",
  "alloy-primitives",
  "alloy-pubsub",
  "alloy-rpc-client",
+ "alloy-rpc-types-anvil",
  "alloy-rpc-types-eth",
+ "alloy-signer",
+ "alloy-signer-local",
  "alloy-transport",
+ "alloy-transport-http",
  "alloy-transport-ipc",
  "alloy-transport-ws",
  "async-stream",
@@ -343,12 +378,14 @@ dependencies = [
  "lru",
  "parking_lot",
  "pin-project",
+ "reqwest 0.12.5",
  "schnellru",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
+ "url",
  "wasmtimer",
 ]
 
@@ -367,7 +404,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
- "tower",
+ "tower 0.5.2",
  "tracing",
 ]
 
@@ -408,11 +445,12 @@ dependencies = [
  "alloy-transport-ws",
  "futures",
  "pin-project",
+ "reqwest 0.12.5",
  "serde",
  "serde_json",
  "tokio",
  "tokio-stream",
- "tower",
+ "tower 0.5.2",
  "tracing",
  "url",
  "wasmtimer",
@@ -426,6 +464,18 @@ checksum = "3410a472ce26c457e9780f708ee6bd540b30f88f1f31fdab7a11d00bd6aa1aee"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "serde",
+]
+
+[[package]]
+name = "alloy-rpc-types-anvil"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed06bd8a5fc57b352a6cbac24eec52a4760f08ae2c1eb56ac49c8ed4b02c351"
+dependencies = [
+ "alloy-primitives",
  "alloy-rpc-types-eth",
  "alloy-serde",
  "serde",
@@ -607,7 +657,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.12",
  "tokio",
- "tower",
+ "tower 0.5.2",
  "tracing",
  "url",
  "wasmtimer",
@@ -619,7 +669,12 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ed40eb1e1265b2911512f6aa1dcece9702d078f5a646730c45e39e2be00ac1c"
 dependencies = [
+ "alloy-json-rpc",
  "alloy-transport",
+ "reqwest 0.12.5",
+ "serde_json",
+ "tower 0.5.2",
+ "tracing",
  "url",
 ]
 
@@ -1626,6 +1681,8 @@ dependencies = [
  "eyre",
  "fhe",
  "fhe-traits",
+ "futures",
+ "tokio",
 ]
 
 [[package]]
@@ -1810,7 +1867,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "reqwest",
+ "reqwest 0.11.27",
  "serde",
  "serde_json",
  "syn 2.0.101",
@@ -1872,7 +1929,7 @@ checksum = "e79e5973c26d4baf0ce55520bd732314328cabe53193286671b47144145b9649"
 dependencies = [
  "chrono",
  "ethers-core",
- "reqwest",
+ "reqwest 0.11.27",
  "semver 1.0.22",
  "serde",
  "serde_json",
@@ -1897,7 +1954,7 @@ dependencies = [
  "futures-locks",
  "futures-util",
  "instant",
- "reqwest",
+ "reqwest 0.11.27",
  "serde",
  "serde_json",
  "thiserror 1.0.58",
@@ -1929,7 +1986,7 @@ dependencies = [
  "jsonwebtoken",
  "once_cell",
  "pin-project",
- "reqwest",
+ "reqwest 0.11.27",
  "serde",
  "serde_json",
  "thiserror 1.0.58",
@@ -2493,6 +2550,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http 1.3.1",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "httparse"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2516,7 +2596,7 @@ dependencies = [
  "futures-util",
  "h2",
  "http 0.2.12",
- "http-body",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -2529,6 +2609,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2536,10 +2635,30 @@ checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
  "http 0.2.12",
- "hyper",
+ "hyper 0.14.28",
  "rustls 0.21.10",
  "tokio",
  "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cde7055719c54e36e95e8719f95883f22072a48ede39db7fc17a4e1d5281e9b9"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "hyper 1.5.2",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower 0.4.13",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3677,8 +3796,8 @@ dependencies = [
  "futures-util",
  "h2",
  "http 0.2.12",
- "http-body",
- "hyper",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
  "hyper-rustls",
  "ipnet",
  "js-sys",
@@ -3702,7 +3821,42 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots 0.25.4",
- "winreg",
+ "winreg 0.50.0",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.5.2",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg 0.52.0",
 ]
 
 [[package]]
@@ -4180,6 +4334,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4350,7 +4513,7 @@ dependencies = [
  "fs2",
  "hex",
  "once_cell",
- "reqwest",
+ "reqwest 0.11.27",
  "semver 1.0.22",
  "serde",
  "serde_json",
@@ -4571,7 +4734,9 @@ dependencies = [
  "libc",
  "mio",
  "num_cpus",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.48.0",
@@ -4730,6 +4895,21 @@ dependencies = [
  "serde_spanned",
  "toml_datetime",
  "winnow 0.6.6",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -5351,6 +5531,16 @@ name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "winreg"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",

--- a/examples/CRISP/apps/wasm-crypto/Cargo.toml
+++ b/examples/CRISP/apps/wasm-crypto/Cargo.toml
@@ -13,7 +13,7 @@ fhe-traits = { git = "https://github.com/gnosisguild/fhe.rs", branch = "feature/
 fhe-math = { git = "https://github.com/gnosisguild/fhe.rs.git", branch = "feature/greco-integration" }
 fhe-util = { git = "https://github.com/gnosisguild/fhe.rs", branch = "feature/greco-integration" }
 rand = "0.8.5"
-ethers = "2.0"
+ethers = "2.0.14"
 getrandom = { version = "0.2.11", features = ["js"] }
 bincode = "1.3.3"
 enclave-sdk = { path = "../../../../packages/enclave-sdk" }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "clean": "cd packages/evm && pnpm clean",
     "compile": "pnpm evm:compile && pnpm ciphernode:build",
-    "lint": "pnpm evm:lint && pnpm ciphernode:lint",
+    "lint": "pnpm evm:lint && pnpm ciphernode:lint && pnpm sdk:lint",
     "typechain": "pnpm evm:typechain",
     "test": "pnpm evm:test && pnpm ciphernode:test",
     "test:integration": "cd ./tests/integration && ./test.sh",
@@ -24,6 +24,7 @@
     "ciphernode:test": "cd packages/ciphernode && ./scripts/test.sh",
     "ciphernode:build": "cd packages/ciphernode && cargo build --release",
     "sdk:test": "cd packages/enclave-sdk && ./scripts/test.sh",
+    "sdk:lint": "cd packages/enclave-sdk && cargo fmt -- --check",
     "preciphernode:build": "pnpm evm:compile",
     "committee:new": "cd packages/evm && pnpm committee:new",
     "committee:publish": "cd packages/evm && pnpm hardhat committee:publish",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "ciphernode:remove": "cd packages/evm && pnpm ciphernode:remove",
     "ciphernode:test": "cd packages/ciphernode && ./scripts/test.sh",
     "ciphernode:build": "cd packages/ciphernode && cargo build --release",
+    "sdk:test": "cd packages/enclave-sdk && ./scripts/test.sh",
     "preciphernode:build": "pnpm evm:compile",
     "committee:new": "cd packages/evm && pnpm committee:new",
     "committee:publish": "cd packages/evm && pnpm hardhat committee:publish",

--- a/packages/ciphernode/Cargo.lock
+++ b/packages/ciphernode/Cargo.lock
@@ -2428,6 +2428,8 @@ dependencies = [
  "eyre",
  "fhe 0.1.0-beta.7",
  "fhe-traits",
+ "futures",
+ "tokio",
 ]
 
 [[package]]

--- a/packages/enclave-sdk/Cargo.lock
+++ b/packages/enclave-sdk/Cargo.lock
@@ -56,6 +56,7 @@ dependencies = [
  "alloy-core",
  "alloy-eips",
  "alloy-network",
+ "alloy-node-bindings",
  "alloy-provider",
  "alloy-pubsub",
  "alloy-rpc-client",
@@ -206,6 +207,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-genesis"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2a4cf7b70f3495788e74ce1c765260ffe38820a2a774ff4aacb62e31ea73f9"
+dependencies = [
+ "alloy-primitives",
+ "alloy-serde",
+ "alloy-trie",
+ "serde",
+]
+
+[[package]]
 name = "alloy-json-abi"
 version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -270,6 +283,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-node-bindings"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef9849fb8bbb28f69f2cbdb4b0dac2f0e35c04f6078a00dfb8486469aed02de"
+dependencies = [
+ "alloy-genesis",
+ "alloy-primitives",
+ "k256",
+ "rand 0.8.5",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.12",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "alloy-primitives"
 version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -308,11 +338,16 @@ dependencies = [
  "alloy-json-rpc",
  "alloy-network",
  "alloy-network-primitives",
+ "alloy-node-bindings",
  "alloy-primitives",
  "alloy-pubsub",
  "alloy-rpc-client",
+ "alloy-rpc-types-anvil",
  "alloy-rpc-types-eth",
+ "alloy-signer",
+ "alloy-signer-local",
  "alloy-transport",
+ "alloy-transport-http",
  "alloy-transport-ipc",
  "alloy-transport-ws",
  "async-stream",
@@ -324,12 +359,14 @@ dependencies = [
  "lru",
  "parking_lot",
  "pin-project",
+ "reqwest",
  "schnellru",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
+ "url",
  "wasmtimer",
 ]
 
@@ -389,6 +426,7 @@ dependencies = [
  "alloy-transport-ws",
  "futures",
  "pin-project",
+ "reqwest",
  "serde",
  "serde_json",
  "tokio",
@@ -407,6 +445,18 @@ checksum = "3410a472ce26c457e9780f708ee6bd540b30f88f1f31fdab7a11d00bd6aa1aee"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "serde",
+]
+
+[[package]]
+name = "alloy-rpc-types-anvil"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed06bd8a5fc57b352a6cbac24eec52a4760f08ae2c1eb56ac49c8ed4b02c351"
+dependencies = [
+ "alloy-primitives",
  "alloy-rpc-types-eth",
  "alloy-serde",
  "serde",
@@ -600,7 +650,12 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ed40eb1e1265b2911512f6aa1dcece9702d078f5a646730c45e39e2be00ac1c"
 dependencies = [
+ "alloy-json-rpc",
  "alloy-transport",
+ "reqwest",
+ "serde_json",
+ "tower",
+ "tracing",
  "url",
 ]
 
@@ -869,7 +924,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1289,6 +1344,8 @@ dependencies = [
  "eyre",
  "fhe",
  "fhe-traits",
+ "futures",
+ "tokio",
 ]
 
 [[package]]
@@ -1690,10 +1747,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "libc",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "icu_collections"
@@ -1855,6 +1974,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2013,6 +2138,12 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
@@ -2248,7 +2379,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2666,6 +2797,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "reqwest"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-registry",
+]
+
+[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2933,6 +3100,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2979,6 +3158,15 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "signature"
@@ -3135,6 +3323,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -3244,7 +3435,9 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",
@@ -3339,6 +3532,7 @@ dependencies = [
  "futures-util",
  "pin-project-lite",
  "sync_wrapper",
+ "tokio",
  "tower-layer",
  "tower-service",
 ]
@@ -3385,6 +3579,12 @@ checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
@@ -3496,6 +3696,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]
@@ -3633,12 +3842,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd7cf3379ca1aac9eea11fba24fd7e315d621f8dfe35c8d7d2be8b793726e07d"
 
 [[package]]
+name = "windows-link"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
+name = "windows-registry"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
+dependencies = [
+ "windows-result",
+ "windows-strings",
+ "windows-targets 0.53.0",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3647,7 +3891,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3656,14 +3900,30 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -3673,10 +3933,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3685,10 +3957,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3697,10 +3981,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3709,10 +4005,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"

--- a/packages/enclave-sdk/Cargo.toml
+++ b/packages/enclave-sdk/Cargo.toml
@@ -9,6 +9,8 @@ anyhow = "1.0.86"
 fhe-traits = { git = "https://github.com/gnosisguild/fhe.rs", branch = "feature/greco-integration" }
 fhe_rs = { package = "fhe", git = "https://github.com/gnosisguild/fhe.rs", branch = "feature/greco-integration" }
 eyre = { version = "0.6.12", optional = true }
+futures = { version = "0.3.30", optional = true }
+tokio = { version = "1.38", features = ["full"], optional = true }
 
 [dependencies.alloy]
 version          = "0.8.3"
@@ -17,5 +19,12 @@ optional         = true
 
 [features]
 default = ["full"]
-full = ["alloy/full", "alloy/rpc-types-eth", "eyre"]
+full = [
+  "alloy/full", 
+  "alloy/rpc-types-eth",
+  "alloy/node-bindings",
+  "eyre",
+  "futures",
+  "tokio",
+]
 risc0 = ["alloy/dyn-abi", "alloy/rlp", "alloy/serde"]

--- a/packages/enclave-sdk/Cargo.toml
+++ b/packages/enclave-sdk/Cargo.toml
@@ -10,7 +10,7 @@ fhe-traits = { git = "https://github.com/gnosisguild/fhe.rs", branch = "feature/
 fhe_rs = { package = "fhe", git = "https://github.com/gnosisguild/fhe.rs", branch = "feature/greco-integration" }
 eyre = { version = "0.6.12", optional = true }
 futures = { version = "0.3.30", optional = true }
-tokio = { version = "1.38", features = ["full"], optional = true }
+tokio = { version = "1.37.0", optional = true }
 
 [dependencies.alloy]
 version          = "0.8.3"
@@ -25,6 +25,6 @@ full = [
   "alloy/node-bindings",
   "eyre",
   "futures",
-  "tokio",
+  "tokio/full",
 ]
 risc0 = ["alloy/dyn-abi", "alloy/rlp", "alloy/serde"]

--- a/packages/enclave-sdk/rust-toolchain.toml
+++ b/packages/enclave-sdk/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.85"
+components = ["rustfmt"]

--- a/packages/enclave-sdk/scripts/build_fixtures.sh
+++ b/packages/enclave-sdk/scripts/build_fixtures.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo "Building fixtures..."
+
+echo "{\"abi\": $(solc --abi tests/fixtures/emit_logs.sol | tail -n 1), \"bin\": \"$(solc --bin tests/fixtures/emit_logs.sol| tail -n 1)\"}" | jq '.' > tests/fixtures/emit_logs.json

--- a/packages/enclave-sdk/scripts/test.sh
+++ b/packages/enclave-sdk/scripts/test.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -e
+
+pushd ./scripts/build_fixtures.sh && popd
+
+cargo test -- $@

--- a/packages/enclave-sdk/scripts/test.sh
+++ b/packages/enclave-sdk/scripts/test.sh
@@ -2,6 +2,6 @@
 
 set -e
 
-pushd ./scripts/build_fixtures.sh && popd
+./scripts/build_fixtures.sh
 
 cargo test -- $@

--- a/packages/enclave-sdk/src/bfv/mod.rs
+++ b/packages/enclave-sdk/src/bfv/mod.rs
@@ -14,8 +14,8 @@ pub mod params {
     /// - Plaintext modulus: 1032193
     /// - Moduli: [0x3FFFFFFF000001] (provides good security level)
     pub const SET_2048_1032193_1: (usize, u64, [u64; 1]) = (
-        2048,              // degree
-        1032193,           // plaintext_modulus
+        2048,               // degree
+        1032193,            // plaintext_modulus
         [0x3FFFFFFF000001], // moduli
     );
 }

--- a/packages/enclave-sdk/src/evm/events.rs
+++ b/packages/enclave-sdk/src/evm/events.rs
@@ -1,0 +1,20 @@
+use alloy::sol;
+
+// TODO: extract these from that actual contract
+
+sol! {
+    #[derive(Debug)]
+    event E3Activated(uint256 e3Id, uint256 expiration, bytes committeePublicKey);
+
+    #[derive(Debug)]
+    event InputPublished(uint256 indexed e3Id, bytes data, uint256 inputHash, uint256 index);
+
+    #[derive(Debug)]
+    event CiphertextOutputPublished(uint256 indexed e3Id, bytes ciphertextOutput);
+
+    #[derive(Debug)]
+    event PlaintextOutputPublished(uint256 indexed e3Id, bytes plaintextOutput);
+
+    #[derive(Debug)]
+    event CommitteePublished(uint256 indexed e3Id, bytes publicKey);
+}

--- a/packages/enclave-sdk/src/evm/listener.rs
+++ b/packages/enclave-sdk/src/evm/listener.rs
@@ -40,13 +40,10 @@ impl EventListener {
             let event = log.log_decode::<E>()?.inner.data;
             handler(&event)
         });
-        println!("ADDING TO HANDLER!");
-        println!("Handler len before: {}", self.handlers.len());
         self.handlers
             .entry(signature)
             .or_insert_with(Vec::new)
             .push(wrapped_handler);
-        println!("Handler len after: {}", self.handlers.len());
     }
 
     pub async fn listen(&self) -> Result<()> {
@@ -61,7 +58,9 @@ impl EventListener {
                 if let Some(handlers) = self.handlers.get(topic0) {
                     for handler in handlers {
                         if let Err(e) = handler(&log) {
-                            println!("Error processing event 0x{:x}: {:?}", topic0, e);
+                            // We don't necessarily want logging here so just printing to stderr
+                            // for now. We can make this fancier later if we need to.
+                            eprintln!("Error processing event 0x{:x}: {:?}", topic0, e);
                         }
                     }
                 }

--- a/packages/enclave-sdk/src/evm/listener.rs
+++ b/packages/enclave-sdk/src/evm/listener.rs
@@ -1,0 +1,85 @@
+use alloy::{
+    primitives::{Address, B256},
+    providers::{Provider, ProviderBuilder, RootProvider},
+    rpc::types::{BlockNumberOrTag, Filter, Log},
+    sol_types::SolEvent,
+    transports::BoxTransport,
+};
+use eyre::Result;
+use futures::stream::StreamExt;
+use std::{collections::HashMap, sync::Arc};
+
+// Define a domain event type that's decoupled from Log
+pub trait DomainEvent: Send + Sync {
+    fn signature(&self) -> B256;
+}
+
+pub struct EventListener {
+    provider: Arc<RootProvider<BoxTransport>>,
+    filter: Filter,
+    handlers: HashMap<B256, Vec<Box<dyn Fn(&Log) -> Result<()> + Send + Sync>>>,
+}
+
+impl EventListener {
+    pub fn new(provider: Arc<RootProvider<BoxTransport>>, filter: Filter) -> Self {
+        Self {
+            provider,
+            filter,
+            handlers: HashMap::new(),
+        }
+    }
+
+    pub fn add_event_handler<E>(
+        &mut self,
+        handler: impl Fn(&E) -> Result<()> + Send + Sync + 'static,
+    ) where
+        E: SolEvent + 'static,
+    {
+        let signature = E::SIGNATURE_HASH;
+        let wrapped_handler = Box::new(move |log: &Log| -> Result<()> {
+            let event = log.log_decode::<E>()?.inner.data;
+            handler(&event)
+        });
+        println!("ADDING TO HANDLER!");
+        println!("Handler len before: {}", self.handlers.len());
+        self.handlers
+            .entry(signature)
+            .or_insert_with(Vec::new)
+            .push(wrapped_handler);
+        println!("Handler len after: {}", self.handlers.len());
+    }
+
+    pub async fn listen(&self) -> Result<()> {
+        let mut stream = self
+            .provider
+            .subscribe_logs(&self.filter)
+            .await?
+            .into_stream();
+
+        while let Some(log) = stream.next().await {
+            if let Some(topic0) = log.topic0() {
+                if let Some(handlers) = self.handlers.get(topic0) {
+                    for handler in handlers {
+                        if let Err(e) = handler(&log) {
+                            println!("Error processing event 0x{:x}: {:?}", topic0, e);
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+pub async fn create_enclave_contract_listener(
+    rpc_url: &str,
+    contract_address: &Address,
+) -> Result<EventListener> {
+    let provider = Arc::new(ProviderBuilder::new().on_builtin(rpc_url).await?);
+    let filter = Filter::new()
+        .address(contract_address.clone())
+        .from_block(BlockNumberOrTag::Latest);
+
+    Ok(EventListener::new(provider, filter))
+}

--- a/packages/enclave-sdk/src/evm/listener.rs
+++ b/packages/enclave-sdk/src/evm/listener.rs
@@ -70,16 +70,16 @@ impl EventListener {
 
         Ok(())
     }
-}
 
-pub async fn create_enclave_contract_listener(
-    rpc_url: &str,
-    contract_address: &Address,
-) -> Result<EventListener> {
-    let provider = Arc::new(ProviderBuilder::new().on_builtin(rpc_url).await?);
-    let filter = Filter::new()
-        .address(contract_address.clone())
-        .from_block(BlockNumberOrTag::Latest);
+    pub async fn create_contract_listener(
+        ws_url: &str,
+        contract_address: &Address,
+    ) -> Result<Self> {
+        let provider = Arc::new(ProviderBuilder::new().on_builtin(ws_url).await?);
+        let filter = Filter::new()
+            .address(contract_address.clone())
+            .from_block(BlockNumberOrTag::Latest);
 
-    Ok(EventListener::new(provider, filter))
+        Ok(EventListener::new(provider, filter))
+    }
 }

--- a/packages/enclave-sdk/src/evm/mod.rs
+++ b/packages/enclave-sdk/src/evm/mod.rs
@@ -1,1 +1,3 @@
 pub mod contracts;
+pub mod events;
+pub mod listener;

--- a/packages/enclave-sdk/src/indexer/indexer.rs
+++ b/packages/enclave-sdk/src/indexer/indexer.rs
@@ -1,3 +1,4 @@
+// Stub indexer
 use crate::evm::contracts::EnclaveContract;
 
 pub struct EnclaveIndexer {
@@ -5,5 +6,7 @@ pub struct EnclaveIndexer {
 }
 
 impl EnclaveIndexer {
-    pub fn start() {}
+    pub fn start() {
+        todo!();
+    }
 }

--- a/packages/enclave-sdk/src/indexer/indexer.rs
+++ b/packages/enclave-sdk/src/indexer/indexer.rs
@@ -1,0 +1,9 @@
+use crate::evm::contracts::EnclaveContract;
+
+pub struct EnclaveIndexer {
+    contract: EnclaveContract,
+}
+
+impl EnclaveIndexer {
+    pub fn start() {}
+}

--- a/packages/enclave-sdk/src/indexer/mod.rs
+++ b/packages/enclave-sdk/src/indexer/mod.rs
@@ -1,2 +1,1 @@
 mod indexer;
-// pub indexer::*;

--- a/packages/enclave-sdk/src/indexer/mod.rs
+++ b/packages/enclave-sdk/src/indexer/mod.rs
@@ -1,0 +1,2 @@
+mod indexer;
+// pub indexer::*;

--- a/packages/enclave-sdk/src/lib.rs
+++ b/packages/enclave-sdk/src/lib.rs
@@ -2,3 +2,6 @@ pub mod bfv;
 
 #[cfg(feature = "full")]
 pub mod evm;
+
+#[cfg(feature = "full")]
+pub mod indexer;

--- a/packages/enclave-sdk/tests/fixtures/.gitignore
+++ b/packages/enclave-sdk/tests/fixtures/.gitignore
@@ -1,0 +1,2 @@
+# ignore .json
+*.json

--- a/packages/enclave-sdk/tests/fixtures/emit_logs.sol
+++ b/packages/enclave-sdk/tests/fixtures/emit_logs.sol
@@ -1,0 +1,23 @@
+pragma solidity >=0.4.24;
+
+contract EmitLogs {
+    event ValueChanged(address indexed author, uint256 count, string value);
+
+    string _value;
+
+    uint256 count = 0;
+
+    constructor() {
+        _value = "";
+    }
+
+    function getValue() public view returns (string memory) {
+        return _value;
+    }
+
+    function setValue(string memory value) public {
+        count++;
+        emit ValueChanged(msg.sender, count, value);
+        _value = value;
+    }
+}

--- a/packages/enclave-sdk/tests/listener.rs
+++ b/packages/enclave-sdk/tests/listener.rs
@@ -1,0 +1,55 @@
+use alloy::{
+    node_bindings::Anvil,
+    providers::{ProviderBuilder, WsConnect},
+    sol,
+};
+use enclave_sdk::evm::listener::create_enclave_contract_listener;
+use eyre::Result;
+
+sol!(
+    #[sol(rpc)]
+    EmitLogs,
+    "tests/fixtures/emit_logs.json"
+);
+
+#[tokio::test]
+async fn listener() -> Result<()> {
+    let anvil = Anvil::new().block_time(1).try_spawn()?;
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<String>(10);
+
+    let provider = ProviderBuilder::new()
+        .on_ws(WsConnect::new(anvil.ws_endpoint()))
+        .await?;
+
+    let contract = EmitLogs::deploy(provider).await?;
+
+    let mut dispatcher =
+        create_enclave_contract_listener(&anvil.ws_endpoint(), contract.address()).await?;
+
+    dispatcher.add_event_handler::<EmitLogs::ValueChanged>(
+        move |event: &EmitLogs::ValueChanged| {
+            let _ = tx.clone().try_send(event.value.clone());
+            Ok(())
+        },
+    );
+
+    tokio::spawn(async move { dispatcher.listen().await.unwrap() });
+
+    contract
+        .setValue("hello".to_string())
+        .send()
+        .await?
+        .watch()
+        .await?;
+    contract
+        .setValue("world!".to_string())
+        .send()
+        .await?
+        .watch()
+        .await?;
+
+    assert_eq!(rx.recv().await.unwrap(), "hello");
+    assert_eq!(rx.recv().await.unwrap(), "world!");
+
+    Ok(())
+}

--- a/packages/enclave-sdk/tests/listener.rs
+++ b/packages/enclave-sdk/tests/listener.rs
@@ -3,7 +3,7 @@ use alloy::{
     providers::{ProviderBuilder, WsConnect},
     sol,
 };
-use enclave_sdk::evm::listener::create_enclave_contract_listener;
+use enclave_sdk::evm::listener::EventListener;
 use eyre::Result;
 
 sol!(
@@ -24,7 +24,7 @@ async fn listener() -> Result<()> {
     let contract = EmitLogs::deploy(provider).await?;
 
     let mut dispatcher =
-        create_enclave_contract_listener(&anvil.ws_endpoint(), contract.address()).await?;
+        EventListener::create_contract_listener(&anvil.ws_endpoint(), contract.address()).await?;
 
     dispatcher.add_event_handler::<EmitLogs::ValueChanged>(
         move |event: &EmitLogs::ValueChanged| {


### PR DESCRIPTION
So investigating the refactoring it seems clear we need an indexer component that is shared between program and server. This creates a dynamic evm event listener that forms the basis of that. This uses the code in server but makes handlers dynamic and makes it possible for clients to use this to attach multiple listeners to Enclave events.

- [ ] @hmzakhalid 
- [ ] @0xjei 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an event listener system for Ethereum-like logs, allowing asynchronous handling of contract events in the SDK.
  - Added Solidity event definitions and contract event handling capabilities.
  - Added an indexer module stub for future expansion.
  - Integrated new scripts for linting, testing, and fixture building for the SDK.
  - Provided a sample Solidity contract and related test fixtures for event-driven testing.

- **Bug Fixes**
  - None.

- **Chores**
  - Updated Rust toolchain and dependencies to newer versions.
  - Improved project structure and CI workflows to include the SDK in linting and testing processes.
  - Added `.gitignore` rules for test fixture outputs.

- **Tests**
  - Added an asynchronous test to verify event listener functionality with a local Ethereum node and smart contract events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->