### PR TITLE
Improve DataStore API mutability design

### DIFF
--- a/examples/CRISP/apps/server/src/server/blockchain/sync.rs
+++ b/examples/CRISP/apps/server/src/server/blockchain/sync.rs
@@ -1,7 +1,7 @@
 use super::events::InputPublished;
 use crate::server::{
     config::CONFIG,
-    database::{generate_emoji, get_e3, update_e3_status, GLOBAL_DB},
+    database::{db_get, db_insert, generate_emoji, get_e3, update_e3_status},
     models::{CurrentRound, E3},
 };
 use alloy::{
@@ -43,7 +43,7 @@ pub async fn sync_server() -> Result<()> {
     );
 
     // Retrieve the current round from the database.
-    let current_round = match GLOBAL_DB.get::<CurrentRound>("e3:current_round").await? {
+    let current_round = match db_get::<CurrentRound>("e3:current_round").await? {
         Some(round) => round,
         None => {
             info!("No current round found in DB. Exiting sync process. Will compute next round.");
@@ -320,7 +320,7 @@ async fn sync_e3_with_db(e3_id: U256, contract_e3: &ContractE3, vote_count: u64)
         warn!("Unexpected plaintext output format for E3 {}", e3_id);
     }
 
-    GLOBAL_DB.insert(&key, &db_e3).await?;
+    db_insert(&key, &db_e3).await?;
     info!("E3 {} synced with DB", e3_id);
 
     Ok(())

--- a/examples/CRISP/apps/server/src/server/blockchain/sync.rs
+++ b/examples/CRISP/apps/server/src/server/blockchain/sync.rs
@@ -103,9 +103,7 @@ pub async fn sync_server() -> Result<()> {
     let new_current_round = CurrentRound {
         id: latest_contract_e3_id,
     };
-    GLOBAL_DB
-        .insert("e3:current_round", &new_current_round)
-        .await?;
+    db_insert("e3:current_round", &new_current_round).await?;
 
     info!("Server synchronization completed.");
     Ok(())
@@ -250,9 +248,7 @@ async fn compute_and_publish_ciphertext(
     // Update vote count
     let mut db_e3 = get_e3(e3_id.to::<u64>()).await?.0;
     db_e3.vote_count = ciphertext_inputs.len() as u64;
-    GLOBAL_DB
-        .insert(&format!("e3:{}", e3_id.to::<u64>()), &db_e3)
-        .await?;
+    db_insert(&format!("e3:{}", e3_id.to::<u64>()), &db_e3).await?;
 
     let contract_e3 = contract.get_e3(e3_id).await?;
     let fhe_inputs = FHEInputs {

--- a/examples/CRISP/apps/server/src/server/database.rs
+++ b/examples/CRISP/apps/server/src/server/database.rs
@@ -61,7 +61,7 @@ static GLOBAL_DB: Lazy<RwLock<SledDB>> = Lazy::new(|| {
     RwLock::new(SledDB::new(pathdb.to_str().unwrap()).unwrap())
 });
 
-pub fn get_db() -> Lazy<RwLock<SledDB>> {
+pub fn db_instance() -> Lazy<RwLock<SledDB>> {
     GLOBAL_DB
 }
 

--- a/examples/CRISP/apps/server/src/server/database.rs
+++ b/examples/CRISP/apps/server/src/server/database.rs
@@ -61,10 +61,6 @@ static GLOBAL_DB: Lazy<RwLock<SledDB>> = Lazy::new(|| {
     RwLock::new(SledDB::new(pathdb.to_str().unwrap()).unwrap())
 });
 
-pub fn db_instance() -> Lazy<RwLock<SledDB>> {
-    GLOBAL_DB
-}
-
 pub async fn db_insert<T: Serialize + Send + Sync>(
     key: &str,
     value: &T,

--- a/examples/CRISP/apps/server/src/server/database.rs
+++ b/examples/CRISP/apps/server/src/server/database.rs
@@ -20,13 +20,13 @@ pub enum DatabaseError {
 }
 #[derive(Clone)]
 pub struct SledDB {
-    pub db: Arc<Db>,
+    pub db: Db,
 }
 
 impl SledDB {
     pub fn new(path: &str) -> Result<Self, DatabaseError> {
         let db = sled::open(path)?;
-        Ok(Self { db: Arc::new(db) })
+        Ok(Self { db })
     }
 }
 

--- a/examples/CRISP/apps/server/src/server/database.rs
+++ b/examples/CRISP/apps/server/src/server/database.rs
@@ -61,6 +61,10 @@ static GLOBAL_DB: Lazy<RwLock<SledDB>> = Lazy::new(|| {
     RwLock::new(SledDB::new(pathdb.to_str().unwrap()).unwrap())
 });
 
+pub fn get_db() -> Lazy<RwLock<SledDB>> {
+    GLOBAL_DB
+}
+
 pub async fn db_insert<T: Serialize + Send + Sync>(
     key: &str,
     value: &T,

--- a/examples/CRISP/apps/server/src/server/database.rs
+++ b/examples/CRISP/apps/server/src/server/database.rs
@@ -56,7 +56,7 @@ impl DataStore for SledDB {
     }
 }
 
-pub static GLOBAL_DB: Lazy<RwLock<SledDB>> = Lazy::new(|| {
+static GLOBAL_DB: Lazy<RwLock<SledDB>> = Lazy::new(|| {
     let pathdb = std::env::current_dir().unwrap().join("database/server");
     RwLock::new(SledDB::new(pathdb.to_str().unwrap()).unwrap())
 });

--- a/examples/CRISP/apps/server/src/server/mod.rs
+++ b/examples/CRISP/apps/server/src/server/mod.rs
@@ -8,7 +8,7 @@ use actix_cors::Cors;
 use actix_web::{middleware::Logger, web, App, HttpServer};
 
 use blockchain::listener::start_listener;
-use database::GLOBAL_DB;
+use database::get_db;
 use models::AppState;
 
 use crate::logger::init_logger;
@@ -47,9 +47,7 @@ pub async fn start() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         App::new()
             .wrap(cors)
             .wrap(Logger::new(r#"%a "%r" %s %b %T"#))
-            .app_data(web::Data::new(AppState {
-                sled: GLOBAL_DB.clone(),
-            }))
+            .app_data(web::Data::new(AppState { sled: get_db() }))
             .configure(routes::setup_routes)
     })
     .bind("0.0.0.0:4000")?

--- a/examples/CRISP/apps/server/src/server/mod.rs
+++ b/examples/CRISP/apps/server/src/server/mod.rs
@@ -8,7 +8,7 @@ use actix_cors::Cors;
 use actix_web::{middleware::Logger, web, App, HttpServer};
 
 use blockchain::listener::start_listener;
-use database::get_db;
+use database::db_instance;
 use models::AppState;
 
 use crate::logger::init_logger;
@@ -47,7 +47,9 @@ pub async fn start() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         App::new()
             .wrap(cors)
             .wrap(Logger::new(r#"%a "%r" %s %b %T"#))
-            .app_data(web::Data::new(AppState { sled: get_db() }))
+            .app_data(web::Data::new(AppState {
+                sled: db_instance(),
+            }))
             .configure(routes::setup_routes)
     })
     .bind("0.0.0.0:4000")?

--- a/examples/CRISP/apps/server/src/server/mod.rs
+++ b/examples/CRISP/apps/server/src/server/mod.rs
@@ -8,8 +8,6 @@ use actix_cors::Cors;
 use actix_web::{middleware::Logger, web, App, HttpServer};
 
 use blockchain::listener::start_listener;
-use database::db_instance;
-use models::AppState;
 
 use crate::logger::init_logger;
 use config::CONFIG;
@@ -47,9 +45,6 @@ pub async fn start() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         App::new()
             .wrap(cors)
             .wrap(Logger::new(r#"%a "%r" %s %b %T"#))
-            .app_data(web::Data::new(AppState {
-                sled: db_instance(),
-            }))
             .configure(routes::setup_routes)
     })
     .bind("0.0.0.0:4000")?

--- a/examples/CRISP/apps/server/src/server/models.rs
+++ b/examples/CRISP/apps/server/src/server/models.rs
@@ -2,10 +2,6 @@ use crate::server::database::SledDB;
 use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
 
-pub struct AppState {
-    pub sled: RwLock<SledDB>,
-}
-
 #[derive(Debug, Deserialize, Serialize)]
 pub struct JsonResponse {
     pub response: String,

--- a/examples/CRISP/apps/server/src/server/models.rs
+++ b/examples/CRISP/apps/server/src/server/models.rs
@@ -1,8 +1,9 @@
 use crate::server::database::SledDB;
 use serde::{Deserialize, Serialize};
+use tokio::sync::RwLock;
 
 pub struct AppState {
-    pub sled: SledDB,
+    pub sled: RwLock<SledDB>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/examples/CRISP/apps/server/src/server/routes/rounds.rs
+++ b/examples/CRISP/apps/server/src/server/routes/rounds.rs
@@ -58,7 +58,13 @@ async fn request_new_round(data: web::Json<CronRequestE3>) -> impl Responder {
 ///
 /// * A JSON response containing the current round
 async fn get_current_round(state: web::Data<AppState>) -> impl Responder {
-    match state.sled.get::<CurrentRound>("e3:current_round").await {
+    match state
+        .sled
+        .read()
+        .await
+        .get::<CurrentRound>("e3:current_round")
+        .await
+    {
         Ok(Some(current_round)) => HttpResponse::Ok().json(current_round),
         Ok(None) => HttpResponse::NotFound().json(JsonResponse {
             response: "No current round found".to_string(),

--- a/examples/CRISP/apps/server/src/server/routes/rounds.rs
+++ b/examples/CRISP/apps/server/src/server/routes/rounds.rs
@@ -1,8 +1,7 @@
 use crate::server::config::CONFIG;
-use crate::server::database::get_e3;
+use crate::server::database::{db_get, get_e3};
 use crate::server::models::{
-    AppState, CTRequest, ComputeProviderParams, CronRequestE3, CurrentRound, JsonResponse,
-    PKRequest,
+    CTRequest, ComputeProviderParams, CronRequestE3, CurrentRound, JsonResponse, PKRequest,
 };
 use actix_web::{web, HttpResponse, Responder};
 use alloy::primitives::{Address, Bytes, U256};
@@ -50,21 +49,11 @@ async fn request_new_round(data: web::Json<CronRequestE3>) -> impl Responder {
 
 /// Get the current E3 round
 ///
-/// # Arguments
-///
-/// * `AppState` - The application state
-///
 /// # Returns
 ///
 /// * A JSON response containing the current round
-async fn get_current_round(state: web::Data<AppState>) -> impl Responder {
-    match state
-        .sled
-        .read()
-        .await
-        .get::<CurrentRound>("e3:current_round")
-        .await
-    {
+async fn get_current_round() -> impl Responder {
+    match db_get::<CurrentRound>("e3:current_round").await {
         Ok(Some(current_round)) => HttpResponse::Ok().json(current_round),
         Ok(None) => HttpResponse::NotFound().json(JsonResponse {
             response: "No current round found".to_string(),

--- a/examples/CRISP/apps/server/src/server/routes/state.rs
+++ b/examples/CRISP/apps/server/src/server/routes/state.rs
@@ -1,4 +1,4 @@
-use crate::server::database::{get_e3, GLOBAL_DB};
+use crate::server::database::{db_get, get_e3};
 use crate::server::models::{CurrentRound, E3StateLite, GetRoundRequest, WebResultRequest};
 use actix_web::{web, HttpResponse, Responder};
 use enclave_sdk::evm::contracts::{EnclaveRead, EnclaveWrite};

--- a/examples/CRISP/apps/server/src/server/routes/state.rs
+++ b/examples/CRISP/apps/server/src/server/routes/state.rs
@@ -43,7 +43,7 @@ async fn get_round_result(data: web::Json<GetRoundRequest>) -> impl Responder {
 ///
 /// * A JSON response containing the results for all rounds
 async fn get_all_round_results() -> impl Responder {
-    let round_count = match GLOBAL_DB.get::<CurrentRound>("e3:current_round").await {
+    let round_count = match db_get::<CurrentRound>("e3:current_round").await {
         Ok(count) => count.unwrap().id,
         Err(e) => {
             info!("Error retrieving round count: {:?}", e);

--- a/examples/CRISP/apps/server/src/server/routes/voting.rs
+++ b/examples/CRISP/apps/server/src/server/routes/voting.rs
@@ -1,6 +1,6 @@
 use crate::server::{
     config::CONFIG,
-    database::{get_e3, GLOBAL_DB},
+    database::{db_get, db_insert, get_e3},
     models::{EncryptedVote, VoteResponse, VoteResponseStatus, E3},
 };
 use actix_web::{web, HttpResponse, Responder};
@@ -88,7 +88,7 @@ async fn validate_and_update_vote_status(
     }
 
     state_data.has_voted.push(vote.address.clone());
-    GLOBAL_DB.insert(&key, &state_data).await.unwrap();
+    db_insert(&key, &state_data).await.unwrap();
 
     Ok((state_data, key.to_string()))
 }
@@ -112,7 +112,7 @@ async fn handle_vote_error(
     // Rollback the vote
     if let Some(pos) = state_data.has_voted.iter().position(|x| x == address) {
         state_data.has_voted.remove(pos);
-        GLOBAL_DB.insert(key, state_data).await.unwrap();
+        db_insert(key, state_data).await.unwrap();
     }
 
     HttpResponse::Ok().json(VoteResponse {


### PR DESCRIPTION
The current `DataStore` trait and corresponding `SledDB` struct forces unnecessary interior mutability management on consumers when passed to a library like `EnclaveIndexer` for example. The `insert` method uses `&self` instead of `&mut self`, creating friction when wrapping datastores that naturally [require mutable references](https://docs.rs/redis/latest/redis/trait.Commands.html#method.set).

- Changed `DataStore::insert` to accept `&mut self` for better ergonomics
- Added `db_instance`, `db_get`, and `db_insert` helper methods to handle `GLOBAL_DB` access and interior mutability at the application level

```rust
pub trait DataStore: Send + Sync + 'static {
    type Error;
    async fn insert<T: Serialize + Send + Sync>(
        &mut self, // CHANGED THIS TO MUTABLE
        key: &str,
        value: &T,
    ) -> Result<(), Self::Error>;
    async fn get<T: DeserializeOwned + Send + Sync>(
        &self,
        key: &str,
    ) -> Result<Option<T>, Self::Error>;
}
```

- [ ] @hmzakhalid 