### PR TITLE
handle otel flag when used with `enclave nodes up`

### DIFF
--- a/packages/ciphernode/enclave/src/cli.rs
+++ b/packages/ciphernode/enclave/src/cli.rs
@@ -131,7 +131,7 @@ impl Cli {
                 bail!("Cannot run `enclave init` when a configuration exists.");
             }
             Commands::Nodes { command } => {
-                nodes::execute(command, &config, self.verbose, self.config).await?
+                nodes::execute(command, &config, self.verbose, self.config, self.otel.clone().map(Into::into)).await?
             }
             Commands::Password { command } => password::execute(command, &config).await?,
             Commands::Wallet { command } => wallet::execute(command, config).await?,

--- a/packages/ciphernode/enclave/src/cli.rs
+++ b/packages/ciphernode/enclave/src/cli.rs
@@ -131,7 +131,14 @@ impl Cli {
                 bail!("Cannot run `enclave init` when a configuration exists.");
             }
             Commands::Nodes { command } => {
-                nodes::execute(command, &config, self.verbose, self.config, self.otel.clone().map(Into::into)).await?
+                nodes::execute(
+                    command,
+                    &config,
+                    self.verbose,
+                    self.config,
+                    self.otel.clone().map(Into::into),
+                )
+                .await?
             }
             Commands::Password { command } => password::execute(command, &config).await?,
             Commands::Wallet { command } => wallet::execute(command, config).await?,

--- a/packages/ciphernode/enclave/src/nodes.rs
+++ b/packages/ciphernode/enclave/src/nodes.rs
@@ -66,15 +66,16 @@ pub async fn execute(
     config: &AppConfig,
     verbose: u8,
     config_string: Option<String>,
+    otel: Option<String>,
 ) -> Result<()> {
     match command {
         NodeCommands::Up { detach, exclude } => {
-            nodes_up::execute(config, detach, exclude, verbose, config_string).await?
+            nodes_up::execute(config, detach, exclude, verbose, config_string, otel).await?
         }
         NodeCommands::Down => nodes_down::execute().await?,
         NodeCommands::Ps => nodes_ps::execute().await?,
         NodeCommands::Daemon { exclude } => {
-            nodes_daemon::execute(config, exclude, verbose, config_string).await?
+            nodes_daemon::execute(config, exclude, verbose, config_string, otel).await?
         }
         NodeCommands::Start { id } => nodes_start::execute(&id).await?,
         NodeCommands::Status { id } => nodes_status::execute(&id).await?,

--- a/packages/ciphernode/enclave/src/nodes_daemon.rs
+++ b/packages/ciphernode/enclave/src/nodes_daemon.rs
@@ -7,6 +7,7 @@ pub async fn execute(
     exclude: Vec<String>,
     verbose: u8,
     config_string: Option<String>,
+    otel: Option<String>,
 ) -> Result<()> {
-    daemon::execute(config, exclude, verbose, config_string).await
+    daemon::execute(config, exclude, verbose, config_string, otel).await
 }

--- a/packages/ciphernode/enclave/src/nodes_up.rs
+++ b/packages/ciphernode/enclave/src/nodes_up.rs
@@ -8,6 +8,7 @@ pub async fn execute(
     exclude: Vec<String>,
     verbose: u8,
     config_string: Option<String>,
+    otel: Option<String>,
 ) -> Result<()> {
-    up::execute(config, detach, exclude, verbose, config_string).await
+    up::execute(config, detach, exclude, verbose, config_string, otel).await
 }

--- a/packages/ciphernode/enclave_core/src/nodes/up.rs
+++ b/packages/ciphernode/enclave_core/src/nodes/up.rs
@@ -12,6 +12,7 @@ pub async fn execute(
     exclude: Vec<String>,
     verbose: u8,
     maybe_config_string: Option<String>,
+    maybe_otel: Option<String>,
 ) -> Result<()> {
     if client::is_ready().await? {
         bail!("Swarm is already running!");
@@ -23,7 +24,7 @@ pub async fn execute(
     }
 
     //  run the swarm_daemon process locally forwarding args
-    daemon::execute(config, exclude, verbose, maybe_config_string).await?;
+    daemon::execute(config, exclude, verbose, maybe_config_string, maybe_otel).await?;
 
     Ok(())
 }


### PR DESCRIPTION
fixes #446 

Though CLI was accepting the --otel flag when using the command `enclave nodes up --otel`, but in Jaeger UI (localhost:16686), no traces from individual nodes were found(i.e there were no options for 4 nodes as services).

