### PR TITLE
Fix UID & GID malarchy

### DIFF
--- a/examples/CRISP/Dockerfile
+++ b/examples/CRISP/Dockerfile
@@ -28,8 +28,8 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
 #  Non-root user (skip if it already exists)
 # ────────────────────────────────────────────────────────────────────────────────
 ARG USERNAME=ubuntu
-ARG USER_UID=1001
-ARG USER_GID=118          # use any free GID you like
+ARG USER_UID=1000
+ARG USER_GID=100         # use any free GID you like
 
 RUN set -eux; \
     if ! id -u "${USERNAME}" 2>/dev/null; then \

--- a/examples/CRISP/docker-compose.yaml
+++ b/examples/CRISP/docker-compose.yaml
@@ -4,8 +4,8 @@ services:
     build:
       context: .
       args:
-        USER_UID: ${USER_UID:-1001}
-        USER_GID: ${USER_GID:-118}
+        USER_UID: ${USER_UID:-1000}
+        USER_GID: ${USER_GID:-100}
         USERNAME: ubuntu
     volumes:
       - ../..:/app
@@ -48,4 +48,3 @@ volumes:
   synpress-cache:
   test-results:
   playwright-report:
-  

--- a/examples/CRISP/scripts/tasks/dockerize.sh
+++ b/examples/CRISP/scripts/tasks/dockerize.sh
@@ -25,7 +25,8 @@ function run_in_docker() {
   else
     # Not in container, start Docker and run inside
     echo "Running outside container, starting Docker and executing command"
-    docker compose up -d # ensure our container is running
+    # Passing in the following on first run should theoretically bake the current group and user id into the container so if you build locally using this script the container shouldn't clobber your files with the wrong user
+    USER_UID=$(id -u) USER_GID=$(id -g) docker compose up -d # ensure our container is running
      
     if [ $# -eq 0 ]; then
       docker compose exec enclave-dev bash


### PR DESCRIPTION
We hardcoded UID and GID in the docker container we were using. This is an attempt to ensure that building the container via our scripts uses the local user so that file ownership and permissions aren't messed up.