### PR TITLE
Add shutdown logic to prevent swallowing errors in connection

### DIFF
--- a/crates/entrypoint/src/helpers/shutdown.rs
+++ b/crates/entrypoint/src/helpers/shutdown.rs
@@ -3,29 +3,46 @@ use anyhow::Result;
 use e3_events::{EnclaveEvent, Shutdown};
 use std::time::Duration;
 use tokio::{
+    select,
     signal::unix::{signal, SignalKind},
     task::JoinHandle,
 };
-use tracing::info;
+use tracing::{error, info};
 
-pub async fn listen_for_shutdown(bus: Recipient<EnclaveEvent>, handle: JoinHandle<Result<()>>) {
+pub async fn listen_for_shutdown(bus: Recipient<EnclaveEvent>, mut handle: JoinHandle<Result<()>>) {
     let mut sigterm =
         signal(SignalKind::terminate()).expect("Failed to create SIGTERM signal stream");
+    select! {
+        _ = sigterm.recv() => {
+            info!("SIGTERM received, initiating graceful shutdown...");
 
-    sigterm.recv().await;
-    info!("SIGTERM received, initiating graceful shutdown...");
+            // Stop the actor system
+            let _ = bus.send(EnclaveEvent::from(Shutdown)).await;
 
-    // Stop the actor system
-    let _ = bus.send(EnclaveEvent::from(Shutdown)).await;
+            // Abort the spawned task
+            handle.abort();
 
-    // Abort the spawned task
-    handle.abort();
+            // Wait for all actor processes to disconnect
+            tokio::time::sleep(Duration::from_secs(2)).await;
 
-    // Wait for all actor processes to disconnect
-    tokio::time::sleep(Duration::from_secs(2)).await;
+            // Wait for the task to finish
+            let _ = handle.await;
 
-    // Wait for the task to finish
-    let _ = handle.await;
+            info!("Graceful shutdown complete");
 
-    info!("Graceful shutdown complete");
+        }
+        result = &mut handle => {
+            match result {
+                Ok(Ok(_)) => {
+                    info!("Completed");
+                }
+                Ok(Err(e)) => {
+                    error!("Failed: {}", e);
+                }
+                Err(e) => {
+                    error!("Panicked: {}", e);
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
When we listen for connections via the net package if there is a failure to connect then the process does not fail but it probably should as it means the node can't connect and this is likely because other nodes are listening (zombie processes). We don't want our developers having to debug this so the best thing to do is to fail.