### PR TITLE
Pass Bonsai Credentials to Risc0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2681,6 +2681,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "duct",
+ "e3-config",
  "tokio",
 ]
 

--- a/crates/cli/src/program.rs
+++ b/crates/cli/src/program.rs
@@ -1,32 +1,19 @@
 use anyhow::Result;
 use clap::Subcommand;
 use e3_config::AppConfig;
-use e3_support_scripts::{SupportArgs, SupportConfig};
 
 #[derive(Subcommand, Debug)]
 pub enum ProgramCommands {
     /// Start the program
-    Start {
-        #[arg(long, short)]
-        bonsai_api_key: Option<String>,
-    },
+    Start,
 
     /// Compile the program code
     Compile,
 }
 
-pub async fn execute(command: ProgramCommands, _config: &AppConfig) -> Result<()> {
+pub async fn execute(command: ProgramCommands, config: &AppConfig) -> Result<()> {
     match command {
-        ProgramCommands::Start { bonsai_api_key } => {
-            let support_args = match bonsai_api_key {
-                Some(api_key) => SupportArgs::BonsaiCredentials {
-                    api_key,
-                    api_url: "https://api.bonsai.xyz".to_string(),
-                },
-                None => SupportArgs::DevMode,
-            };
-            e3_support_scripts::program_start(support_args).await?
-        }
+        ProgramCommands::Start => e3_support_scripts::program_start(config.program()).await?,
         ProgramCommands::Compile => e3_support_scripts::program_compile().await?,
     };
 

--- a/crates/cli/src/program.rs
+++ b/crates/cli/src/program.rs
@@ -1,11 +1,15 @@
 use anyhow::Result;
 use clap::Subcommand;
 use e3_config::AppConfig;
+use e3_support_scripts::{SupportArgs, SupportConfig};
 
 #[derive(Subcommand, Debug)]
 pub enum ProgramCommands {
     /// Start the program
-    Start,
+    Start {
+        #[arg(long, short)]
+        bonsai_api_key: Option<String>,
+    },
 
     /// Compile the program code
     Compile,
@@ -13,7 +17,16 @@ pub enum ProgramCommands {
 
 pub async fn execute(command: ProgramCommands, _config: &AppConfig) -> Result<()> {
     match command {
-        ProgramCommands::Start => e3_support_scripts::program_start().await?,
+        ProgramCommands::Start { bonsai_api_key } => {
+            let support_args = match bonsai_api_key {
+                Some(api_key) => SupportArgs::BonsaiCredentials {
+                    api_key,
+                    api_url: "https://api.bonsai.xyz".to_string(),
+                },
+                None => SupportArgs::DevMode,
+            };
+            e3_support_scripts::program_start(support_args).await?
+        }
         ProgramCommands::Compile => e3_support_scripts::program_compile().await?,
     };
 

--- a/crates/config/src/app_config.rs
+++ b/crates/config/src/app_config.rs
@@ -84,6 +84,25 @@ impl Default for NodeDefinition {
     }
 }
 
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Risc0Config {
+    Bonsai { api_key: String, api_url: String },
+    DevMode,
+}
+
+impl Default for Risc0Config {
+    fn default() -> Self {
+        Risc0Config::DevMode
+    }
+}
+
+/// Configuration for the program runner
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub struct ProgramConfig {
+    pub risc0: Risc0Config,
+}
+
 /// The config actually used throughout the app
 #[derive(Debug, Deserialize, Serialize)]
 pub struct AppConfig {
@@ -105,6 +124,8 @@ pub struct AppConfig {
     autopassword: bool,
     /// If a wallet has not been set autogenerate one on start
     autowallet: bool,
+    /// Program config
+    program: ProgramConfig,
 }
 
 impl AppConfig {
@@ -160,6 +181,7 @@ impl AppConfig {
             autopassword: node.autopassword,
             autowallet: node.autowallet,
             autonetkey: node.autonetkey,
+            program: config.program.unwrap_or_default(),
         })
     }
 
@@ -275,6 +297,10 @@ impl AppConfig {
     pub fn autopassword(&self) -> bool {
         self.autopassword
     }
+
+    pub fn program(&self) -> &ProgramConfig {
+        &self.program
+    }
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -296,6 +322,8 @@ pub struct UnscopedAppConfig {
     nodes: HashMap<String, NodeDefinition>,
     /// Set the Open Telemetry collector grpc endpoint. Eg. 127.0.0.1:4317
     otel: Option<String>,
+    /// Program config
+    program: Option<ProgramConfig>,
 }
 
 impl Default for UnscopedAppConfig {
@@ -308,6 +336,7 @@ impl Default for UnscopedAppConfig {
             found_config_file: None,
             otel: None,
             nodes: HashMap::new(),
+            program: None,
         }
     }
 }

--- a/crates/support-scripts/Cargo.toml
+++ b/crates/support-scripts/Cargo.toml
@@ -10,3 +10,4 @@ repository.workspace = true
 anyhow.workspace = true
 tokio.workspace = true
 duct.workspace = true
+e3-config.workspace = true

--- a/crates/support-scripts/ctl/start
+++ b/crates/support-scripts/ctl/start
@@ -1,4 +1,19 @@
 #!/usr/bin/env bash
 
+while [[ $# -gt 0 ]]; do
+  [[ $1 == --api-key ]] && API_KEY="$2" && shift 2 && continue
+  [[ $1 == --api-url ]] && API_URL="$2" && shift 2 && continue
+  shift
+done
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-"$SCRIPT_DIR/container" ./scripts/container/start.sh
+
+if [[ -n "$API_KEY" && -n "$API_URL" ]]; then
+  # BONSAI MODE
+  "$SCRIPT_DIR/container" ./scripts/container/start.sh --api-key "$API_KEY" --api-url "$API_URL"
+elif [[ -z "$API_KEY" && -z "$API_URL" ]]; then
+  # DEV MODE
+  "$SCRIPT_DIR/container" ./scripts/container/start.sh
+else
+  exit 1
+fi

--- a/crates/support-scripts/src/lib.rs
+++ b/crates/support-scripts/src/lib.rs
@@ -59,9 +59,17 @@ pub async fn program_start(program_config: &ProgramConfig) -> Result<()> {
     let script = cwd.join(".enclave/support/ctl/start");
     ensure_script_exists(&script).await?;
 
-    let args: Vec<&str> = match &program_config.risc0 {
-        Risc0Config::Bonsai { api_key, api_url } => {
-            vec!["--api-key", api_key.as_str(), "--api-url", api_url.as_str()]
+    let args: Vec<&str> = match program_config.risc0() {
+        Risc0Config::Bonsai {
+            bonsai_api_key,
+            bonsai_api_url,
+        } => {
+            vec![
+                "--api-key",
+                bonsai_api_key.as_str(),
+                "--api-url",
+                bonsai_api_url.as_str(),
+            ]
         }
         Risc0Config::DevMode => vec![],
     };

--- a/crates/support-scripts/src/lib.rs
+++ b/crates/support-scripts/src/lib.rs
@@ -1,16 +1,20 @@
 use anyhow::{bail, Result};
 use duct::cmd;
+use e3_config::ProgramConfig;
+use e3_config::Risc0Config;
 use std::{env, path::PathBuf};
 use tokio::fs;
 use tokio::signal;
 
 async fn run_bash_script(cwd: &PathBuf, script: &PathBuf, args: &[&str]) -> Result<()> {
-    println!("run_bash_script: {:?} {:?} {:?}", cwd, script, args);
+    println!("run_bash_script: {:?} {:?} {:?}", cwd, script, args); // Delete this later as this exposes
+                                                                    // credential information
 
     // Build the command using cmd! macro for cleaner syntax
     let mut cmd_args = vec!["bash".to_string(), script.to_string_lossy().to_string()];
     cmd_args.extend(args.iter().map(|s| s.to_string()));
 
+    // Note this will not end up on shell history
     let expression = cmd("bash", &cmd_args[1..]).dir(cwd);
 
     let handle = expression.start()?;
@@ -50,21 +54,16 @@ pub async fn program_compile() -> Result<()> {
     Ok(())
 }
 
-pub enum SupportArgs {
-    BonsaiCredentials { api_key: String, api_url: String },
-    DevMode,
-}
-
-pub async fn program_start(bonsai_api: SupportArgs) -> Result<()> {
+pub async fn program_start(program_config: &ProgramConfig) -> Result<()> {
     let cwd = env::current_dir()?;
     let script = cwd.join(".enclave/support/ctl/start");
     ensure_script_exists(&script).await?;
 
-    let args: Vec<&str> = match &bonsai_api {
-        SupportArgs::BonsaiCredentials { api_key, api_url } => {
+    let args: Vec<&str> = match &program_config.risc0 {
+        Risc0Config::Bonsai { api_key, api_url } => {
             vec!["--api-key", api_key.as_str(), "--api-url", api_url.as_str()]
         }
-        SupportArgs::DevMode => vec![],
+        Risc0Config::DevMode => vec![],
     };
     run_bash_script(&cwd, &script, &args).await?;
     Ok(())

--- a/crates/support-scripts/src/lib.rs
+++ b/crates/support-scripts/src/lib.rs
@@ -50,10 +50,22 @@ pub async fn program_compile() -> Result<()> {
     Ok(())
 }
 
-pub async fn program_start() -> Result<()> {
+pub enum SupportArgs {
+    BonsaiCredentials { api_key: String, api_url: String },
+    DevMode,
+}
+
+pub async fn program_start(bonsai_api: SupportArgs) -> Result<()> {
     let cwd = env::current_dir()?;
     let script = cwd.join(".enclave/support/ctl/start");
     ensure_script_exists(&script).await?;
-    run_bash_script(&cwd, &script, &[]).await?;
+
+    let args: Vec<&str> = match &bonsai_api {
+        SupportArgs::BonsaiCredentials { api_key, api_url } => {
+            vec!["--api-key", api_key.as_str(), "--api-url", api_url.as_str()]
+        }
+        SupportArgs::DevMode => vec![],
+    };
+    run_bash_script(&cwd, &script, &args).await?;
     Ok(())
 }

--- a/crates/support/scripts/container/start.sh
+++ b/crates/support/scripts/container/start.sh
@@ -1,3 +1,16 @@
 #!/usr/bin/env bash
+while [[ $# -gt 0 ]]; do
+    if [[ $1 == --api-key ]]; then
+        export BONSAI_API_KEY="$2"
+        shift 2
+    elif [[ $1 == --api-url ]]; then
+        export BONSAI_API_URL="$2"
+        shift 2
+    else
+        break
+    fi
+done
+
+[[ -z "$BONSAI_API_KEY" ]] && export RISC0_DEV_MODE=1
 
 exec cargo run --bin e3-support-app "$@"


### PR DESCRIPTION
This means we can pass credentials via env vars in the config:

```yaml
program:
  risc0:
    bonsai_api_key: "${BONSAI_API_KEY}"
    bonsai_api_url: "http://my.api.com"
```

Then either:

```yaml
program:
  risc0:
```
or simply leave it out for devmode