### PR TITLE
fix default address for support compute provider

### DIFF
--- a/crates/support/app/src/main.rs
+++ b/crates/support/app/src/main.rs
@@ -110,7 +110,7 @@ async fn handle_compute(req: web::Json<ComputeRequest>) -> ActixResult<HttpRespo
 async fn main() -> anyhow::Result<()> {
     env_logger::init();
 
-    let bind_addr = "0.0.0.0:13151";
+    let bind_addr = "127.0.0.1:13151";
     let server = HttpServer::new(move || {
         App::new()
             .wrap(Logger::default())


### PR DESCRIPTION
I have noticed that I'm getting an error in the FHE compute service when I run the template since seems to listen to 0.0.0.0:13151 instead of localhost.

this is the error that i got when the request gets processed - `[cause]: Error: connect ECONNREFUSED 127.0.0.1:13151`