### PR TITLE
Fix macos issue and cleanup after fail

### DIFF
--- a/crates/init/src/copy.rs
+++ b/crates/init/src/copy.rs
@@ -106,8 +106,12 @@ async fn apply_filter_to_files(base_path: impl AsRef<OsStr>, filter: &Filter) ->
 
         // Check if we're on macOS (BSD sed) and add empty backup extension
         if is_bsd {
+            // This is a quirk of BSD sed - we need to do the equivalent of:
+            // sed -i '' pattern filename
             cmd.arg("-i").arg("");
         } else {
+            // Normal sed is:
+            // sed -i pattern filename
             cmd.arg("-i");
         }
 

--- a/crates/init/src/file_utils.rs
+++ b/crates/init/src/file_utils.rs
@@ -55,3 +55,16 @@ pub async fn move_file<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> Result
         .await?;
     Ok(())
 }
+
+pub async fn remove_all_files_in_dir<P: AsRef<Path>>(dir_path: P) -> Result<()> {
+    let mut entries = fs::read_dir(dir_path).await?;
+
+    while let Some(entry) = entries.next_entry().await? {
+        let path = entry.path();
+        if path.is_file() {
+            fs::remove_file(path).await?;
+        }
+    }
+
+    Ok(())
+}

--- a/crates/init/src/lib.rs
+++ b/crates/init/src/lib.rs
@@ -4,9 +4,9 @@ mod git;
 mod package_json;
 mod pkgman;
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use copy::Filter;
-use file_utils::{chmod_recursive, delete_path, move_file};
+use file_utils::{chmod_recursive, delete_path, move_file, remove_all_files_in_dir};
 use git::parse_git_url;
 use package_json::DependencyType;
 use pkgman::PkgMan;
@@ -21,24 +21,11 @@ const TEMP_DIR: &str = "/tmp/__enclave-tmp-folder.1";
 const DEFAULT_TEMPLATE_PATH: &str = ".";
 const DEFAULT_BRANCH: &str = "main";
 
-// Updated execute function to include workspace dependency substitution
-pub async fn execute(location: Option<PathBuf>, template: Option<String>) -> Result<()> {
+async fn install_enclave(cwd: &PathBuf, template: Option<String>) -> Result<()> {
     let repo = parse_git_url(template.unwrap_or(DEFAULT_TEMPLATE_URL.to_string()))?;
     let base_url = repo.base_url;
     let branch = repo.branch.unwrap_or(DEFAULT_BRANCH.to_string());
     let template_path = repo.path.unwrap_or(DEFAULT_TEMPLATE_PATH.to_string());
-
-    let cwd = match location {
-        Some(loc) => loc,
-        None => env::current_dir()?,
-    };
-
-    println!("Ensuring tmp folder does not exist...");
-    if fs::try_exists(TEMP_DIR).await? {
-        fs::remove_dir_all(TEMP_DIR).await?;
-    }
-    println!("Ensuring cwd is empty...");
-    file_utils::ensure_empty_folder(&cwd).await?;
 
     println!("Start git clone...");
     git::shallow_clone(&base_url, &branch, TEMP_DIR).await?;
@@ -140,4 +127,39 @@ pub async fn execute(location: Option<PathBuf>, template: Option<String>) -> Res
     git::commit(&cwd, "Initial Commit").await?;
 
     Ok(())
+}
+
+// Updated execute function to include workspace dependency substitution
+pub async fn execute(location: Option<PathBuf>, template: Option<String>) -> Result<()> {
+    let mut install_in_current_dir = false;
+    let cwd = match location {
+        Some(loc) => loc,
+        None => {
+            install_in_current_dir = true;
+            env::current_dir()?
+        }
+    };
+
+    println!("Ensuring tmp folder does not exist...");
+    if fs::try_exists(TEMP_DIR).await? {
+        fs::remove_dir_all(TEMP_DIR).await?;
+    }
+
+    println!("Ensuring cwd is empty...");
+    file_utils::ensure_empty_folder(&cwd).await?;
+
+    match install_enclave(&cwd, template).await {
+        Ok(_) => Ok(()),
+        Err(e) => {
+            if install_in_current_dir {
+                remove_all_files_in_dir(&cwd).await?;
+            } else {
+                fs::remove_dir_all(&cwd).await?;
+            }
+            eprintln!("Sorry about this but there was an error running the installer. ");
+            eprintln!("\n {}\n", e);
+            eprintln!("Enclave is currently under active development please share this with our team:\n  https://github.com/gnosisguild/enclave/issues/new\n");
+            Ok(())
+        }
+    }
 }

--- a/crates/init/src/lib.rs
+++ b/crates/init/src/lib.rs
@@ -4,7 +4,7 @@ mod git;
 mod package_json;
 mod pkgman;
 
-use anyhow::{bail, Result};
+use anyhow::Result;
 use copy::Filter;
 use file_utils::{chmod_recursive, delete_path, move_file, remove_all_files_in_dir};
 use git::parse_git_url;

--- a/crates/init/src/lib.rs
+++ b/crates/init/src/lib.rs
@@ -4,7 +4,7 @@ mod git;
 mod package_json;
 mod pkgman;
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use copy::Filter;
 use file_utils::{chmod_recursive, delete_path, move_file, remove_all_files_in_dir};
 use git::parse_git_url;
@@ -151,14 +151,18 @@ pub async fn execute(location: Option<PathBuf>, template: Option<String>) -> Res
     match install_enclave(&cwd, template).await {
         Ok(_) => Ok(()),
         Err(e) => {
+            println!(
+                "install_in_current_dir: {} {:?}",
+                install_in_current_dir, cwd
+            );
             if install_in_current_dir {
                 remove_all_files_in_dir(&cwd).await?;
             } else {
                 fs::remove_dir_all(&cwd).await?;
             }
-            eprintln!("Sorry about this but there was an error running the installer. ");
-            eprintln!("\n {}\n", e);
-            eprintln!("Enclave is currently under active development please share this with our team:\n  https://github.com/gnosisguild/enclave/issues/new\n");
+            eprintln!("\nSorry about this but there was an error running the installer. ");
+            eprintln!("\n Error: {}\n", e);
+            eprintln!("Enclave is currently under active development please share this with our team:\n\n  https://github.com/gnosisguild/enclave/issues/new\n");
             Ok(())
         }
     }

--- a/crates/init/src/lib.rs
+++ b/crates/init/src/lib.rs
@@ -151,10 +151,7 @@ pub async fn execute(location: Option<PathBuf>, template: Option<String>) -> Res
     match install_enclave(&cwd, template).await {
         Ok(_) => Ok(()),
         Err(e) => {
-            println!(
-                "install_in_current_dir: {} {:?}",
-                install_in_current_dir, cwd
-            );
+            println!("Cleaning up due to error...");
             if install_in_current_dir {
                 remove_all_files_in_dir(&cwd).await?;
             } else {


### PR DESCRIPTION
- Detect sed bsd and accommodate it's quirks
- If there is a failure during `enclave init` wipe the folder that was attempted to build into eg `enclave init foo` will remove the foo folder completely. `mkdir foo && cd foo && enclave init` will leave foo empty if there is a failure.