### PR TITLE
fix: (docs) update CRISP setup documentation

### DIFF
--- a/docs/pages/CRISP/setup.mdx
+++ b/docs/pages/CRISP/setup.mdx
@@ -20,6 +20,8 @@ The setup includes the following:
 
 The fastest way to get CRISP running is using the Docker development environment:
 
+> **Note:** This setup requires `pnpm` to be installed on your system. If you don't have it installed, see the [Prerequisites](#prerequisites) section below for installation instructions.
+
 ```sh
 # Clone the repository first (shallow clone for faster setup)
 git clone --depth 1 https://github.com/gnosisguild/enclave.git
@@ -67,6 +69,7 @@ Before getting started, ensure you have the following tools installed:
 - **Foundry** (Ethereum development framework)
 - **RISC Zero toolchain** (for RISC Zero program development)
 - **Node.js** (JavaScript runtime for client-side dependencies)
+- **pnpm** (package manager for Node.js dependencies)
 - **Anvil** (local Ethereum node)
 - **Enclave CLI** (for managing ciphernodes)
 
@@ -83,6 +86,22 @@ nvm install 22
 nvm use 22
 
 # Or download from https://nodejs.org/
+```
+
+### Install pnpm
+
+The project uses pnpm as the package manager. Install pnpm (version 10.7.1 or higher recommended):
+
+```sh
+# Using corepack (recommended - comes with Node.js 16+)
+corepack enable
+corepack prepare pnpm@10.7.1 --activate
+
+# Or using npm
+npm install -g pnpm@10.7.1
+
+# Or using curl
+curl -fsSL https://get.pnpm.io/install.sh | sh -
 ```
 
 ### Install Enclave CLI

--- a/docs/pages/CRISP/setup.mdx
+++ b/docs/pages/CRISP/setup.mdx
@@ -21,8 +21,8 @@ The setup includes the following:
 The fastest way to get CRISP running is using the Docker development environment:
 
 ```sh
-# Clone the repository first
-git clone https://github.com/gnosisguild/enclave.git
+# Clone the repository first (shallow clone for faster setup)
+git clone --depth 1 https://github.com/gnosisguild/enclave.git
 cd enclave
 
 # Navigate to the CRISP example
@@ -135,10 +135,10 @@ At this point, you should have all the necessary tools to develop and deploy app
 
 ### Clone the Repository
 
-Now clone the Enclave repository which contains the CRISP example:
+If you haven't already cloned the repository from the [Quick Start](#quick-start-with-docker-recommended) section above, do so now:
 
 ```sh
-git clone https://github.com/gnosisguild/enclave.git
+git clone --depth 1 https://github.com/gnosisguild/enclave.git
 cd enclave
 ```
 
@@ -147,7 +147,7 @@ cd enclave
 If you prefer to build the Enclave CLI from source instead of using the installer:
 
 ```sh
-# Make sure you're in the cloned repository root (you should be after the clone step)
+# Make sure you're in the cloned repository root (cd enclave if not already there)
 cargo install --locked --path ./crates/cli --bin enclave -f
 ```
 
@@ -158,6 +158,7 @@ The Client is a React application used to interact with the CRISP Server. Follow
 1. Navigate to the client directory (from the cloned repository root):
 
    ```sh
+   # Make sure you're in the repository root (cd enclave if not already there)
    cd examples/CRISP/apps/client
    ```
 
@@ -200,6 +201,7 @@ Keep this terminal open and running. Open a new terminal for the next steps.
 2. Navigate to the `packages/evm` directory:
 
    ```sh
+   # Make sure you're in the repository root (cd enclave if not already there)
    cd packages/evm
    ```
 
@@ -222,6 +224,7 @@ After deployment, take note of the addresses for the following contracts:
 1. Navigate to the CRISP directory (from the cloned repository root):
 
    ```sh
+   # Make sure you're in the repository root (cd enclave if not already there)
    cd examples/CRISP
    ```
 

--- a/docs/pages/CRISP/setup.mdx
+++ b/docs/pages/CRISP/setup.mdx
@@ -7,7 +7,9 @@ import { Steps } from 'nextra/components'
 
 # Getting Started with CRISP
 
-This guide will walk you through the steps to set up and run CRISP locally. CRISP is a complete example of an E3 Program, built with a modern Hardhat-based architecture that includes smart contracts, frontend applications, and secure computation components.
+This guide will walk you through the steps to set up and run CRISP locally. CRISP is a complete
+example of an E3 Program, built with a modern Hardhat-based architecture that includes smart
+contracts, frontend applications, and secure computation components.
 
 The setup includes the following:
 
@@ -20,12 +22,16 @@ The setup includes the following:
 
 The fastest way to get CRISP running is using the Docker development environment:
 
-> **Note:** This setup requires `pnpm` to be installed on your system. If you don't have it installed, see the [Prerequisites](#prerequisites) section below for installation instructions.
+> **Note:** This setup requires `pnpm` to be installed on your system. If you don't have it
+> installed, see the [Prerequisites](#prerequisites) section below for installation instructions.
 
 ```sh
 # Clone the repository first (shallow clone for faster setup)
 git clone --depth 1 https://github.com/gnosisguild/enclave.git
 cd enclave
+
+# Initialize Git submodules (required for RISC Zero contracts)
+git submodule update --init --recursive
 
 # Navigate to the CRISP example
 cd examples/CRISP
@@ -38,6 +44,7 @@ pnpm dev:up
 ```
 
 This will:
+
 - Build all necessary Docker containers
 - Start Anvil (local blockchain)
 - Deploy all contracts
@@ -45,6 +52,7 @@ This will:
 - Launch all CRISP applications
 
 **Available Docker Commands:**
+
 - `pnpm dev:setup` - Build the development containers
 - `pnpm dev:up` - Start all services
 - `pnpm dev:down` - Stop and clean up all services
@@ -52,6 +60,7 @@ This will:
 - `pnpm cli` - Invoke the Server CLI inside the Docker Container
 
 Once everything is running, you can:
+
 1. Run `pnpm cli` to start a new E3 Round.
 2. Open `http://localhost:3000` for the client interface
 3. Configure MetaMask with the Anvil network (see [MetaMask Setup](#metamask-setup) below)
@@ -77,7 +86,8 @@ Before getting started, ensure you have the following tools installed:
 
 ### Install Node.js
 
-The client application requires Node.js for running the React/Vite development server and managing dependencies. Install Node.js (version 22 or higher recommended):
+The client application requires Node.js for running the React/Vite development server and managing
+dependencies. Install Node.js (version 22 or higher recommended):
 
 ```sh
 # Using nvm (recommended)
@@ -150,16 +160,25 @@ Verify the installation by running the following command:
 cargo risczero --version
 ```
 
-At this point, you should have all the necessary tools to develop and deploy applications with [RISC Zero](https://www.risczero.com).
+At this point, you should have all the necessary tools to develop and deploy applications with
+[RISC Zero](https://www.risczero.com).
 
 ### Clone the Repository
 
-If you haven't already cloned the repository from the [Quick Start](#quick-start-with-docker-recommended) section above, do so now:
+If you haven't already cloned the repository from the
+[Quick Start](#quick-start-with-docker-recommended) section above, do so now:
 
 ```sh
 git clone --depth 1 https://github.com/gnosisguild/enclave.git
 cd enclave
+
+# Initialize Git submodules (required for RISC Zero contracts)
+git submodule update --init --recursive
 ```
+
+> **Note:** The project uses Git submodules to include RISC Zero Ethereum contracts. The
+> `git submodule update --init --recursive` command downloads these dependencies which are required
+> for contract compilation.
 
 **Alternative: Build Enclave CLI from Source**
 
@@ -172,7 +191,8 @@ cargo install --locked --path ./crates/cli --bin enclave -f
 
 ## Setting Up the Client
 
-The Client is a React application used to interact with the CRISP Server. Follow these steps to set it up locally:
+The Client is a React application used to interact with the CRISP Server. Follow these steps to set
+it up locally:
 
 1. Navigate to the client directory (from the cloned repository root):
 
@@ -247,7 +267,8 @@ After deployment, take note of the addresses for the following contracts:
    cd examples/CRISP
    ```
 
-2. Set up the environment variables by exporting the ETH wallet private key (Anvil's default private key):
+2. Set up the environment variables by exporting the ETH wallet private key (Anvil's default private
+   key):
 
    ```sh
    export ETH_WALLET_PRIVATE_KEY="0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
@@ -268,7 +289,8 @@ After deployment, take note of the addresses for the following contracts:
    FOUNDRY_PROFILE=local forge script --rpc-url http://localhost:8545 --broadcast deploy/Deploy.s.sol
    ```
 
-Make sure to take note of the **CRISP Program Contract Address**, as this will serve as the **E3 Program Address**.
+Make sure to take note of the **CRISP Program Contract Address**, as this will serve as the **E3
+Program Address**.
 
 ### Set Up Ciphernodes
 
@@ -315,6 +337,7 @@ The default configuration is already set up for local development with Anvil.
 To interact with CRISP through the web interface, configure MetaMask:
 
 1. **Add the Anvil private key** to your wallet:
+
    ```
    0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
    ```
@@ -327,7 +350,7 @@ To interact with CRISP through the web interface, configure MetaMask:
 
 3. **Connect to the application** at `http://localhost:3000`
 
-
 ## Next Steps
 
-Once you have completed the setup, you can proceed to [Running an E3 Program](/CRISP/running-e3) to learn how to interact with CRISP and run voting rounds.
+Once you have completed the setup, you can proceed to [Running an E3 Program](/CRISP/running-e3) to
+learn how to interact with CRISP and run voting rounds.

--- a/docs/pages/CRISP/setup.mdx
+++ b/docs/pages/CRISP/setup.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Setup - CRISP'  
-description: ''
+title: 'Setup - CRISP'
+description: 'Setup and build the development environment for CRISP'
 ---
 
 import { Steps } from 'nextra/components'
@@ -12,7 +12,7 @@ This guide will walk you through the steps to set up and run CRISP locally. CRIS
 The setup includes the following:
 
 - **CRISP contracts**: Smart contracts located in the `contracts/` directory
-- **Applications**: Frontend, server, and computation programs in the `apps/` directory  
+- **Applications**: Frontend, server, and computation programs in the `apps/` directory
 - **Ciphernodes**: Distributed nodes managed through the Enclave CLI
 - **Development environment**: Hardhat + Foundry hybrid setup
 
@@ -21,6 +21,11 @@ The setup includes the following:
 The fastest way to get CRISP running is using the Docker development environment:
 
 ```sh
+# Clone the repository first
+git clone https://github.com/gnosisguild/enclave.git
+cd enclave
+
+# Navigate to the CRISP example
 cd examples/CRISP
 
 # Setup and build the development environment
@@ -53,6 +58,15 @@ Once everything is running, you can:
 ## Manual Setup
 
 If you prefer to set up CRISP manually or want to understand each component:
+
+### Clone the Repository
+
+First, clone the Enclave repository which contains the CRISP example:
+
+```sh
+git clone https://github.com/gnosisguild/enclave.git
+cd enclave
+```
 
 ## Prerequisites
 
@@ -127,7 +141,7 @@ At this point, you should have all the necessary tools to develop and deploy app
 
 The Client is a React application used to interact with the CRISP Server. Follow these steps to set it up locally:
 
-1. Navigate to the client directory:
+1. Navigate to the client directory (from the cloned repository root):
 
    ```sh
    cd examples/CRISP/apps/client
@@ -163,26 +177,19 @@ Keep this terminal open and running. Open a new terminal for the next steps.
 
 ### Deploy the Enclave Contracts
 
-1. Clone the [Enclave Repository](https://github.com/gnosisguild/enclave) if you haven't already:
-
-   ```sh
-   git clone https://github.com/gnosisguild/enclave.git
-   cd enclave
-   ```
-
-2. Install the dependencies:
+1. Install the dependencies:
 
    ```sh
    pnpm install
    ```
 
-3. Navigate to the `packages/evm` directory:
+2. Navigate to the `packages/evm` directory:
 
    ```sh
    cd packages/evm
    ```
 
-4. Deploy the Enclave contracts on the local testnet:
+3. Deploy the Enclave contracts on the local testnet:
 
    ```sh
    rm -rf deployments/localhost
@@ -198,7 +205,7 @@ After deployment, take note of the addresses for the following contracts:
 
 ### Deploy the CRISP Contracts
 
-1. Navigate to the CRISP directory:
+1. Navigate to the CRISP directory (from the cloned repository root):
 
    ```sh
    cd examples/CRISP
@@ -246,9 +253,9 @@ Start the ciphernodes using the Enclave CLI:
 3. Add ciphernodes to the registry:
 
    ```sh
-   # Navigate back to the Enclave repository
+   # Navigate back to the Enclave repository root
    cd ../../packages/evm
-   
+
    # Add the ciphernodes
    pnpm ciphernode:add --ciphernode-address "0xbDA5747bFD65F08deb54cb465eB87D40e51B197E" --network "localhost"
    pnpm ciphernode:add --ciphernode-address "0xdD2FD4581271e230360230F9337D5c0430Bf44C0" --network "localhost"

--- a/docs/pages/CRISP/setup.mdx
+++ b/docs/pages/CRISP/setup.mdx
@@ -59,16 +59,7 @@ Once everything is running, you can:
 
 If you prefer to set up CRISP manually or want to understand each component:
 
-### Clone the Repository
-
-First, clone the Enclave repository which contains the CRISP example:
-
-```sh
-git clone https://github.com/gnosisguild/enclave.git
-cd enclave
-```
-
-## Prerequisites
+### Prerequisites
 
 Before getting started, ensure you have the following tools installed:
 
@@ -80,6 +71,19 @@ Before getting started, ensure you have the following tools installed:
 - **Enclave CLI** (for managing ciphernodes)
 
 ## Install Dependencies
+
+### Install Node.js
+
+The client application requires Node.js for running the React/Vite development server and managing dependencies. Install Node.js (version 22 or higher recommended):
+
+```sh
+# Using nvm (recommended)
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
+nvm install 22
+nvm use 22
+
+# Or download from https://nodejs.org/
+```
 
 ### Install Enclave CLI
 
@@ -96,14 +100,6 @@ enclaveup install
 ```
 
 For more installation options and details, see the [Installation Guide](/installation).
-
-**Alternative: Build from Source**
-
-If you prefer to build from source:
-
-```sh
-cargo install --locked --path ./crates/cli --bin enclave -f
-```
 
 ### Install Rust and Foundry
 
@@ -136,6 +132,24 @@ cargo risczero --version
 ```
 
 At this point, you should have all the necessary tools to develop and deploy applications with [RISC Zero](https://www.risczero.com).
+
+### Clone the Repository
+
+Now clone the Enclave repository which contains the CRISP example:
+
+```sh
+git clone https://github.com/gnosisguild/enclave.git
+cd enclave
+```
+
+**Alternative: Build Enclave CLI from Source**
+
+If you prefer to build the Enclave CLI from source instead of using the installer:
+
+```sh
+# Make sure you're in the cloned repository root (you should be after the clone step)
+cargo install --locked --path ./crates/cli --bin enclave -f
+```
 
 ## Setting Up the Client
 
@@ -236,7 +250,7 @@ Make sure to take note of the **CRISP Program Contract Address**, as this will s
 
 ### Set Up Ciphernodes
 
-Start the ciphernodes using the Enclave CLI:
+Start the ciphernodes using the Enclave CLI (make sure you're in the `examples/CRISP` directory):
 
 1. Set up the aggregator wallet:
 
@@ -253,7 +267,7 @@ Start the ciphernodes using the Enclave CLI:
 3. Add ciphernodes to the registry:
 
    ```sh
-   # Navigate back to the Enclave repository root
+   # Navigate to the `packages/evm` directory to add ciphernodes to the registry
    cd ../../packages/evm
 
    # Add the ciphernodes

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9623,7 +9623,7 @@ snapshots:
     dependencies:
       comlink: 4.4.2
       commander: 12.1.0
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.1(supports-color@8.1.1)
       fflate: 0.8.2
       pako: 2.1.0
       tslib: 2.8.1
@@ -9634,7 +9634,7 @@ snapshots:
     dependencies:
       comlink: 4.4.2
       commander: 12.1.0
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.1(supports-color@8.1.1)
       fflate: 0.8.2
       pako: 2.1.0
       tslib: 2.8.1
@@ -9659,10 +9659,10 @@ snapshots:
       '@babel/helpers': 7.27.6
       '@babel/parser': 7.27.7
       '@babel/template': 7.27.2
-      '@babel/traverse': 7.27.7(supports-color@5.5.0)
+      '@babel/traverse': 7.27.7
       '@babel/types': 7.27.7
       convert-source-map: 2.0.0
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.1(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -9703,7 +9703,7 @@ snapshots:
       '@babel/helper-optimise-call-expression': 7.27.1
       '@babel/helper-replace-supers': 7.27.1(@babel/core@7.27.7)
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/traverse': 7.27.7(supports-color@5.5.0)
+      '@babel/traverse': 7.27.7
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -9720,7 +9720,7 @@ snapshots:
       '@babel/core': 7.27.7
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.1(supports-color@8.1.1)
       lodash.debounce: 4.0.8
       resolve: 1.22.10
     transitivePeerDependencies:
@@ -9741,7 +9741,14 @@ snapshots:
 
   '@babel/helper-member-expression-to-functions@7.27.1':
     dependencies:
-      '@babel/traverse': 7.27.7(supports-color@5.5.0)
+      '@babel/traverse': 7.27.7
+      '@babel/types': 7.27.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-imports@7.27.1':
+    dependencies:
+      '@babel/traverse': 7.27.7
       '@babel/types': 7.27.7
     transitivePeerDependencies:
       - supports-color
@@ -9756,9 +9763,9 @@ snapshots:
   '@babel/helper-module-transforms@7.27.3(@babel/core@7.27.7)':
     dependencies:
       '@babel/core': 7.27.7
-      '@babel/helper-module-imports': 7.27.1(supports-color@5.5.0)
+      '@babel/helper-module-imports': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
-      '@babel/traverse': 7.27.7(supports-color@5.5.0)
+      '@babel/traverse': 7.27.7
     transitivePeerDependencies:
       - supports-color
 
@@ -9773,7 +9780,7 @@ snapshots:
       '@babel/core': 7.27.7
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-wrap-function': 7.27.1
-      '@babel/traverse': 7.27.7(supports-color@5.5.0)
+      '@babel/traverse': 7.27.7
     transitivePeerDependencies:
       - supports-color
 
@@ -9782,13 +9789,13 @@ snapshots:
       '@babel/core': 7.27.7
       '@babel/helper-member-expression-to-functions': 7.27.1
       '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/traverse': 7.27.7(supports-color@5.5.0)
+      '@babel/traverse': 7.27.7
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
     dependencies:
-      '@babel/traverse': 7.27.7(supports-color@5.5.0)
+      '@babel/traverse': 7.27.7
       '@babel/types': 7.27.7
     transitivePeerDependencies:
       - supports-color
@@ -9806,7 +9813,7 @@ snapshots:
   '@babel/helper-wrap-function@7.27.1':
     dependencies:
       '@babel/template': 7.27.2
-      '@babel/traverse': 7.27.7(supports-color@5.5.0)
+      '@babel/traverse': 7.27.7
       '@babel/types': 7.27.7
     transitivePeerDependencies:
       - supports-color
@@ -9824,7 +9831,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.27.7
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.27.7(supports-color@5.5.0)
+      '@babel/traverse': 7.27.7
     transitivePeerDependencies:
       - supports-color
 
@@ -9851,7 +9858,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.27.7
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.27.7(supports-color@5.5.0)
+      '@babel/traverse': 7.27.7
     transitivePeerDependencies:
       - supports-color
 
@@ -9895,14 +9902,14 @@ snapshots:
       '@babel/core': 7.27.7
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.27.7)
-      '@babel/traverse': 7.27.7(supports-color@5.5.0)
+      '@babel/traverse': 7.27.7
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-transform-async-to-generator@7.27.1(@babel/core@7.27.7)':
     dependencies:
       '@babel/core': 7.27.7
-      '@babel/helper-module-imports': 7.27.1(supports-color@5.5.0)
+      '@babel/helper-module-imports': 7.27.1
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.27.7)
     transitivePeerDependencies:
@@ -9941,7 +9948,7 @@ snapshots:
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-replace-supers': 7.27.1(@babel/core@7.27.7)
-      '@babel/traverse': 7.27.7(supports-color@5.5.0)
+      '@babel/traverse': 7.27.7
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -9956,7 +9963,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.27.7
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.27.7(supports-color@5.5.0)
+      '@babel/traverse': 7.27.7
     transitivePeerDependencies:
       - supports-color
 
@@ -10005,7 +10012,7 @@ snapshots:
       '@babel/core': 7.27.7
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.27.7(supports-color@5.5.0)
+      '@babel/traverse': 7.27.7
     transitivePeerDependencies:
       - supports-color
 
@@ -10051,7 +10058,7 @@ snapshots:
       '@babel/helper-module-transforms': 7.27.3(@babel/core@7.27.7)
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
-      '@babel/traverse': 7.27.7(supports-color@5.5.0)
+      '@babel/traverse': 7.27.7
     transitivePeerDependencies:
       - supports-color
 
@@ -10091,7 +10098,7 @@ snapshots:
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/plugin-transform-destructuring': 7.27.7(@babel/core@7.27.7)
       '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.27.7)
-      '@babel/traverse': 7.27.7(supports-color@5.5.0)
+      '@babel/traverse': 7.27.7
     transitivePeerDependencies:
       - supports-color
 
@@ -10174,7 +10181,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.27.7
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-module-imports': 7.27.1(supports-color@5.5.0)
+      '@babel/helper-module-imports': 7.27.1
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.27.7)
       '@babel/types': 7.27.7
@@ -10388,7 +10395,19 @@ snapshots:
       '@babel/helper-split-export-declaration': 7.24.7
       '@babel/parser': 7.27.7
       '@babel/types': 7.27.7
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.1(supports-color@8.1.1)
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/traverse@7.27.7':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/generator': 7.27.5
+      '@babel/parser': 7.27.7
+      '@babel/template': 7.27.2
+      '@babel/types': 7.27.7
+      debug: 4.4.1(supports-color@8.1.1)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -10631,7 +10650,7 @@ snapshots:
 
   '@emotion/babel-plugin@11.13.5':
     dependencies:
-      '@babel/helper-module-imports': 7.27.1(supports-color@5.5.0)
+      '@babel/helper-module-imports': 7.27.1
       '@babel/runtime': 7.27.6
       '@emotion/hash': 0.9.2
       '@emotion/memoize': 0.9.0
@@ -10935,7 +10954,7 @@ snapshots:
   '@eslint/eslintrc@2.1.4':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.1(supports-color@8.1.1)
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.2
@@ -11262,7 +11281,7 @@ snapshots:
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.1(supports-color@8.1.1)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -11562,7 +11581,7 @@ snapshots:
       bufferutil: 4.0.9
       cross-fetch: 4.1.0
       date-fns: 2.30.0
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.1(supports-color@8.1.1)
       eciesjs: 0.4.15
       eventemitter2: 6.4.9
       readable-stream: 3.6.2
@@ -11586,7 +11605,7 @@ snapshots:
       '@paulmillr/qr': 0.2.1
       bowser: 2.11.0
       cross-fetch: 4.1.0
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.1(supports-color@8.1.1)
       eciesjs: 0.4.15
       eth-rpc-errors: 4.0.3
       eventemitter2: 6.4.9
@@ -11609,7 +11628,7 @@ snapshots:
     dependencies:
       '@ethereumjs/tx': 4.2.0
       '@types/debug': 4.1.12
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.1(supports-color@8.1.1)
       semver: 7.7.2
       superstruct: 1.0.4
     transitivePeerDependencies:
@@ -11622,7 +11641,7 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
       '@types/debug': 4.1.12
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.1(supports-color@8.1.1)
       pony-cause: 2.1.11
       semver: 7.7.2
       uuid: 9.0.1
@@ -11636,7 +11655,7 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
       '@types/debug': 4.1.12
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.1(supports-color@8.1.1)
       pony-cause: 2.1.11
       semver: 7.7.2
       uuid: 9.0.1
@@ -11956,7 +11975,7 @@ snapshots:
 
   '@nomicfoundation/hardhat-ethers@3.0.9(ethers@5.8.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(hardhat@2.25.0(bufferutil@4.0.9)(ts-node@10.9.2(@swc/core@1.12.7)(@types/node@22.15.33)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10))':
     dependencies:
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.1(supports-color@8.1.1)
       ethers: 5.8.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       hardhat: 2.25.0(bufferutil@4.0.9)(ts-node@10.9.2(@swc/core@1.12.7)(@types/node@22.15.33)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10)
       lodash.isequal: 4.5.0
@@ -11965,7 +11984,7 @@ snapshots:
 
   '@nomicfoundation/hardhat-ethers@3.0.9(ethers@6.14.4(bufferutil@4.0.9)(utf-8-validate@5.0.10))(hardhat@2.25.0(bufferutil@4.0.9)(ts-node@10.9.2(@swc/core@1.12.7)(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10))':
     dependencies:
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.1(supports-color@8.1.1)
       ethers: 6.14.4(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       hardhat: 2.25.0(bufferutil@4.0.9)(ts-node@10.9.2(@swc/core@1.12.7)(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10)
       lodash.isequal: 4.5.0
@@ -11991,7 +12010,7 @@ snapshots:
       '@nomicfoundation/ignition-core': 0.15.12(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       '@nomicfoundation/ignition-ui': 0.15.11
       chalk: 4.1.2
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.1(supports-color@8.1.1)
       fs-extra: 10.1.0
       hardhat: 2.25.0(bufferutil@4.0.9)(ts-node@10.9.2(@swc/core@1.12.7)(@types/node@22.15.33)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10)
       json5: 2.2.3
@@ -12077,7 +12096,7 @@ snapshots:
       '@ethersproject/abi': 5.8.0
       '@ethersproject/address': 5.8.0
       cbor: 8.1.0
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.1(supports-color@8.1.1)
       hardhat: 2.25.0(bufferutil@4.0.9)(ts-node@10.9.2(@swc/core@1.12.7)(@types/node@22.15.33)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10)
       lodash.clonedeep: 4.5.0
       picocolors: 1.1.1
@@ -12092,7 +12111,7 @@ snapshots:
       '@ethersproject/abi': 5.8.0
       '@ethersproject/address': 5.8.0
       cbor: 8.1.0
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.1(supports-color@8.1.1)
       hardhat: 2.25.0(bufferutil@4.0.9)(ts-node@10.9.2(@swc/core@1.12.7)(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10)
       lodash.clonedeep: 4.5.0
       picocolors: 1.1.1
@@ -12107,7 +12126,7 @@ snapshots:
       '@ethersproject/address': 5.6.1
       '@nomicfoundation/solidity-analyzer': 0.1.2
       cbor: 9.0.2
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.1(supports-color@8.1.1)
       ethers: 6.14.4(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       fs-extra: 10.1.0
       immer: 10.0.2
@@ -12961,7 +12980,7 @@ snapshots:
       '@depay/web3-mock-evm': 14.19.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       '@playwright/test': 1.52.0
       '@synthetixio/synpress-core': 0.0.12(@playwright/test@1.52.0)
-      viem: 2.30.6(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.22.4)
+      viem: 2.30.6(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - '@depay/solana-web3.js'
       - '@depay/web3-blockchains'
@@ -13404,7 +13423,7 @@ snapshots:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 7.18.0
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.1(supports-color@8.1.1)
       eslint: 8.57.1
     optionalDependencies:
       typescript: 5.8.3
@@ -13420,7 +13439,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.8.3)
       '@typescript-eslint/utils': 7.18.0(eslint@8.57.1)(typescript@5.8.3)
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.1(supports-color@8.1.1)
       eslint: 8.57.1
       ts-api-utils: 1.4.3(typescript@5.8.3)
     optionalDependencies:
@@ -13434,7 +13453,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/visitor-keys': 7.18.0
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.1(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -14274,7 +14293,7 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -14593,7 +14612,7 @@ snapshots:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.1(supports-color@8.1.1)
       http-errors: 2.0.0
       iconv-lite: 0.6.3
       on-finished: 2.4.1
@@ -15876,7 +15895,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.1(supports-color@8.1.1)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -16184,7 +16203,7 @@ snapshots:
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.1(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -16323,7 +16342,7 @@ snapshots:
 
   finalhandler@2.1.0:
     dependencies:
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.1(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -16382,7 +16401,7 @@ snapshots:
 
   follow-redirects@1.15.9(debug@4.4.1):
     optionalDependencies:
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.1(supports-color@8.1.1)
 
   for-each@0.3.5:
     dependencies:
@@ -16733,7 +16752,7 @@ snapshots:
       axios: 0.21.4(debug@4.4.1)
       chalk: 4.1.2
       chokidar: 3.6.0
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.1(supports-color@8.1.1)
       enquirer: 2.4.1
       ethers: 5.8.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       form-data: 4.0.3
@@ -16788,7 +16807,7 @@ snapshots:
       lodash: 4.17.21
       markdown-table: 2.0.0
       sha1: 1.1.1
-      viem: 2.30.6(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.22.4)
+      viem: 2.30.6(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -16811,7 +16830,7 @@ snapshots:
       boxen: 5.1.2
       chokidar: 4.0.3
       ci-info: 2.0.0
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.1(supports-color@8.1.1)
       enquirer: 2.4.1
       env-paths: 2.2.1
       ethereum-cryptography: 1.2.0
@@ -16862,7 +16881,7 @@ snapshots:
       boxen: 5.1.2
       chokidar: 4.0.3
       ci-info: 2.0.0
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.1(supports-color@8.1.1)
       enquirer: 2.4.1
       env-paths: 2.2.1
       ethereum-cryptography: 1.2.0
@@ -17149,7 +17168,7 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -18318,7 +18337,7 @@ snapshots:
   micromark@3.2.0:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.1(supports-color@8.1.1)
       decode-named-character-reference: 1.2.0
       micromark-core-commonmark: 1.1.0
       micromark-factory-space: 1.1.0
@@ -18340,7 +18359,7 @@ snapshots:
   micromark@4.0.2:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.1(supports-color@8.1.1)
       decode-named-character-reference: 1.2.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -18790,6 +18809,21 @@ snapshots:
   os-tmpdir@1.0.2: {}
 
   outdent@0.5.0: {}
+
+  ox@0.7.1(typescript@5.8.3):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.0
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.2
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.0.8(typescript@5.8.3)(zod@3.25.67)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - zod
 
   ox@0.7.1(typescript@5.8.3)(zod@3.22.4):
     dependencies:
@@ -19640,7 +19674,7 @@ snapshots:
 
   router@2.2.0:
     dependencies:
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.1(supports-color@8.1.1)
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -19726,7 +19760,7 @@ snapshots:
 
   send@1.2.0:
     dependencies:
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.1(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -20538,7 +20572,7 @@ snapshots:
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.2
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.1(supports-color@8.1.1)
       esbuild: 0.25.6
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
@@ -20568,7 +20602,7 @@ snapshots:
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.2
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.1(supports-color@8.1.1)
       esbuild: 0.25.6
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
@@ -20628,7 +20662,7 @@ snapshots:
   typechain@8.3.2(typescript@5.8.3):
     dependencies:
       '@types/prettier': 2.7.3
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.1(supports-color@8.1.1)
       fs-extra: 7.0.1
       glob: 7.1.7
       js-sha3: 0.8.0
@@ -20927,6 +20961,23 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
+  viem@2.30.6(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10):
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.0.8(typescript@5.8.3)(zod@3.25.67)
+      isows: 1.0.7(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      ox: 0.7.1(typescript@5.8.3)
+      ws: 8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+    optionalDependencies:
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+
   viem@2.30.6(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.22.4):
     dependencies:
       '@noble/curves': 1.9.1
@@ -20964,7 +21015,7 @@ snapshots:
   vite-node@1.6.1(@types/node@22.7.5):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.1(supports-color@8.1.1)
       pathe: 1.1.2
       picocolors: 1.1.1
       vite: 5.4.19(@types/node@22.7.5)
@@ -20986,7 +21037,7 @@ snapshots:
       '@volar/typescript': 2.4.18
       '@vue/language-core': 2.2.0(typescript@5.8.3)
       compare-versions: 6.1.1
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.1(supports-color@8.1.1)
       kolorist: 1.8.0
       local-pkg: 1.1.1
       magic-string: 0.30.17
@@ -21036,7 +21087,7 @@ snapshots:
 
   vite-tsconfig-paths@4.3.2(typescript@5.8.3)(vite@5.4.19(@types/node@22.7.5)):
     dependencies:
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.1(supports-color@8.1.1)
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.8.3)
     optionalDependencies:
@@ -21078,7 +21129,7 @@ snapshots:
       '@vitest/utils': 1.6.1
       acorn-walk: 8.3.4
       chai: 4.5.0
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.1(supports-color@8.1.1)
       execa: 8.0.1
       local-pkg: 0.5.1
       magic-string: 0.30.17


### PR DESCRIPTION
I noticed the CRISP docs already assumed the user had the repo cloned and some prereqs in some places but it wasn't explicitly stated so I added them.
- Added a description for the setup page.
- Clarified instructions for cloning the repository and navigating directories.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Documentation**
  * Improved CRISP setup instructions for clarity and completeness, including enhanced Docker quick start steps, clearer directory navigation guidance, and updated Node.js installation recommendations.
  * Refined instructions for building the Enclave CLI and setting up ciphernodes.
  * Removed redundant steps and made minor formatting improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->