### PR TITLE
fix: ensure we publish the dist folder of the sdk

### DIFF
--- a/packages/enclave-sdk/package.json
+++ b/packages/enclave-sdk/package.json
@@ -9,6 +9,9 @@
       "default": "./dist/index.js"
     }
   },
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "prebuild": "cd ../evm && pnpm compile:ts && cd ../../crates/wasm && pnpm build",
     "build": "tsup",


### PR DESCRIPTION
Ensure we publish the dist folder of the SDK 