### PR TITLE
chore: tidy init stdout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2022,6 +2022,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e09ced7ebbccb63b4c65413d821f2e00ce54c5ca4514ddc6b3c892fdbcbc69d"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "const-hex"
 version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2375,7 +2388,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
 dependencies = [
- "console",
+ "console 0.15.11",
  "shell-words",
  "tempfile",
  "thiserror 1.0.69",
@@ -2785,6 +2798,7 @@ dependencies = [
  "async-trait",
  "e3-fs",
  "git2",
+ "indicatif 0.18.0",
  "regex",
  "serde",
  "serde_json",
@@ -3045,7 +3059,7 @@ dependencies = [
  "directories",
  "flate2",
  "futures-util",
- "indicatif",
+ "indicatif 0.17.11",
  "reqwest",
  "serde",
  "serde_json",
@@ -4216,10 +4230,23 @@ version = "0.17.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
 dependencies = [
- "console",
+ "console 0.15.11",
  "number_prefix",
  "portable-atomic",
  "unicode-width",
+ "web-time",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a646d946d06bedbbc4cac4c218acf4bbf2d87757a784857025f4d447e4e1cd"
+dependencies = [
+ "console 0.16.0",
+ "portable-atomic",
+ "unicode-width",
+ "unit-prefix",
  "web-time",
 ]
 
@@ -7758,6 +7785,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unit-prefix"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323402cff2dd658f39ca17c789b502021b3f18707c91cdf22e3838e1b4023817"
 
 [[package]]
 name = "universal-hash"

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -94,7 +94,7 @@ impl Cli {
                     Commands::Rev => rev::execute().await?,
                     Commands::Init {path, template, skip_cleanup} => {
                         setup_simple_tracing(log_level);
-                        init::execute(path, template, skip_cleanup).await?
+                        init::execute(path, template, skip_cleanup, self.verbose > 0).await?
                     },
                     Commands::ConfigSet {
                         rpc_url,

--- a/crates/cli/src/init.rs
+++ b/crates/cli/src/init.rs
@@ -12,6 +12,7 @@ pub async fn execute(
     location: Option<PathBuf>,
     template: Option<String>,
     skip_cleanup: bool,
+    verbose: bool,
 ) -> Result<()> {
-    e3_init::execute(location, template, skip_cleanup).await
+    e3_init::execute(location, template, skip_cleanup, verbose).await
 }

--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -142,20 +142,16 @@ impl FileFinder for Fs {
         let pattern = Pattern::new(glob_pattern)?;
         let mut matching_files = Vec::new();
 
-        println!("Folder Path: {}", folder_path.as_str());
-        println!("Pattern: {pattern}");
-
         let all_entries: Vec<_> = folder_path
             .walk_dir()
             .await?
             .map(|res| res.unwrap())
             .collect::<Vec<_>>()
             .await;
-        println!("ALL ENTRIES: {:?}", all_entries);
+
         for entry in all_entries {
             if entry.is_file().await? {
                 let filename = entry.as_str();
-                println!("entry is file for {filename}");
                 if pattern.matches(filename) {
                     matching_files.push(entry.as_str().to_string());
                 }
@@ -173,18 +169,10 @@ impl Replacer for Fs {
         replacement: &str,
         file_path: P,
     ) -> Result<()> {
-        println!(
-            "replace_in_place({:?},{:?},{:?})",
-            &pattern,
-            &replacement,
-            file_path.as_ref()
-        );
         let content = self.read_to_string(&file_path).await?;
         let new_content = pattern.replace_all(&content, replacement);
         if content != new_content {
             self.write_to_file(file_path, &new_content).await?;
-        } else {
-            println!("No change made to {:?}", file_path.as_ref());
         }
         Ok(())
     }

--- a/crates/init/Cargo.toml
+++ b/crates/init/Cargo.toml
@@ -18,3 +18,4 @@ url.workspace = true
 e3-fs.workspace = true
 regex.workspace = true
 tracing.workspace = true
+indicatif = "0.18.0"

--- a/crates/init/src/copy.rs
+++ b/crates/init/src/copy.rs
@@ -50,6 +50,7 @@ where
             &filter.glob_pattern
         );
         info!("Running filter: {:?}", filter);
+
         let file_paths = fs.find_files(&dest_path, &prefixed_glob_pattern).await?;
         info!("pattern:{} found {:?}", filter.glob_pattern, file_paths);
 

--- a/crates/init/src/file_utils.rs
+++ b/crates/init/src/file_utils.rs
@@ -18,14 +18,14 @@ pub async fn ensure_empty_folder<P: AsRef<Path>>(path: P) -> Result<()> {
     }
 
     if !path.is_dir() {
-        bail!("Path '{}' is not a directory", path.display());
+        bail!("❌ Path '{}' is not a directory", path.display());
     }
 
     let mut entries = std::fs::read_dir(path)
         .map_err(|e| anyhow::anyhow!("Failed to read directory '{}': {}", path.display(), e))?;
 
     if entries.next().is_some() {
-        bail!("Directory '{}' is not empty", path.display());
+        bail!("❌ Directory '{}' is not empty", path.display());
     }
 
     Ok(())

--- a/crates/init/src/lib.rs
+++ b/crates/init/src/lib.rs
@@ -7,6 +7,7 @@
 mod copy;
 mod file_utils;
 mod git;
+mod logging;
 mod package_json;
 mod pkgman;
 
@@ -16,141 +17,242 @@ use file_utils::{chmod_recursive, delete_path, move_file, remove_all_files_in_di
 use git::parse_git_url;
 use package_json::DependencyType;
 use pkgman::PkgMan;
-use std::env;
 use std::path::PathBuf;
 use std::process::exit;
+use std::{env, vec};
 use tokio::fs;
 
-// const GIT_URL: &str = "https://github.com/gnosisguild/enclave.git#ry/support-alterations-2";
+use crate::logging::TaskSpinner;
+
 const DEFAULT_TEMPLATE_URL: &str =
     "https://github.com/gnosisguild/enclave.git#main:templates/default";
 const TEMP_DIR: &str = "/tmp/__enclave-tmp-folder.1";
 const DEFAULT_TEMPLATE_PATH: &str = ".";
 const DEFAULT_BRANCH: &str = "main";
 
-async fn install_enclave(cwd: &PathBuf, template: Option<String>) -> Result<()> {
+async fn install_enclave(cwd: &PathBuf, template: Option<String>, verbose: bool) -> Result<()> {
+    let mut spinner = TaskSpinner::new("".to_string(), verbose);
+
+    spinner.update("Downloading template...".to_string()).await;
+
     let repo = parse_git_url(template.unwrap_or(DEFAULT_TEMPLATE_URL.to_string()))?;
     let base_url = repo.base_url;
     let branch = repo.branch.unwrap_or(DEFAULT_BRANCH.to_string());
     let template_path = repo.path.unwrap_or(DEFAULT_TEMPLATE_PATH.to_string());
 
-    println!("Start git clone...");
-    git::shallow_clone(&base_url, &branch, TEMP_DIR).await?;
+    spinner
+        .run("Start git clone", || async {
+            git::shallow_clone(&base_url, &branch, TEMP_DIR, verbose).await
+        })
+        .await?;
 
-    println!("Getting workspace version for enclave...");
-    let evm_version = package_json::get_version_from_package_json(
-        &PathBuf::from(TEMP_DIR).join("packages/evm/package.json"),
-    )
-    .await?;
+    spinner.complete_task("Template downloaded\n");
 
-    println!("Getting workspace version for enclave_react...");
-    let react_version = package_json::get_version_from_package_json(
-        &PathBuf::from(TEMP_DIR).join("packages/enclave-react/package.json"),
-    )
-    .await?;
+    spinner.update("Configuring template...".to_string()).await;
 
-    println!("Getting workspace version for enclave-sdk...");
-    let sdk_version = package_json::get_version_from_package_json(
-        &PathBuf::from(TEMP_DIR).join("packages/enclave-sdk/package.json"),
-    )
-    .await?;
+    let evm_version = spinner
+        .run("Getting workspace version of enclave...", || async {
+            package_json::get_version_from_package_json(
+                &PathBuf::from(TEMP_DIR).join("packages/evm/package.json"),
+            )
+            .await
+        })
+        .await?;
+
+    let react_version = spinner
+        .run("Getting workspace version of enclave-react...", || async {
+            package_json::get_version_from_package_json(
+                &PathBuf::from(TEMP_DIR).join("packages/enclave-react/package.json"),
+            )
+            .await
+        })
+        .await?;
+
+    let sdk_version = spinner
+        .run("Getting workspace version of enclave-sdk...", || async {
+            package_json::get_version_from_package_json(
+                &PathBuf::from(TEMP_DIR).join("packages/enclave-sdk/package.json"),
+            )
+            .await
+        })
+        .await?;
+
     let src = PathBuf::from(TEMP_DIR).join(template_path);
 
-    println!("Copy with filters...");
-    copy::copy_with_filters(
-        &src,
-        &cwd,
-        &vec![
-            Filter::new(
-                "**/package.json",
-                r#""@gnosis-guild/enclave":\s*"[^"]*""#,
-                &format!(r#""@gnosis-guild/enclave": "{}""#, evm_version),
-            ),
-            Filter::new(
-                "**/package.json",
-                r#""@gnosis-guild/enclave-react":\s*"[^"]*""#,
-                &format!(r#""@gnosis-guild/enclave-react": "{}""#, react_version),
-            ),
-            Filter::new(
-                "**/package.json",
-                r#""@gnosis-guild/enclave-sdk":\s*"[^"]*""#,
-                &format!(r#""@gnosis-guild/enclave-sdk": "{}""#, sdk_version),
-            ),
-        ],
-    )
-    .await?;
+    spinner
+        .run("Copy with filters...", || async {
+            copy::copy_with_filters(
+                &src,
+                &cwd,
+                &vec![
+                    Filter::new(
+                        "**/package.json",
+                        r#""@gnosis-guild/enclave":\s*"[^"]*""#,
+                        &format!(r#""@gnosis-guild/enclave": "{}""#, evm_version),
+                    ),
+                    Filter::new(
+                        "**/package.json",
+                        r#""@gnosis-guild/enclave-react":\s*"[^"]*""#,
+                        &format!(r#""@gnosis-guild/enclave-react": "{}""#, react_version),
+                    ),
+                    Filter::new(
+                        "**/package.json",
+                        r#""@gnosis-guild/enclave-sdk":\s*"[^"]*""#,
+                        &format!(r#""@gnosis-guild/enclave-sdk": "{}""#, sdk_version),
+                    ),
+                ],
+            )
+            .await
+        })
+        .await?;
 
-    println!("Resetting support folder...");
-    delete_path(&cwd.join(".enclave")).await?;
+    spinner.complete_task("Template configured\n");
 
-    println!("Setting up support folders...");
-    copy::copy_with_filters(
-        &PathBuf::from(TEMP_DIR).join("crates/support-scripts/ctl"),
-        &cwd.join(".enclave/support/ctl"),
-        &vec![],
-    )
-    .await?;
+    spinner
+        .update("Setting up support folders...".to_string())
+        .await;
 
-    copy::copy_with_filters(
-        &PathBuf::from(TEMP_DIR).join("crates/support-scripts/dev"),
-        &cwd.join(".enclave/support/dev"),
-        &vec![],
-    )
-    .await?;
+    spinner
+        .run("Resetting support folder...", || async {
+            delete_path(&cwd.join(".enclave")).await
+        })
+        .await?;
 
-    println!("Removing template ignore files...");
-    delete_path(&cwd.join(".gitignore")).await?;
+    spinner
+        .run("Setting up support folders ctl and dev", || async {
+            copy::copy_with_filters(
+                &PathBuf::from(TEMP_DIR).join("crates/support-scripts/ctl"),
+                &cwd.join(".enclave/support/ctl"),
+                &vec![],
+            )
+            .await?;
 
-    println!("Using bak files for ignores...");
-    move_file(&cwd.join(".gitignore.bak"), &cwd.join(".gitignore")).await?;
+            copy::copy_with_filters(
+                &PathBuf::from(TEMP_DIR).join("crates/support-scripts/dev"),
+                &cwd.join(".enclave/support/dev"),
+                &vec![],
+            )
+            .await
+        })
+        .await?;
 
-    println!("Move bak files for workspace...");
-    move_file(
-        &cwd.join("pnpm-workspace.yaml.bak"),
-        &cwd.join("pnpm-workspace.yaml"),
-    )
-    .await?;
+    spinner
+        .run("Removing template ignore files...", || async {
+            delete_path(&cwd.join(".gitignore")).await
+        })
+        .await?;
 
-    println!("Remove lib folder...");
-    delete_path(&cwd.join("lib")).await?;
+    spinner
+        .run("Using bak files for ignores...", || async {
+            move_file(&cwd.join(".gitignore.bak"), &cwd.join(".gitignore")).await
+        })
+        .await?;
+
+    spinner
+        .run("Move bak files for workspace...", || async {
+            move_file(
+                &cwd.join("pnpm-workspace.yaml.bak"),
+                &cwd.join("pnpm-workspace.yaml"),
+            )
+            .await
+        })
+        .await?;
+
+    spinner
+        .run("Remove lib folder...", || async {
+            delete_path(&cwd.join("lib")).await
+        })
+        .await?;
+
+    spinner.complete_task("Support folders set up\n");
 
     // We need to make these chmod 777 because the dockerfile needs to be able to successfully
     // write to them. There are better ways to do this but right now this is the most efficient.
     // PRs/Ideas welcome.
-    //
-    println!("Fixing permissions...");
-    chmod_recursive(&cwd.join("contracts"), "777").await?;
-    chmod_recursive(&cwd.join("tests"), "777").await?;
+    spinner.update("Restoring permissions...".to_string()).await;
 
-    println!("Initializing repository...");
-    git::init(&cwd).await?;
+    spinner
+        .run("Setting contracts folder permissions to 777", || async {
+            chmod_recursive(&cwd.join("contracts"), "777").await
+        })
+        .await?;
+    spinner
+        .run("Setting tests folder permissions to 777", || async {
+            chmod_recursive(&cwd.join("tests"), "777").await
+        })
+        .await?;
 
-    println!("Setting up submodule...");
-    git::add_submodule(
-        &cwd,
-        "https://github.com/gnosisguild/risc0-ethereum",
-        "lib/risc0-ethereum",
-    )
-    .await?;
+    spinner.complete_task("Permissions restored\n");
 
-    println!("Ensuring package is in json...");
-    package_json::add_package_to_json(
-        &cwd.join("package.json"),
-        "@risc0/ethereum",
-        "file:lib/risc0-ethereum",
-        DependencyType::DevDependencies,
-    )
-    .await?;
+    spinner.update("Setting up submodules...").await;
 
-    println!("Running pnpm install...");
-    let npm = PkgMan::new(pkgman::PkgManKind::PNPM)?.with_cwd(&cwd);
-    npm.run(&["install"]).await?;
+    spinner
+        .run("Init git repo", || async { git::init(&cwd, verbose).await })
+        .await?;
 
-    println!("Adding everything to git...");
-    git::add_all(&cwd).await?;
+    spinner
+        .run("Adding @risc0/ethereum submodule", || async {
+            git::add_submodule(
+                &cwd,
+                "https://github.com/gnosisguild/risc0-ethereum",
+                "lib/risc0-ethereum",
+                verbose,
+            )
+            .await
+        })
+        .await?;
 
-    println!("Committing...");
-    git::commit(&cwd, "Initial Commit").await?;
+    spinner
+        .run("Ensuring @risc0/ethereum is in package.json", || async {
+            package_json::add_package_to_json(
+                &cwd.join("package.json"),
+                "@risc0/ethereum",
+                "file:lib/risc0-ethereum",
+                DependencyType::DevDependencies,
+            )
+            .await
+        })
+        .await?;
+
+    spinner.complete_task("Submodules set up\n");
+
+    spinner
+        .update("Installing packages with pnpm...".to_string())
+        .await;
+
+    spinner
+        .run("", || async {
+            let npm = PkgMan::new(pkgman::PkgManKind::PNPM)?.with_cwd(&cwd);
+            let mut args = vec!["install"];
+            if !verbose {
+                args.push("--silent");
+            }
+            npm.run(&args).await
+        })
+        .await?;
+
+    spinner.complete_task("Packages installed\n");
+
+    spinner.update("Setting up local git repository...").await;
+
+    spinner
+        .run("Adding all files to git", || async {
+            git::add_all(&cwd, verbose).await
+        })
+        .await?;
+    spinner
+        .run("Committing changes", || async {
+            git::commit(&cwd, "Initial Commit", verbose).await
+        })
+        .await?;
+
+    git::add_all(&cwd, verbose).await?;
+
+    git::commit(&cwd, "Initial Commit", verbose).await?;
+
+    spinner.complete_task("Git repository set up\n");
+
+    spinner.done("🎉 You can now start building on Enclave");
 
     Ok(())
 }
@@ -160,7 +262,25 @@ pub async fn execute(
     location: Option<PathBuf>,
     template: Option<String>,
     skip_cleanup: bool,
+    verbose: bool,
 ) -> Result<()> {
+    println!(
+        r"
+    ░██████████                       ░██                                  
+    ░██                               ░██                                  
+    ░██         ░████████   ░███████  ░██  ░██████   ░██    ░██  ░███████  
+    ░█████████  ░██    ░██ ░██    ░██ ░██       ░██  ░██    ░██ ░██    ░██ 
+    ░██         ░██    ░██ ░██        ░██  ░███████   ░██  ░██  ░█████████ 
+    ░██         ░██    ░██ ░██    ░██ ░██ ░██   ░██    ░██░██   ░██        
+    ░██████████ ░██    ░██  ░███████  ░██  ░█████░██    ░███     ░███████                                                                                                                                                     
+    "
+    );
+
+    let mut task_spinner =
+        TaskSpinner::new("Setting up a new Enclave project".to_string(), verbose);
+
+    task_spinner.update("Preparing paths...".to_string()).await;
+
     let mut install_in_current_dir = false;
     let env_current_dir = env::current_dir()?;
     let cwd = match location {
@@ -177,27 +297,39 @@ pub async fn execute(
         }
     };
 
-    println!("Ensuring tmp folder does not exist...");
-    if fs::try_exists(TEMP_DIR).await? {
-        fs::remove_dir_all(TEMP_DIR).await?;
-    }
+    task_spinner
+        .run("Ensuring tmp dir does not exists...", || async {
+            if fs::try_exists(TEMP_DIR).await? {
+                fs::remove_dir_all(TEMP_DIR).await?;
+            }
+            Ok(())
+        })
+        .await?;
 
-    println!("Ensuring cwd is empty...");
-    file_utils::ensure_empty_folder(&cwd).await?;
+    task_spinner
+        .run("Ensuring current directory is empty...", || async {
+            file_utils::ensure_empty_folder(&cwd).await?;
 
-    match install_enclave(&cwd, template).await {
+            Ok(())
+        })
+        .await?;
+
+    task_spinner.complete_task("Paths prepared");
+    task_spinner.done("");
+
+    match install_enclave(&cwd, template, verbose).await {
         Ok(_) => Ok(()),
         Err(e) => {
-            println!("Cleaning up due to error...");
             if !skip_cleanup {
+                println!("❌ Cleaning up due to error...");
                 if install_in_current_dir {
                     remove_all_files_in_dir(&cwd).await?;
                 } else {
                     fs::remove_dir_all(&cwd).await?;
                 }
             }
-            eprintln!("\nSorry about this but there was an error running the installer. ");
-            eprintln!("\n Error: {}\n", e);
+            eprintln!("❌ Sorry about this but there was an error running the installer. ");
+            eprintln!("❌ Error: {}\n", e);
             eprintln!("Enclave is currently under active development please share this with our team:\n\n  https://github.com/gnosisguild/enclave/issues/new\n");
             exit(1);
         }

--- a/crates/init/src/logging.rs
+++ b/crates/init/src/logging.rs
@@ -1,0 +1,313 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+//
+// This file is provided WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE.
+
+use anyhow::Result;
+use indicatif::{ProgressBar, ProgressStyle};
+use std::future::Future;
+use tokio::time::{sleep, Duration};
+
+/// A progress spinner for displaying async task status with optional verbose output.
+///
+/// `TaskSpinner` provides a clean way to show progress for long-running operations,
+/// with support for both animated spinner mode and verbose text output.
+///
+/// # Examples
+///
+/// ```ignore
+/// use task_spinner::TaskSpinner;
+///
+/// #[tokio::main]
+/// async fn main() -> Result<()> {
+///     let mut spinner = TaskSpinner::new("Initializing", false);
+///     
+///     // Run a task with the spinner
+///     let result = spinner.run("Downloading files", || async {
+///         // Your async work here
+///         download_files().await?;
+///         Ok(())
+///     }).await?;
+///     
+///     // Update progress
+///     spinner.update("Files downloaded").await;
+///     
+///     // Mark as complete
+///     spinner.done("✅ All tasks completed").await?;
+///     
+///     Ok(())
+/// }
+pub struct TaskSpinner {
+    spinner: ProgressBar,
+    verbose: bool,
+}
+
+impl TaskSpinner {
+    /// Creates a new `TaskSpinner` with an initial message.
+    ///
+    /// # Arguments
+    ///
+    /// * `message` - The initial message to display alongside the spinner
+    /// * `verbose` - If `true`, displays plain text output instead of animated spinner
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// // Create a spinner with animation
+    /// let spinner = TaskSpinner::new("Loading data", false);
+    ///
+    /// // Create a spinner in verbose mode (no animation, just text)
+    /// let verbose_spinner = TaskSpinner::new("Loading data", true);
+    /// ```
+    pub fn new(message: impl Into<String>, verbose: bool) -> Self {
+        let spinner = if verbose {
+            // Hidden spinner in verbose mode - we just print text
+            ProgressBar::hidden()
+        } else {
+            // Animated spinner in normal mode
+            let pb = ProgressBar::new_spinner();
+            pb.set_style(
+                ProgressStyle::default_spinner()
+                    .template("{spinner:.green} {msg}")
+                    .unwrap()
+                    .tick_chars("⠁⠂⠄⡀⢀⠠⠐⠈ "),
+            );
+            pb.enable_steady_tick(Duration::from_millis(100));
+            pb
+        };
+
+        let msg = message.into();
+        if !msg.is_empty() {
+            if verbose {
+                println!("{}", msg);
+            } else {
+                spinner.set_message(msg);
+            }
+        }
+
+        Self { spinner, verbose }
+    }
+
+    /// Runs an async task while displaying a progress message.
+    ///
+    /// This method executes the provided async closure while showing either
+    /// a spinning animation or verbose text output, depending on the spinner's mode.
+    ///
+    /// # Arguments
+    ///
+    /// * `message` - The message to display while the task is running
+    /// * `task` - An async closure that performs the actual work
+    ///
+    /// # Returns
+    ///
+    /// Returns the result of the async task, propagating any errors that occur.
+    ///
+    /// # Type Parameters
+    ///
+    /// * `F` - The closure type
+    /// * `Fut` - The future type returned by the closure
+    /// * `T` - The success type returned by the future
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let mut spinner = TaskSpinner::new("Starting", false);
+    ///
+    /// let result = spinner.run("Processing data", || async {
+    ///     // Perform some async operation
+    ///     process_data().await?;
+    ///     Ok(42)
+    /// }).await?;
+    ///
+    /// assert_eq!(result, 42);
+    /// ```
+    ///
+    /// # Notes
+    ///
+    /// In verbose mode, this will print the message to stdout.
+    /// In normal mode, the spinner continues to animate during task execution.
+    pub async fn run<F, Fut, T>(&mut self, message: impl Into<String>, task: F) -> Result<T>
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = Result<T>>,
+    {
+        if self.verbose {
+            println!("{}", message.into());
+        }
+
+        let res = task().await;
+
+        match res {
+            Ok(res) => Ok(res),
+            Err(e) => {
+                if !self.verbose {
+                    self.spinner.finish_and_clear();
+                }
+                Err(e)
+            }
+        }
+    }
+
+    /// Updates the spinner with a completion message for the current step.
+    ///
+    /// This method briefly pauses execution, then displays a success message
+    /// with a checkmark. The spinner animation continues after the update.
+    ///
+    /// # Arguments
+    ///
+    /// * `message` - The completion message to display
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let mut spinner = TaskSpinner::new("Working", false);
+    ///
+    /// // Perform some work...
+    /// spinner.update("Step 1 completed").await;
+    ///
+    /// // Continue with more work...
+    /// spinner.update("Step 2 completed").await;
+    /// ```
+    ///
+    /// # Notes
+    ///
+    /// - Adds a 500ms delay before showing the update for better visual flow
+    /// - Temporarily suspends the spinner to print the message cleanly
+    pub async fn update(&mut self, message: impl Into<String>) {
+        sleep(Duration::from_millis(500)).await;
+
+        self.spinner.suspend(|| {
+            println!("🏗️  {}", message.into());
+        });
+    }
+
+    /// Marks the current task as complete with a success message.
+    ///
+    /// This method suspends the spinner, prints a checkmark message,
+    /// and then clears the spinner message.
+    ///
+    /// # Arguments
+    ///
+    /// * `message` - The message to display when the task is completed
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let mut spinner = TaskSpinner::new("Processing", false);
+    ///
+    /// // Perform some processing...
+    /// spinner.complete_task("Task completed successfully").await;
+    /// ```
+    ///
+    /// # Notes
+    ///
+    /// - This method is useful for marking individual tasks as done
+    ///   within a larger operation, while keeping the spinner active.
+    /// - The spinner will continue to animate until `done()` is called.
+    pub fn complete_task(&mut self, message: impl Into<String>) {
+        self.spinner.suspend(|| {
+            println!("✅ {}", message.into());
+        });
+    }
+
+    /// Completes the spinner with a final message.
+    ///
+    /// This method stops the spinner animation and replaces it with
+    /// the provided completion message. Use this when all tasks are finished.
+    ///
+    /// # Arguments
+    ///
+    /// * `message` - The final message to display
+    ///
+    /// # Returns
+    ///
+    /// Always returns `Ok(())` for convenience in error propagation chains.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let mut spinner = TaskSpinner::new("Installing", false);
+    ///
+    /// // Do installation work...
+    ///
+    /// spinner.done("✅ Installation complete!").await?;
+    /// ```
+    ///
+    /// # Notes
+    ///
+    /// After calling `done()`, the spinner is finished and should not be reused.
+    /// The final message remains visible in the terminal.
+    pub fn done(&mut self, message: impl Into<String>) {
+        self.spinner.finish_and_clear();
+        println!("{}", message.into());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_spinner_creation_normal_mode() {
+        let spinner = TaskSpinner::new("Test message", false);
+        assert!(!spinner.verbose);
+    }
+
+    #[tokio::test]
+    async fn test_spinner_creation_verbose_mode() {
+        let spinner = TaskSpinner::new("Test message", true);
+        assert!(spinner.verbose);
+    }
+
+    #[tokio::test]
+    async fn test_run_success() -> Result<()> {
+        let mut spinner = TaskSpinner::new("Testing", false);
+
+        let result = spinner.run("Running test", || async { Ok(42) }).await?;
+
+        assert_eq!(result, 42);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_run_error_clears_spinner() {
+        let mut spinner = TaskSpinner::new("Testing", false);
+
+        let result: Result<()> = spinner
+            .run("Failing test", || async {
+                Err(anyhow::anyhow!("Test error"))
+            })
+            .await;
+
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_update_adds_delay() {
+        let mut spinner = TaskSpinner::new("Testing", false);
+
+        let start = std::time::Instant::now();
+        spinner.update("Update message").await;
+        let elapsed = start.elapsed();
+
+        // Should have at least 500ms delay
+        assert!(elapsed >= Duration::from_millis(500));
+    }
+
+    #[tokio::test]
+    async fn test_run_with_async_work() -> Result<()> {
+        let mut spinner = TaskSpinner::new("Testing async", false);
+
+        let result = spinner
+            .run("Async operation", || async {
+                // Simulate some async work
+                sleep(Duration::from_millis(100)).await;
+                Ok("async result".to_string())
+            })
+            .await?;
+
+        assert_eq!(result, "async result");
+        Ok(())
+    }
+}

--- a/crates/init/src/package_json.rs
+++ b/crates/init/src/package_json.rs
@@ -29,7 +29,6 @@ impl DependencyType {
 }
 
 pub async fn get_version_from_package_json(file_path: &PathBuf) -> Result<String> {
-    println!("json path: {:?}", file_path);
     let content = fs::read_to_string(file_path).await?;
     let json: Value = serde_json::from_str(&content)?;
 
@@ -77,4 +76,12 @@ pub async fn add_package_to_json(
     fs::write(file_path, formatted_json).await?;
 
     Ok(())
+}
+
+#[test]
+fn test_validate_dependency_type() {
+    assert!(validate_dependency_type("dependencies").is_ok());
+    assert!(validate_dependency_type("devDependencies").is_ok());
+    assert!(validate_dependency_type("peerDependencies").is_ok());
+    assert!(validate_dependency_type("invalidType").is_err());
 }


### PR DESCRIPTION
Cleanup `enclave init` stdout.

Without `-v` it prints only the main tasks. Passing `-v` lets it be fully verbose and print the current output.  

fix #515 


```

    ░██████████                       ░██                                  
    ░██                               ░██                                  
    ░██         ░████████   ░███████  ░██  ░██████   ░██    ░██  ░███████  
    ░█████████  ░██    ░██ ░██    ░██ ░██       ░██  ░██    ░██ ░██    ░██ 
    ░██         ░██    ░██ ░██        ░██  ░███████   ░██  ░██  ░█████████ 
    ░██         ░██    ░██ ░██    ░██ ░██ ░██   ░██    ░██░██   ░██        
    ░██████████ ░██    ░██  ░███████  ░██  ░█████░██    ░███     ░███████                                                                                                                                                     
    
🏗️  Preparing paths...
✅ Paths prepared

🏗️  Downloading template...
✅ Template downloaded

🏗️  Configuring template...
✅ Template configured

🏗️  Setting up support folders...
✅ Support folders set up

🏗️  Restoring permissions...
✅ Permissions restored

🏗️  Setting up submodules...
✅ Submodules set up

🏗️  Installing packages with pnpm...
✅ Packages installed

🏗️  Setting up local git repository...
✅ Git repository set up

🎉 You can now start building on Enclave
```