### PR TITLE
fix typo in whitepaper.mdx

### DIFF
--- a/docs/pages/whitepaper.mdx
+++ b/docs/pages/whitepaper.mdx
@@ -167,7 +167,7 @@ To maintain integrity and encourage correct behaviour, Enclave utilises a system
 
 ### Staking
 
-Anyone can register a new Ciphernode by staking an amount[^7] of Enclave tokens. After registration, new nodes must wait for a regitration delay period[^8] before they can be selected for Ciphernode duties. The registration delay period enables Requesters to reasonably predict the current Ciphernode set when requesting a computation. This economic stake aligns their interests with the security of the system.
+Anyone can register a new Ciphernode by staking an amount[^7] of Enclave tokens. After registration, new nodes must wait for a registration delay period[^8] before they can be selected for Ciphernode duties. The registration delay period enables Requesters to reasonably predict the current Ciphernode set when requesting a computation. This economic stake aligns their interests with the security of the system.
 
 Nodes can request to be decommissioned at any time. Prior to being decommissioned, nodes must remain active for a decommission delay period[^9], after which they will no longer be selected for duties. Nodes must also remain active to complete any duties for which they have been selected. Once its decommission delay has passed and all assigned duties have been completed, a node may be decommissioned, and its staking deposit will be returned.
 


### PR DESCRIPTION
fix typo in whitepaper 'regitration'--'registration'