### PR TITLE
feat: allow checkin without nargo

### DIFF
--- a/scripts/lint-circuits.sh
+++ b/scripts/lint-circuits.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
-
 set -euo pipefail
+
+# Check if nargo command exists
+if ! command -v nargo >/dev/null 2>&1; then
+    echo "nargo command not found, skipping circuit format check"
+    exit 0
+fi
 
 # Ensure we're in the right directory
 cd packages/circuits
@@ -11,5 +16,4 @@ if ! (nargo fmt --check); then
     echo "Error: Circuit format check failed"
     exit 1
 fi
-
 echo "Noir circuits compiled successfully"


### PR DESCRIPTION
I noticed [nargo is now a dependency](https://github.com/gnosisguild/enclave/pull/648) in order to check in code because we use its linting. For this to work on my system I have to write a nix flake that builds nargo as it is [not available for nixos](https://search.nixos.org/packages?channel=25.05&query=nargo)  - this is going to take a bit of time for me so my initial reaction is to disable linting if nargo is not available

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Circuit formatting check now gracefully skips when the required tool isn’t installed, preventing unnecessary failures.

* **Chores**
  * Minor cleanup of the linting script, including formatting improvements and clearer success messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->