### PR TITLE
chore: update actions/checkout to v5 in CI workflows

### DIFF
--- a/.github/workflows/binary-releases.yml
+++ b/.github/workflows/binary-releases.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -87,7 +87,7 @@ jobs:
     needs: build
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
   rust_unit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust 1.86.0
         uses: dtolnay/rust-toolchain@stable
@@ -75,7 +75,7 @@ jobs:
     outputs:
       image_tag: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Generate version tag
         id: version
         run: |
@@ -119,7 +119,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: "Check out the repo"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v5"
 
       - name: Install Rust 1.86.0
         uses: dtolnay/rust-toolchain@stable
@@ -170,7 +170,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: "Check out the repo"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v5"
       - name: "Setup node"
         uses: actions/setup-node@v4
         with:
@@ -188,7 +188,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: "Check out the repo"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v5"
       - name: "Setup node"
         uses: actions/setup-node@v4
         with:
@@ -243,7 +243,7 @@ jobs:
       fail-fast: false
     steps:
       - name: "Check out the repo"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v5"
       - name: "Setup node"
         uses: actions/setup-node@v4
         with:
@@ -299,7 +299,7 @@ jobs:
   build_enclave_cli:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
       - name: Cache Rust dependencies
@@ -338,7 +338,7 @@ jobs:
     needs: [build_enclave_cli]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -431,7 +431,7 @@ jobs:
   test_enclave_circuits:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -465,7 +465,7 @@ jobs:
   build_e3_support_dev:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
       - name: Cache Rust dependencies
@@ -498,7 +498,7 @@ jobs:
   build_sdk:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
       - name: Cache Node dependencies
@@ -557,7 +557,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build_enclave_cli, build_e3_support_dev, build_sdk]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
       - name: Setup Node.js
@@ -656,7 +656,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/crisp-docker.yml
+++ b/.github/workflows/crisp-docker.yml
@@ -30,7 +30,7 @@ jobs:
     outputs:
       image_tag: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Generate version tag
         id: version

--- a/.github/workflows/ec2-deployment.yml
+++ b/.github/workflows/ec2-deployment.yml
@@ -32,7 +32,7 @@ jobs:
     outputs:
       image_tag: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
 
       - name: Generate version tag
         id: version

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Check license headers
         id: check-headers

--- a/.github/workflows/publish-evm.yml
+++ b/.github/workflows/publish-evm.yml
@@ -10,7 +10,7 @@ jobs:
   publish-npm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v3
         with:
           node-version: 22

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -28,7 +28,7 @@ jobs:
       releases_created: ${{ steps.release-plz.outputs.releases_created }}
       version: ${{ steps.release-plz.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -84,7 +84,7 @@ jobs:
     needs: release-rust
     if: github.event_name == 'push'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -119,7 +119,7 @@ jobs:
     needs: [release-rust, release-npm]
     if: github.event_name == 'push' && needs.release-rust.outputs.releases_created == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Trigger binary release workflow
         uses: peter-evans/repository-dispatch@v3

--- a/.github/workflows/validate-commits.yml
+++ b/.github/workflows/validate-commits.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
Updates actions/checkout@v4 to actions/checkout@v5 across CI workflows.

Upgrade to actions/checkout@v5 for improved performance and stability.

Reference:
Latest version: https://github.com/actions/checkout/releases/tag/v5.0.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing changes.
- Chores
  - Upgraded GitHub Actions “checkout” to v5 across CI, release, publish, deployment, and validation workflows for improved reliability and security.
  - Minor formatting cleanup in workflow configuration.
- Tests
  - CI pipelines updated to use the latest runner actions; no test logic changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->