### PR TITLE
docs: update hosted docs on CRISP

### DIFF
--- a/docs/pages/CRISP/introduction.mdx
+++ b/docs/pages/CRISP/introduction.mdx
@@ -27,7 +27,6 @@ CRISP/
 |── client/                  # React frontend application
 |── server/                  # Rust coordination server
 |── program/                 # RISC Zero computation program
-|── wasm-crypto/             # WebAssembly crypto utilities
 ├── contracts/               # Smart contracts (Solidity)
 ├── circuits/                # Noir circuits for ZK proofs
 ├── scripts/                 # Development and utility scripts
@@ -66,16 +65,6 @@ The core computation logic written in Rust for zkVM:
 - Performs computations on encrypted votes
 - Counts votes without decrypting individual ballots
 - Creates proofs of correct computation
-
----
-
-### **WebAssembly Crypto** (`/wasm-crypto`)
-
-High-performance cryptographic operations compiled to WebAssembly:
-
-- Client-side fully homomorphic encryption
-- ZK Circuit input generation for Noir proofs
-- Optimized for browser execution
 
 ---
 

--- a/docs/pages/CRISP/running-e3.mdx
+++ b/docs/pages/CRISP/running-e3.mdx
@@ -69,11 +69,20 @@ The server will start and begin listening for blockchain events.
 Navigate to the program directory and start the program server:
 
 ```sh
-cd examples/CRISP/program
-cargo run
+cd examples/CRISP/
+enclave program start 
 ```
 
 This runs the RISC Zero program server that handles secure computations.
+
+If you would like to run the program server in dev mode, you can run the following command:
+
+```sh
+cd examples/CRISP/
+enclave program start --dev true
+```
+
+In this case, Risc0 will not be used to generate proofs, and instead these will be mocked. 
 
 ### Initialize a New Voting Round
 

--- a/docs/pages/CRISP/setup.mdx
+++ b/docs/pages/CRISP/setup.mdx
@@ -18,7 +18,7 @@ The setup includes the following:
 
 ## Quick Start with Docker (Recommended)
 
-The fastest way to get CRISP running is using the Docker development environment:
+The fastest way to get CRISP running is using the scripts provided in the `scripts/` directory:
 
 ```sh
 cd examples/CRISP
@@ -60,7 +60,7 @@ Before getting started, ensure you have the following tools installed:
 
 - **Rust** (programming language and package manager)
 - **Foundry** (Ethereum development framework)
-- **RISC Zero toolchain** (for RISC Zero program development)
+- **RISC Zero toolchain** (for RISC Zero program development) - Note that you can also run the program server in dev mode which does not use Risc0.
 - **Node.js** (JavaScript runtime for client-side dependencies)
 - **Anvil** (local Ethereum node)
 - **Enclave CLI** (for managing ciphernodes)
@@ -104,6 +104,8 @@ curl -L https://foundry.paradigm.xyz | bash
 ```
 
 ### Install RISC Zero Toolchain
+
+> Optional: you can run CRISP in dev mode which does not use Risc0.
 
 Next, install `rzup`, which provides the `cargo-risczero` toolchain.
 
@@ -185,7 +187,7 @@ Keep this terminal open and running. Open a new terminal for the next steps.
 4. Deploy the Enclave contracts on the local testnet:
 
    ```sh
-   rm -rf deployments/localhost
+   pnpm clean:deployments
    pnpm deploy:mocks --network localhost
    ```
 

--- a/examples/CRISP/Readme.md
+++ b/examples/CRISP/Readme.md
@@ -17,9 +17,10 @@ CRISP
 
 ## Development
 
-To start the development environment, run the following commands:
+To start the development environment, run the following commands from inside the CRISP directory:
 
 ```sh
+pnpm install # install dependencies
 pnpm dev:setup # build the project
 pnpm dev:up # run the services 
 ```

--- a/examples/CRISP/contracts/README.md
+++ b/examples/CRISP/contracts/README.md
@@ -18,5 +18,6 @@ It exposes two main functions:
 
 The input validator contract is used to validate the input data that is submitted to the E3 instance. It is called by the Enclave contract when a new input is published (`Enclave.publishInput`). In CRISP, the data providers (the ones submitting the inputs) are the voters, and the input submitted is the vote itself. 
 
-The validator will validate the input data by checking whether the gating conditions are satisifed (this uses Semaphore by default), and that the ciphertext is constructed correctly, using [Greco](https://github.com/gnosisguild/enclave/tree/main/packages/circuits/crates/libs/greco) ([link to paper(https://eprint.iacr.org/2024/594)]).
+The validator checks that gating conditions are satisfied (uses [Semaphore](https://semaphore.pse.dev/) by default) and that the ciphertext is constructed correctly using [Greco](https://github.com/gnosisguild/enclave/tree/main/packages/circuits/crates/libs/greco). See the Greco [paper](https://eprint.iacr.org/2024/594).
+
 


### PR DESCRIPTION
Update live docs with up to date instructions on how to run CRISP

fix #723 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Removed the WebAssembly Crypto subsection and directory from CRISP docs.
  * Updated server startup to use the enclave start command and added a dev mode that mocks RISC0 proofs.
  * Revised Quick Start to use scripts (pnpm dev:setup, pnpm dev:up) and added an initial pnpm install step.
  * Marked RISC0 as optional when using dev mode and updated cleanup to pnpm clean:deployments.
  * Clarified example README to run from the CRISP directory.
  * Reworded contract validator docs to present tense and fixed a typo.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->