### PR TITLE
fix: contracts exports

### DIFF
--- a/crates/wasm/package.json
+++ b/crates/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@enclave-e3/wasm",
-  "version": "0.0.12-test",
+  "version": "0.0.13-test",
   "description": "Wasm modules for enclave.",
   "main": "dist/nodejs/e3_wasm.js",
   "module": "dist/web/e3_wasm.js",

--- a/examples/CRISP/client/package.json
+++ b/examples/CRISP/client/package.json
@@ -18,7 +18,7 @@
     "deploy": "gh-pages -d dist"
   },
   "dependencies": {
-    "@enclave-e3/sdk": "^0.0.12-test",
+    "@enclave-e3/sdk": "^0.0.13-test",
     "@aztec/bb.js": "^0.82.2",
     "@emotion/babel-plugin": "^11.11.0",
     "@emotion/react": "^11.11.4",

--- a/examples/CRISP/package.json
+++ b/examples/CRISP/package.json
@@ -23,8 +23,8 @@
   "dependencies": {
     "@excubiae/contracts": "^0.4.0",
     "@hashcloak/semaphore-contracts-noir": "1.0.1",
-    "@enclave-e3/sdk": "^0.0.12-test",
-    "@enclave-e3/contracts": "^0.0.12-test",
+    "@enclave-e3/sdk": "^0.0.13-test",
+    "@enclave-e3/contracts": "^0.0.13-test",
     "@zk-kit/lean-imt.sol": "2.0.0",
     "poseidon-solidity": "^0.0.5",
     "solady": "^0.1.13"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/gnosisguild"
   },
   "scripts": {
+    "bump:versions": "pnpm --filter \"@enclave-e3/contracts\" --filter \"@enclave-e3/sdk\" --filter \"@enclave-e3/react\" --filter \"@enclave-e3/config\" --filter \"@enclave-e3/wasm\" exec npm version", 
     "clean": "cd packages/enclave-contracts && pnpm clean",
     "compile": "pnpm evm:build && pnpm sdk:build && pnpm react:build && pnpm ciphernode:build && ./scripts/compile-circuits.sh",
     "lint": "pnpm evm:lint && pnpm ciphernode:lint && ./scripts/lint-circuits.sh",

--- a/packages/enclave-config/package.json
+++ b/packages/enclave-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@enclave-e3/config",
-  "version": "0.0.12-test",
+  "version": "0.0.13-test",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/enclave-contracts/package.json
+++ b/packages/enclave-contracts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@enclave-e3/contracts",
   "description": "Enclave is an open-source protocol for Encrypted Execution Environments (E3).",
-  "version": "0.0.12-test",
+  "version": "0.0.13-test",
   "license": "LGPL-3.0-only",
   "type": "module",
   "author": {

--- a/packages/enclave-contracts/scripts/index.ts
+++ b/packages/enclave-contracts/scripts/index.ts
@@ -1,3 +1,9 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+//
+// This file is provided WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE.
+
 export * from "./deployEnclave";
 export * from "./deployMocks";
 export * from "./utils";

--- a/packages/enclave-react/package.json
+++ b/packages/enclave-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@enclave-e3/react",
-  "version": "0.0.12-test",
+  "version": "0.0.13-test",
   "description": "React hooks and utilities for Enclave SDK",
   "type": "module",
   "private": false,

--- a/packages/enclave-sdk/package.json
+++ b/packages/enclave-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@enclave-e3/sdk",
-  "version": "0.0.12-test",
+  "version": "0.0.13-test",
   "type": "module",
   "exports": {
     ".": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,11 +64,11 @@ importers:
   examples/CRISP:
     dependencies:
       '@enclave-e3/contracts':
-        specifier: ^0.0.12-test
-        version: 0.0.12-test(@openzeppelin/contracts@5.3.0)
+        specifier: ^0.0.13-test
+        version: 0.0.13-test(@openzeppelin/contracts@5.3.0)
       '@enclave-e3/sdk':
-        specifier: ^0.0.12-test
-        version: 0.0.12-test(@openzeppelin/contracts@5.3.0)(@types/node@22.7.5)(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(vite@6.3.5(@types/node@22.7.5)(jiti@1.21.7)(tsx@4.20.5)(yaml@2.8.1))(zod@3.25.76)
+        specifier: ^0.0.13-test
+        version: 0.0.13-test(@openzeppelin/contracts@5.3.0)(@types/node@22.7.5)(bufferutil@4.0.9)(rollup@4.49.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(vite@6.3.5(@types/node@22.7.5)(jiti@1.21.7)(tsx@4.20.5)(yaml@2.8.1))(zod@3.25.76)
       '@excubiae/contracts':
         specifier: ^0.4.0
         version: 0.4.0
@@ -179,8 +179,8 @@ importers:
         specifier: ^11.11.4
         version: 11.14.0(@types/react@18.3.24)(react@18.3.1)
       '@enclave-e3/sdk':
-        specifier: ^0.0.12-test
-        version: 0.0.12-test(@types/node@22.7.5)(bufferutil@4.0.9)(rollup@4.49.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(vite@5.4.19(@types/node@22.7.5))(zod@3.25.76)
+        specifier: ^0.0.13-test
+        version: 0.0.13-test(@types/node@22.7.5)(bufferutil@4.0.9)(rollup@4.49.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(vite@5.4.19(@types/node@22.7.5))(zod@3.25.76)
       '@hashcloak/semaphore-noir-proof':
         specifier: 1.0.0
         version: 1.0.0(@semaphore-protocol/group@4.13.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(@semaphore-protocol/identity@4.13.0)(@types/snarkjs@0.7.9)(bufferutil@4.0.9)(commander@13.1.0)(utf-8-validate@5.0.10)
@@ -1538,14 +1538,14 @@ packages:
     peerDependencies:
       tsup: 8.5.0
 
-  '@enclave-e3/contracts@0.0.12-test':
-    resolution: {integrity: sha512-avuh6Z65ytGyHXYjecCTosXNyGiSkGVDi2IGoi6oP2J8FvZzSrd3IqIqrA22feB7azn7y4UH81jnhprJS1vnzw==}
+  '@enclave-e3/contracts@0.0.13-test':
+    resolution: {integrity: sha512-ZPtVGQd1zT8V+VsKBRb3u+2ywd8YmqYFa/TOjfh86uxrFkcQrnvUL9D49xbfJakNM34HDNV8ayUYwHvnhLAyEw==}
 
-  '@enclave-e3/sdk@0.0.12-test':
-    resolution: {integrity: sha512-KGsOWXNxVfD5Gr3mkWye/KsJCkpoTK5HYg0aB4NLtO21hocXNsjOcxI2fEGmLWoDdP0WEoviOzvZu3j5GmDmfQ==}
+  '@enclave-e3/sdk@0.0.13-test':
+    resolution: {integrity: sha512-bk9TlqGKzpzGogAn22X/CcsNW06NX0q1VhoaEAoxtmN0eHPHYNhz5nJbtDTC+S7M/zANQfxjpFQFw9OTrUIszA==}
 
-  '@enclave-e3/wasm@0.0.12-test':
-    resolution: {integrity: sha512-ViYlRu6qDf89ILA9DUPqOxmVVzzGVMh8qK5imrRsNPiT878sYmoWgav4j7AROAViVSDWTho8tAa0VpaP/M13BQ==}
+  '@enclave-e3/wasm@0.0.13-test':
+    resolution: {integrity: sha512-taZ0l8/Fg1C7HapCnLHBJlbUjSWxRRVjkamlSMvz7U5CkZTGHprEolYMAwrR1ihv2BWL2k5ik3M7VMZuXmaylA==}
 
   '@esbuild/aix-ppc64@0.20.0':
     resolution: {integrity: sha512-fGFDEctNh0CcSwsiRPxiaqX0P5rq+AqE0SRhYGZ4PX46Lg1FNR6oCxJghf8YgY0WQEgQuh3lErUFE4KxLeRmmw==}
@@ -10925,7 +10925,7 @@ snapshots:
     dependencies:
       tsup: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@22.7.5))(@swc/core@1.13.5)(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.8.3)(yaml@2.8.1)
 
-  '@enclave-e3/contracts@0.0.12-test(@openzeppelin/contracts@5.3.0)':
+  '@enclave-e3/contracts@0.0.13-test(@openzeppelin/contracts@5.3.0)':
     dependencies:
       '@openzeppelin/contracts-upgradeable': 5.4.0(@openzeppelin/contracts@5.3.0)
       '@zk-kit/lean-imt.sol': 2.0.1
@@ -10933,11 +10933,11 @@ snapshots:
     transitivePeerDependencies:
       - '@openzeppelin/contracts'
 
-  '@enclave-e3/sdk@0.0.12-test(@openzeppelin/contracts@5.3.0)(@types/node@22.7.5)(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(vite@6.3.5(@types/node@22.7.5)(jiti@1.21.7)(tsx@4.20.5)(yaml@2.8.1))(zod@3.25.76)':
+  '@enclave-e3/sdk@0.0.13-test(@openzeppelin/contracts@5.3.0)(@types/node@22.7.5)(bufferutil@4.0.9)(rollup@4.49.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(vite@6.3.5(@types/node@22.7.5)(jiti@1.21.7)(tsx@4.20.5)(yaml@2.8.1))(zod@3.25.76)':
     dependencies:
       '@aztec/bb.js': 0.82.3
-      '@enclave-e3/contracts': 0.0.12-test(@openzeppelin/contracts@5.3.0)
-      '@enclave-e3/wasm': 0.0.12-test
+      '@enclave-e3/contracts': 0.0.13-test(@openzeppelin/contracts@5.3.0)
+      '@enclave-e3/wasm': 0.0.13-test
       '@noir-lang/noir_js': 1.0.0-beta.3
       comlink: 4.4.2
       viem: 2.30.6(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
@@ -10969,11 +10969,11 @@ snapshots:
       - vite
       - zod
 
-  '@enclave-e3/sdk@0.0.12-test(@types/node@22.7.5)(bufferutil@4.0.9)(rollup@4.49.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(vite@5.4.19(@types/node@22.7.5))(zod@3.25.76)':
+  '@enclave-e3/sdk@0.0.13-test(@types/node@22.7.5)(bufferutil@4.0.9)(rollup@4.49.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(vite@5.4.19(@types/node@22.7.5))(zod@3.25.76)':
     dependencies:
       '@aztec/bb.js': 0.82.3
-      '@enclave-e3/contracts': 0.0.12-test(@openzeppelin/contracts@5.3.0)
-      '@enclave-e3/wasm': 0.0.12-test
+      '@enclave-e3/contracts': 0.0.13-test(@openzeppelin/contracts@5.3.0)
+      '@enclave-e3/wasm': 0.0.13-test
       '@noir-lang/noir_js': 1.0.0-beta.3
       comlink: 4.4.2
       viem: 2.30.6(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
@@ -11005,7 +11005,7 @@ snapshots:
       - vite
       - zod
 
-  '@enclave-e3/wasm@0.0.12-test': {}
+  '@enclave-e3/wasm@0.0.13-test': {}
 
   '@esbuild/aix-ppc64@0.20.0':
     optional: true

--- a/templates/default/deploy/default.ts
+++ b/templates/default/deploy/default.ts
@@ -4,7 +4,7 @@
 // without even the implied warranty of MERCHANTABILITY
 // or FITNESS FOR A PARTICULAR PURPOSE.
 
-import { readDeploymentArgs, storeDeploymentArgs } from "@enclave-e3/contracts/utils";
+import { readDeploymentArgs, storeDeploymentArgs } from "@enclave-e3/contracts/scripts";
 import { Enclave__factory as EnclaveFactory } from "@enclave-e3/contracts/types";
 import hre from "hardhat";
 

--- a/templates/default/deployed_contracts.json
+++ b/templates/default/deployed_contracts.json
@@ -1,67 +1,30 @@
 {
-  "localhost": {
+  "sepolia": {
     "Enclave": {
       "constructorArgs": {
         "params": "0x000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000fc00100000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000003fffffff000001",
-        "owner": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+        "owner": "0x4f1f3a157073A35515C4fC4A8af2F1Af088f0676",
         "maxDuration": "2592000",
         "registry": "0x0000000000000000000000000000000000000001"
       },
-      "blockNumber": 2,
-      "address": "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512"
+      "blockNumber": 9181738,
+      "address": "0xD43c70A343E631475d8470d0403e0c4b43c76927"
     },
     "CiphernodeRegistry": {
       "constructorArgs": {
-        "enclaveAddress": "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512",
-        "owner": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+        "enclaveAddress": "0xD43c70A343E631475d8470d0403e0c4b43c76927",
+        "owner": "0x4f1f3a157073A35515C4fC4A8af2F1Af088f0676"
       },
-      "blockNumber": 4,
-      "address": "0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9"
+      "blockNumber": 9181748,
+      "address": "0x5ABDfCbA0366ABF2893D3f2465F4C97908488A6d"
     },
     "NaiveRegistryFilter": {
       "constructorArgs": {
-        "ciphernodeRegistryAddress": "0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9",
-        "owner": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+        "ciphernodeRegistryAddress": "0x5ABDfCbA0366ABF2893D3f2465F4C97908488A6d",
+        "owner": "0x4f1f3a157073A35515C4fC4A8af2F1Af088f0676"
       },
-      "blockNumber": 5,
-      "address": "0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9"
-    },
-    "MockComputeProvider": {
-      "blockNumber": 7,
-      "address": "0x0165878A594ca255338adfa4d48449f69242Eb8F"
-    },
-    "MockDecryptionVerifier": {
-      "blockNumber": 8,
-      "address": "0xa513E6E4b8f2a923D98304ec87F64353C4D5C853"
-    },
-    "MockInputValidator": {
-      "blockNumber": 9,
-      "address": "0x2279B7A0a67DB372996a5FaB50D91eAA73d2eBe6"
-    },
-    "MockE3Program": {
-      "constructorArgs": {
-        "mockInputValidator": "0x2279B7A0a67DB372996a5FaB50D91eAA73d2eBe6"
-      },
-      "blockNumber": 10,
-      "address": "0x8A791620dd6260079BF849Dc5567aDC3F2FdC318"
-    },
-    "MockRISC0Verifier": {
-      "address": "0xA51c1fc2f0D1a1b8494Ed1FE312d7C3a78Ed91C0"
-    },
-    "ImageID": {
-      "address": "0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82"
-    },
-    "InputValidator": {
-      "address": "0x9A676e781A523b5d0C0e43731313A708CB607508"
-    },
-    "MyProgram": {
-      "address": "0x0B306BF915C4d645ff596e518fAf3F9669b97016",
-      "constructorArgs": {
-        "enclave": "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512",
-        "verifier": "0xA51c1fc2f0D1a1b8494Ed1FE312d7C3a78Ed91C0",
-        "programId": "0xaf928ebf39fec4696c3f41f473a1a9473b67d723c6373149c6ab99ba4c1a76ef",
-        "inputValidator": "0x9A676e781A523b5d0C0e43731313A708CB607508"
-      }
+      "blockNumber": 9181753,
+      "address": "0x58708A1bf1AEdf8e75755FDa1882F8dc46985009"
     }
   }
 }

--- a/templates/default/scripts/deploy-local.ts
+++ b/templates/default/scripts/deploy-local.ts
@@ -4,7 +4,7 @@
 // without even the implied warranty of MERCHANTABILITY
 // or FITNESS FOR A PARTICULAR PURPOSE.
 
-import { deployEnclave } from "@enclave-e3/contracts/deploy/enclave";
+import { deployEnclave } from "@enclave-e3/contracts/scripts";
 import { deployTemplate } from "../deploy/default";
 
 async function main() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Consolidated contracts scripts under a single entry point; import from “@enclave-e3/contracts/scripts”. Updated template and local deploy scripts to use the new path.

- Chores
  - Bumped versions to 0.0.13-test across packages and examples; updated example dependencies to ^0.0.13-test.
  - Added a root script to bump versions across packages (“bump:versions”).
  - Updated default deployment config to Sepolia with new contract addresses; removed mock entries from the template config.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->