### PR TITLE
feat: optimization by concatenating coefficients

### DIFF
--- a/packages/circuits/crates/libs/greco/src/lib.nr
+++ b/packages/circuits/crates/libs/greco/src/lib.nr
@@ -4,7 +4,7 @@
 // without even the implied warranty of MERCHANTABILITY
 // or FITNESS FOR A PARTICULAR PURPOSE.
 
-use polynomial::{flatten, Polynomial};
+use polynomial::{flatten, packer, Polynomial};
 use safe::SafeSponge;
 
 /// Cryptographic parameters for Greco circuit.
@@ -329,7 +329,7 @@ impl<let N: u32, let L: u32> Greco<N, L> {
     /// # Returns
     /// Vector of challenge values [gamma_0, gamma_1, ..., gamma_{2L-1}]
     fn generate_challenge(self) -> Vec<Field> {
-        let inputs = self.payload::<(10 * N - 4) * L + 4 * N>();
+        let inputs = packer(self.payload::<((10 * N - 4) * L + 4 * N)>());
 
         // Domain separator for Greco circuit - "Greco" in hex
         let domain_separator = [
@@ -341,7 +341,7 @@ impl<let N: u32, let L: u32> Greco<N, L> {
         ];
 
         // IO Pattern: ABSORB(input_size), SQUEEZE(2*L)
-        let input_size = (10 * N - 4) * L + 4 * N;
+        let input_size = (((10 * N - 4) * L + 4 * N) + 2) / 3;
         let io_pattern = [0x80000000 | input_size, 0x00000000 | (2 * L)];
 
         let mut sponge = SafeSponge::start(io_pattern, domain_separator);

--- a/packages/circuits/crates/libs/polynomial/src/lib.nr
+++ b/packages/circuits/crates/libs/polynomial/src/lib.nr
@@ -132,6 +132,50 @@ pub fn flatten<let A: u32, let L: u32, let SIZE: u32>(
     (inputs, offset)
 }
 
+/// Packs an array of `Field` elements into a more compact representation,
+/// grouping three values into a single `Field` element. If the input length
+/// `A` is not divisible by 3, the final packed element is **zero-padded**.
+///
+/// # Type Parameters
+/// * `A` - Number of input coefficients.
+///
+/// # Parameters
+/// * `values` - The input array `[Field; A]` to be packed.
+///
+/// # Returns
+/// * `[Field; (A + 2) / 3]` - A packed array with length equal to
+///   `ceil(A / 3)`.
+///
+/// # Algorithm
+/// - Computes `S = ceil(A / 3)` (using `(A + 2) / 3` for integer division).
+/// - Iterates over each output position `j`:
+///   * Initializes an accumulator `acc = 0`.
+///   * For each of the 3 input slots belonging to this output position:
+///     * Reads `values[idx]` where `idx = 3 * j + i`, or uses `0` if `idx >= A`
+///       (to avoid out-of-bounds access).
+///     * Adds an offset of `2^64` to every value (ensuring positive packing).
+///     * Updates `acc = acc * 2^65 + adjusted_value`.
+/// - Stores `acc` into the output array at position `j`.
+///
+/// # Padding Behavior
+/// If `A % 3 != 0`, the last packed element will include one or two
+/// zero-padded values, ensuring that `values[idx]` is never accessed
+/// out-of-bounds.
+pub fn packer<let A: u32>(values: [Field; A]) -> [Field; (A + 2) / 3] {
+    let mut carrier = [0; (A + 2) / 3];
+    for j in 0..(A + 2) / 3 {
+        let base: Field = 36893488147419103232; // 2^65
+        let mut acc: Field = 0;
+        for i in 0..3 {
+            let idx: u32 = 3 * j + i;
+            let v: Field = if idx < A { values[idx] } else { 0 };
+            acc = acc * base + (v + 18446744073709551616); // + 2^64
+        }
+        carrier[j] = acc;
+    }
+    carrier
+}
+
 #[test]
 fn test_polynomial_eval() {
     let coeffs = [1, 2, 3]; // represents 1x^2 + 2x + 3


### PR DESCRIPTION
# Description
This PR will optimize Greco circuit by concatenating coefficients of the given polynomials.

Tests shows that this implementation lowers hashing payload costs nearly %66.

# PR Checklist\*
- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `nargo fmt` on default settings.
