### PR TITLE
chore: fix typo

### DIFF
--- a/docs/pages/what-is-e3.mdx
+++ b/docs/pages/what-is-e3.mdx
@@ -7,7 +7,7 @@ integrity by combining three essential components:
 1. **Fully Homomorphic Encryption (FHE):** Enables computations directly on encrypted data without
    needing to decrypt it, maintaining security from start to finish.
 2. **Zero-Knowledge Proofs (ZKPs):** Allow verification of data and computations without revealing
-   sensitive information, offering a way to validate accuracy while preserviing privacy.
+   sensitive information, offering a way to validate accuracy while preserving privacy.
 3. **Distributed Threshold Cryptography (DTC):** Distributes cryptographic keys across multiple
    nodes, eliminating single points of failure and enhancing the framework’s resilience against
    breaches.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Corrected a typographical error in the “What is E3” documentation page within the ZKPs description, updating “preserviing privacy” to “preserving privacy” for improved clarity and professionalism. No structural or functional changes were introduced; only wording was adjusted. This improves readability for end-users and aligns terminology with expected spelling without affecting application behavior or interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->