### PR TITLE
test: add sdk tests to ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -532,6 +532,9 @@ jobs:
       - name: Build the sdk
         run: pnpm sdk:build
 
+      - name: Run the tests
+        run: pnpm sdk:test
+
       - name: Upload SDK artifacts
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
fix #741 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - The CI pipeline now runs the SDK test suite as part of the build to catch regressions earlier and improve release reliability.
- **Chores**
  - CI workflow updated to execute tests before uploading build artifacts, ensuring only validated builds are archived.
  - No direct user-facing changes; this enhances build quality and confidence in releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->