### PR TITLE
feat: add a function to get an e3 public key

### DIFF
--- a/packages/enclave-sdk/src/contract-client.ts
+++ b/packages/enclave-sdk/src/contract-client.ts
@@ -295,6 +295,31 @@ export class ContractClient {
   }
 
   /**
+   * Get the public key for an E3 computation
+   * Based on the contract: committeePublicKey(uint256 e3Id) returns (bytes32 publicKeyHash)
+   * @param e3Id 
+   * @returns The public key
+   */
+  public async getE3PublicKey(e3Id: bigint): Promise<`0x${string}`> {
+    if (!this.contractInfo) {
+      await this.initialize();
+    }
+
+    try {
+      const result: `0x${string}` = await this.publicClient.readContract({
+        address: this.addresses.ciphernodeRegistry,
+        abi: CiphernodeRegistryOwnable__factory.abi,
+        functionName: "committeePublicKey",
+        args: [e3Id],
+      });
+
+      return result;
+    } catch (error) {
+      throw new SDKError(`Failed to get E3 public key: ${error}`, "GET_E3_PUBLIC_KEY_FAILED");
+    }
+  }
+
+  /**
    * Estimate gas for a transaction
    */
   public async estimateGas(

--- a/packages/enclave-sdk/src/enclave-sdk.ts
+++ b/packages/enclave-sdk/src/enclave-sdk.ts
@@ -201,6 +201,19 @@ export class EnclaveSDK {
   }
 
   /**
+   * Get the public key for an E3 computation
+   * @param e3Id - The ID of the E3 computation
+   * @returns The public key
+   */
+  public async getE3PublicKey(e3Id: bigint): Promise<`0x${string}`> {
+    if (!this.initialized) {
+      await this.initialize();
+    }
+
+    return this.contractClient.getE3PublicKey(e3Id);
+  }
+
+  /**
    * Activate an E3 computation
    */
   public async activateE3(


### PR DESCRIPTION
fix #759 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an SDK capability to retrieve an E3 public key by ID, enabling clients to programmatically access committee public keys for computations.
  - Includes built-in initialization checks and standardized error messaging for clearer failure feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->