### PR TITLE
fix: remove mac intel build and allow crates publishing to fail

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -82,10 +82,6 @@ jobs:
             target: aarch64-apple-darwin
             os_name: macos
             arch: aarch64
-          - os: macos-latest
-            target: x86_64-apple-darwin
-            os_name: macos
-            arch: x86_64
 
     steps:
       - name: Checkout
@@ -139,6 +135,7 @@ jobs:
     name: Publish Rust Crates
     runs-on: ubuntu-latest
     needs: validate-and-prepare
+    continue-on-error: true  
     # Publish ALL versions to crates.io (including pre-releases)
     steps:
       - name: Checkout code
@@ -165,6 +162,7 @@ jobs:
           
           cargo install cargo-workspaces
           cargo workspaces publish --from-git --yes
+
   publish-npm-packages:
     name: Publish NPM Packages
     runs-on: ubuntu-latest


### PR DESCRIPTION
Allow to bypass crates publishing on failure and do not build for mac intel 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release pipeline: discontinued macOS Intel (x86_64) binary in release builds; Apple Silicon builds remain available.
  * Made package publishing non-blocking, so releases proceed even if publishing to the registry fails.
  * No changes to application features or behavior; end-user functionality remains the same outside of the adjusted macOS binary availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->