### PR TITLE
chore: update risc0 version v3.0.3

### DIFF
--- a/crates/support/Cargo.toml
+++ b/crates/support/Cargo.toml
@@ -28,11 +28,11 @@ env_logger = "=0.11.8"
 hex = { version = "=0.4.3" }
 log = { version = "=0.4.27" }
 reqwest = { version = "=0.12.22", features = ["json"] }
-risc0-build = { version = "=3.0.0", features = ["docker"] }
+risc0-build = { version = "=3.0.3", features = ["docker"] }
 risc0-build-ethereum = { git = "https://github.com/risc0/risc0-ethereum", tag = "v3.0.0" }
 risc0-ethereum-contracts = { git = "https://github.com/risc0/risc0-ethereum", tag = "v3.0.0" }
-risc0-zkvm = { version = "=3.0.0" }
-risc0-zkp = { version = "=3.0.0", default-features = false }
+risc0-zkvm = { version = "=3.0.3" }
+risc0-zkp = { version = "=3.0.2", default-features = false }
 serde = { version = "=1.0.219", features = ["derive", "std"] }
 serde_json = "=1.0.141"
 fhe_rs = { package = "fhe", git = "https://github.com/gnosisguild/fhe.rs" }

--- a/crates/support/methods/guest/Cargo.toml
+++ b/crates/support/methods/guest/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/bin/program.rs"
 [dependencies]
 alloy-primitives = { version = "=1.3.0", default-features = false, features = ["rlp", "serde", "std"] }
 alloy-sol-types = "=1.3.0"
-risc0-zkvm = { version = "=3.0.0", default-features = false, features = ['std'] }
+risc0-zkvm = { version = "=3.0.3", default-features = false, features = ['std'] }
 e3-compute-provider = { git = "https://github.com/gnosisguild/enclave", rev = "2ca0aa5f47dd962add5d1d0f74900d9bceb957e5" }
 e3-user-program = { path = "../../program" }
 bincode = "=1.3.3"

--- a/examples/CRISP/Cargo.toml
+++ b/examples/CRISP/Cargo.toml
@@ -30,11 +30,11 @@ env_logger = "=0.11.8"
 hex = { version = "=0.4.3" }
 log = { version = "=0.4.27" }
 reqwest = { version = "=0.12.22", features = ["json"] }
-risc0-build = { version = "=3.0.0", features = ["docker"] }
+risc0-build = { version = "=3.0.3", features = ["docker"] }
 risc0-build-ethereum = { git = "https://github.com/risc0/risc0-ethereum", tag = "v3.0.0" }
 risc0-ethereum-contracts = { git = "https://github.com/risc0/risc0-ethereum", tag = "v3.0.0" }
-risc0-zkvm = { version = "=3.0.0" }
-risc0-zkp = { version = "=3.0.0", default-features = false }
+risc0-zkvm = { version = "=3.0.3" }
+risc0-zkp = { version = "=3.0.2", default-features = false }
 serde = { version = "=1.0.219", features = ["derive", "std"] }
 serde_json = "=1.0.141"
 fhe_rs = { package = "fhe", git = "https://github.com/gnosisguild/fhe.rs" }

--- a/examples/CRISP/Cargo.toml
+++ b/examples/CRISP/Cargo.toml
@@ -30,11 +30,6 @@ env_logger = "=0.11.8"
 hex = { version = "=0.4.3" }
 log = { version = "=0.4.27" }
 reqwest = { version = "=0.12.22", features = ["json"] }
-risc0-build = { version = "=3.0.3", features = ["docker"] }
-risc0-build-ethereum = { git = "https://github.com/risc0/risc0-ethereum", tag = "v3.0.0" }
-risc0-ethereum-contracts = { git = "https://github.com/risc0/risc0-ethereum", tag = "v3.0.0" }
-risc0-zkvm = { version = "=3.0.3" }
-risc0-zkp = { version = "=3.0.2", default-features = false }
 serde = { version = "=1.0.219", features = ["derive", "std"] }
 serde_json = "=1.0.141"
 fhe_rs = { package = "fhe", git = "https://github.com/gnosisguild/fhe.rs" }


### PR DESCRIPTION
`version 3.0.0 is yanked`
so the E3-Support Image fails to start in prod
also removed the risc0 crates from crisp since we dont seem to be using them

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated zkVM-related dependencies for improved compatibility and maintenance (risc0-build to 3.0.3, risc0-zkvm to 3.0.3, risc0-zkp to 3.0.2).
  - Streamlined the CRISP example by removing unused RISC Zero tooling dependencies, reducing setup overhead and potential conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->