### PR TITLE
fix: remove guidance on typos and small changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,10 +110,6 @@ This strategy avoids scenarios where pull requests grow too large/out-of-scope a
 
 The easiest way to do this is to have multiple Conventional Commits while you work and then you can cherry-pick the smaller changes into separate branches for pull requesting.
 
-### Typos and other small changes
-
-You are welcome to make PRs for smaller fixes, such as typos, or you can simply report them to us on [Telegram][telegram].
-
 ### Reviews
 
 For any repository in the Enclave repo, we require code review & approval by **one** contributor with edit access before the changes are merged, as enforced by GitHub branch protection. Non-breaking pull requests may be merged at any time. Breaking pull requests will only be merged alongside a breaking release.


### PR DESCRIPTION
Removed section about making PRs for typos and small fixes for now until we are actually ready to take PRs from the community. (sorry community!)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Streamlined the Pull Requests section by removing the subsection for minor typo/small changes and its guidance.
  - No impact on app behavior or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->