### PR TITLE
fix: evm publish plaintext output race condition

### DIFF
--- a/crates/evm/src/enclave_sol_writer.rs
+++ b/crates/evm/src/enclave_sol_writer.rs
@@ -136,6 +136,10 @@ async fn publish_plaintext_output<P: Provider + WalletProvider + Clone>(
     let e3_id: U256 = e3_id.try_into()?;
     let decrypted_output = Bytes::from(decrypted_output);
     let proof = Bytes::from(vec![1]);
+
+    // Wait for ciphertext output transaction to propagate
+    tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+
     let from_address = provider.provider().default_signer_address();
     let current_nonce = provider
         .provider()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Improved stability when publishing outputs by adding a brief wait to ensure data is fully propagated before retrieving the nonce and invoking the contract.
  - Reduces intermittent, race-condition-related errors and the need for retries during contract calls.
  - Users may notice a slight increase (about one second) in the time to publish, traded for more consistent success.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->