### PR TITLE
chore: calculate yes and no indexes in ts

### DIFF
--- a/examples/CRISP/sdk/src/token.ts
+++ b/examples/CRISP/sdk/src/token.ts
@@ -73,7 +73,7 @@ export const getBalanceAt = async (voterAddress: string, tokenAddress: string, s
 }
 
 /**
- * Get the total supply of a ERC20 Token at a specific block
+ * Get the total supply of a ERC20Votes Token at a specific block
  * @param tokenAddress The token address to query
  * @param snapshotBlock The block number at which to get the total supply
  * @param chainId The chain ID of the network

--- a/examples/CRISP/sdk/src/vote.ts
+++ b/examples/CRISP/sdk/src/vote.ts
@@ -9,19 +9,29 @@ import { IVote, VotingMode } from './types'
 import { toBinary } from './utils'
 
 /**
- * This utility function calculates the first valid index for for vote options
- * based on the total voting power and plaintext modulus.
+ * This utility function calculates the first valid index for vote options
+ * based on the total voting power and degree.
  * @dev This is needed to calculate the decoded plaintext
- * @dev Also, we will need to check in the circuit that anything within these indexes is
+ * @dev Also, we will need to check in the circuit that anything within these indices is
  * either 0 or 1.
  * @param totalVotingPower The maximum vote amount (if a single voter had all of the power)
  * @param degree The degree of the polynomial
  */
-export const calculateValidIndexesForPlaintext = (totalVotingPower: bigint, degree: number): { yesIndex: number; noIndex: number } => {
+export const calculateValidIndicesForPlaintext = (totalVotingPower: bigint, degree: number): { yesIndex: number; noIndex: number } => {
+  // Sanity check: degree must be even and positive
+  if (degree <= 0 || degree % 2 !== 0) {
+    throw new Error('Degree must be a positive even number')
+  }
+
   // Calculate the number of bits needed to represent the total voting power
   const bitsNeeded = totalVotingPower.toString(2).length
 
   const halfLength = Math.floor(degree / 2)
+
+  // Check if bits needed exceed half the degree
+  if (bitsNeeded > halfLength) {
+    throw new Error('Total voting power exceeds maximum representable votes for the given degree')
+  }
 
   // For "yes": right-align in first half
   // Start index = (half length) - (bits needed)

--- a/examples/CRISP/sdk/tests/vote.test.ts
+++ b/examples/CRISP/sdk/tests/vote.test.ts
@@ -7,7 +7,7 @@
 import { describe, it, expect } from 'vitest'
 import { BfvProtocolParams, type ProtocolParams } from '@enclave-e3/sdk'
 
-import { calculateValidIndexesForPlaintext, decodeTally, encodeVote, validateVote } from '../src/vote'
+import { calculateValidIndicesForPlaintext, decodeTally, encodeVote, validateVote } from '../src/vote'
 import { VotingMode } from '../src/types'
 
 describe('Vote', () => {
@@ -43,6 +43,7 @@ describe('Vote', () => {
       expect(decoded.no).toBe(0n)
     })
   })
+
   describe('validateVote', () => {
     const validVote = { yes: 10n, no: 0n }
     const invalidVote = { yes: 5n, no: 5n }
@@ -66,8 +67,8 @@ describe('Vote', () => {
     })
   })
 
-  describe('calculateValidIndexesForPlaintext', () => {
-    it('should return the correct indeces', () => {
+  describe('calculateValidIndicesForPlaintext', () => {
+    it('should return the correct indices', () => {
       const degree = 8192
       const totalVotingPower = 100n
 
@@ -75,10 +76,28 @@ describe('Vote', () => {
       // half length = 4096
       // first valid index for yes 4096 - 7 = 4089
       // first valid index for no 8192 - 7 = 8185
-      expect(calculateValidIndexesForPlaintext(totalVotingPower, degree)).toEqual({
+      expect(calculateValidIndicesForPlaintext(totalVotingPower, degree)).toEqual({
         yesIndex: 4089,
         noIndex: 8185,
       })
+    })
+    it('should throw if voting power is too high for degree', () => {
+      const degree = 16
+      const totalVotingPower = 10000n
+
+      expect(() => {
+        calculateValidIndicesForPlaintext(totalVotingPower, degree)
+      }).toThrow('Total voting power exceeds maximum representable votes for the given degree')
+    })
+    it('should throw when the degree is negative', () => {
+      expect(() => {
+        calculateValidIndicesForPlaintext(10n, -16)
+      }).toThrow('Degree must be a positive even number')
+    })
+    it('should throw when the degree is not even', () => {
+      expect(() => {
+        calculateValidIndicesForPlaintext(10n, 15)
+      }).toThrow('Degree must be a positive even number')
     })
   })
 })


### PR DESCRIPTION
Calculate the plaintext indexes given a degree and the total voting power. This is needed to ensure that the encoded plaintext sent to the greco circuit has the correct binary values set in the correct indices. That will prevent overflowing and malicious inputs. 

The total supply is used as this calculates the worst case scenario where one voter has the full voting power which would be the maximum vote possible we would need to fit. (in reality it's always less, but we can't assume a more correct value imo)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added token total supply snapshot querying at specific blockchain blocks
  * Added voting index calculation utility for plaintext constraint validation

* **Tests**
  * Added comprehensive test coverage for voting index calculations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->