### PR TITLE
fix: ensure we can deploy the full risc0 verifier

### DIFF
--- a/examples/CRISP/deploy/Deploy.s.sol
+++ b/examples/CRISP/deploy/Deploy.s.sol
@@ -1,0 +1,54 @@
+// Copyright 2024 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.28;
+
+import {RiscZeroGroth16Verifier} from "risc0/groth16/RiscZeroGroth16Verifier.sol";
+import {ControlID} from "risc0/groth16/ControlID.sol";
+import {Script} from "forge-std/Script.sol";
+import "forge-std/Test.sol";
+
+contract CRISPProgramDeploy is Script {
+    function run() external {
+        // Read and log the chainID
+        uint256 chainId = block.chainid;
+        console2.log("Deploying on ChainID %d", chainId);
+
+        setupDeployer();
+        setupVerifier();
+
+        vm.stopBroadcast();
+    }
+
+    function setupDeployer() private {
+        uint256 deployerKey = uint256(
+            vm.envOr("PRIVATE_KEY", bytes32(0))
+        );
+
+        vm.startBroadcast(deployerKey);
+    }
+
+    function setupVerifier() private {
+        RiscZeroGroth16Verifier verifier = new RiscZeroGroth16Verifier(
+            ControlID.CONTROL_ROOT,
+            ControlID.BN254_CONTROL_ID
+        );
+        console2.log(
+            "Deployed RiscZeroGroth16Verifier to",
+            address(verifier)
+        );
+    }
+}

--- a/examples/CRISP/foundry.toml
+++ b/examples/CRISP/foundry.toml
@@ -1,0 +1,12 @@
+[profile.default]
+src = "contracts"
+out = "out"
+libs = ["lib"]
+test = "tests"
+ffi = true
+fs_permissions = [{ access = "read-write", path = "./"}]
+via_ir = false
+optimizer = true
+optimizer-runs = 10_000_000
+
+# See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/examples/CRISP/package.json
+++ b/examples/CRISP/package.json
@@ -47,6 +47,7 @@
     "@nomicfoundation/hardhat-toolbox-mocha-ethers": "3.0.0",
     "@nomicfoundation/hardhat-typechain": "3",
     "@nomicfoundation/hardhat-verify": "^3.0.1",
+    "@openzeppelin/contracts": "^5.0.2",
     "@playwright/test": "1.52.0",
     "@synthetixio/synpress": "^4.1.0",
     "@synthetixio/synpress-cache": "^0.0.12",

--- a/examples/CRISP/remappings.txt
+++ b/examples/CRISP/remappings.txt
@@ -1,9 +1,9 @@
 forge-std/=lib/risc0-ethereum/lib/forge-std/src/
-@openzeppelin/=lib/risc0-ethereum/lib/openzeppelin-contracts/
-openzeppelin/=lib/risc0-ethereum/lib/openzeppelin-contracts/
 risc0/=lib/risc0-ethereum/contracts/src/
 @enclave-e3/contracts/=node_modules/@enclave-e3/contracts/
 @excubiae/contracts/=node_modules/@excubiae/contracts/
 solady/=node_modules/solady/
 @zk-kit/lean-imt.sol=node_modules/@zk-kit/lean-imt.sol
 poseidon-solidity/=node_modules/poseidon-solidity/
+@openzeppelin/=lib/risc0-ethereum/lib/openzeppelin-contracts/
+openzeppelin/=lib/risc0-ethereum/lib/openzeppelin-contracts/

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,6 +131,9 @@ importers:
       '@nomicfoundation/hardhat-verify':
         specifier: ^3.0.1
         version: 3.0.1(hardhat@3.0.4(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@openzeppelin/contracts':
+        specifier: ^5.0.2
+        version: 5.3.0
       '@playwright/test':
         specifier: 1.52.0
         version: 1.52.0
@@ -469,7 +472,7 @@ importers:
         version: 3.0.4(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       hardhat-gas-reporter:
         specifier: ^2.2.0
-        version: 2.3.0(bufferutil@4.0.9)(hardhat@3.0.4(bufferutil@4.0.9)(utf-8-validate@5.0.10))(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+        version: 2.3.0(bufferutil@4.0.9)(hardhat@3.0.4(bufferutil@4.0.9)(utf-8-validate@5.0.10))(typescript@5.8.3)(utf-8-validate@5.0.10)
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -640,7 +643,7 @@ importers:
         version: 5.3.0
       '@risc0/ethereum':
         specifier: file:lib/risc0-ethereum
-        version: risc0-ethereum@file:templates/default/lib/risc0-ethereum
+        version: file:templates/default/lib/risc0-ethereum
       '@types/chai':
         specifier: ^4.2.0
         version: 4.3.20
@@ -2920,6 +2923,9 @@ packages:
 
   '@reown/appkit@1.7.8':
     resolution: {integrity: sha512-51kTleozhA618T1UvMghkhKfaPcc9JlKwLJ5uV+riHyvSoWPKPRIa5A6M1Wano5puNyW0s3fwywhyqTHSilkaA==}
+
+  '@risc0/ethereum@file:templates/default/lib/risc0-ethereum':
+    resolution: {directory: templates/default/lib/risc0-ethereum, type: directory}
 
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
@@ -8042,9 +8048,6 @@ packages:
   ripemd160@2.0.2:
     resolution: {integrity: sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==}
 
-  risc0-ethereum@file:templates/default/lib/risc0-ethereum:
-    resolution: {directory: templates/default/lib/risc0-ethereum, type: directory}
-
   robust-predicates@3.0.2:
     resolution: {integrity: sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==}
 
@@ -12327,6 +12330,8 @@ snapshots:
       - utf-8-validate
       - zod
 
+  '@risc0/ethereum@file:templates/default/lib/risc0-ethereum': {}
+
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
   '@rollup/plugin-inject@5.0.5(rollup@4.49.0)':
@@ -16378,7 +16383,7 @@ snapshots:
       - debug
       - utf-8-validate
 
-  hardhat-gas-reporter@2.3.0(bufferutil@4.0.9)(hardhat@3.0.4(bufferutil@4.0.9)(utf-8-validate@5.0.10))(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76):
+  hardhat-gas-reporter@2.3.0(bufferutil@4.0.9)(hardhat@3.0.4(bufferutil@4.0.9)(utf-8-validate@5.0.10))(typescript@5.8.3)(utf-8-validate@5.0.10):
     dependencies:
       '@ethersproject/abi': 5.8.0
       '@ethersproject/bytes': 5.8.0
@@ -16395,7 +16400,7 @@ snapshots:
       lodash: 4.17.21
       markdown-table: 2.0.0
       sha1: 1.1.1
-      viem: 2.30.6(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.30.6(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.22.4)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -19098,8 +19103,6 @@ snapshots:
     dependencies:
       hash-base: 3.1.0
       inherits: 2.0.4
-
-  risc0-ethereum@file:templates/default/lib/risc0-ethereum: {}
 
   robust-predicates@3.0.2: {}
 


### PR DESCRIPTION
Given hardhat does not allow to build files outside of node_modules or contracts, we need to use foundry to deploy the risc0 verifier for now.