### PR TITLE
fix: deploy the right input validator

### DIFF
--- a/examples/CRISP/contracts/Mocks/MockCRISPInputValidator.sol
+++ b/examples/CRISP/contracts/Mocks/MockCRISPInputValidator.sol
@@ -13,26 +13,12 @@ import {IVerifier} from "../CRISPVerifier.sol";
 /// @title MockCRISPInputValidator.
 /// @notice Mock Enclave Input Validator
 contract MockCRISPInputValidator is IInputValidator, Clone {
-    /// @notice The policy that will be used to validate the input.
-    IBasePolicy internal policy;
-
-    /// @notice The verifier that will be used to validate the input.
-    IVerifier internal noirVerifier;
-
     /// @notice The error emitted when the input data is empty.
     error EmptyInputData();
-    /// @notice The error emitted when the input data is invalid.
-    error InvalidInputData(bytes reason);
-    /// @notice The error emitted when the Noir proof is invalid.
-    error InvalidNoirProof();
 
     /// @notice Initializes the contract with appended bytes data for configuration.
     function _initialize() internal virtual override(Clone) {
         super._initialize();
-
-        (address policyAddr, address verifierAddr) = abi.decode(_getAppendedBytes(), (address, address));
-        policy = IBasePolicy(policyAddr);
-        noirVerifier = IVerifier(verifierAddr);
     }
 
     /// @notice Validates input

--- a/examples/CRISP/deploy/crisp.ts
+++ b/examples/CRISP/deploy/crisp.ts
@@ -22,6 +22,8 @@ export const deployCRISPContracts = async () => {
     const useMockVerifier = Boolean(process.env.USE_MOCK_VERIFIER) ?? false;
     const useMockInputValidator = Boolean(process.env.USE_MOCK_INPUT_VALIDATOR) ?? false;
 
+    console.log("useMockVerifier", useMockVerifier)
+
     const verifier = await deployVerifier(useMockVerifier)
 
     const inputValidator = await deployInputValidator(useMockInputValidator)
@@ -171,19 +173,19 @@ export const deployInputValidator = async (useMockInputValidator: boolean): Prom
 
     if (useMockInputValidator) {
         // Check if mock input validator already deployed
-        const existingMockInputValidator = readDeploymentArgs("MockInputValidator", chain);
+        const existingMockInputValidator = readDeploymentArgs("MockCRISPInputValidator", chain);
         if (existingMockInputValidator?.address) {
             console.log("MockInputValidator already deployed at:", existingMockInputValidator.address);
             return existingMockInputValidator.address;
         }
 
-        const mockInputValidatorFactory = await ethers.getContractFactory("MockInputValidator");
+        const mockInputValidatorFactory = await ethers.getContractFactory("MockCRISPInputValidator");
         const mockInputValidator = await mockInputValidatorFactory.deploy();
         const address = await mockInputValidator.getAddress();
 
         storeDeploymentArgs({
             address,
-        }, "MockInputValidator", hre.globalOptions.network);
+        }, "MockCRISPInputValidator", hre.globalOptions.network);
 
         return address;
     }


### PR DESCRIPTION
Ensure we deploy the right contract for CRISP input validator when using the mock option