### PR TITLE
chore: mock sepolia token holders as api does not support it

### DIFF
--- a/examples/CRISP/server/src/server/indexer.rs
+++ b/examples/CRISP/server/src/server/indexer.rs
@@ -75,7 +75,7 @@ pub async fn register_e3_requested(
                     .await?;
 
                 // Get token holders from Bitquery API or mocked data.
-                let token_holders = if matches!(CONFIG.chain_id, 31337 | 1337) {
+                let token_holders = if matches!(CONFIG.chain_id, 31337 | 1337 | 11155111) {
                     info!(
                         "Using mocked token holders for local network (chain_id: {})",
                         CONFIG.chain_id


### PR DESCRIPTION
mock sepolia token holders merkle tree

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Extended local mock token-holder support to include an additional local network configuration for improved development testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->