### PR TITLE
fix: wait until start window before activating an e3

### DIFF
--- a/examples/CRISP/server/src/server/indexer.rs
+++ b/examples/CRISP/server/src/server/indexer.rs
@@ -292,9 +292,7 @@ pub async fn register_committee_published(
                 }
 
                 // Convert milliseconds to seconds for comparison with block.timestamp
-                let start_time_ms = e3.startWindow[0].to::<u64>();
-                let start_time_secs = start_time_ms / 1000; // Convert to seconds
-                let start_time = UNIX_EPOCH + Duration::from_secs(start_time_secs);
+                let start_time = UNIX_EPOCH + Duration::from_secs(e3.startWindow[0].to::<u64>());
 
                 // Get current time
                 let now = SystemTime::now();


### PR DESCRIPTION
Ensure we wait until the activation period starts before calling e3.activate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Contract activation now respects scheduled start times and will wait until the scheduled moment before activating.
  * Added logging to indicate whether activation was delayed and for how long, or if activation occurred immediately, improving synchronization transparency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->