### PR TITLE
chore: use latest abi encoding

### DIFF
--- a/examples/CRISP/packages/crisp-contracts/contracts/Mocks/MockCRISPInputValidator.sol
+++ b/examples/CRISP/packages/crisp-contracts/contracts/Mocks/MockCRISPInputValidator.sol
@@ -28,7 +28,7 @@ contract MockCRISPInputValidator is IInputValidator, Clone {
     function validate(address sender, bytes memory data) external returns (bytes memory input) {
         if (data.length == 0) revert EmptyInputData();
 
-        (,,, bytes memory vote) = abi.decode(data, (bytes, bytes, bytes32[], bytes));
+        (,,bytes memory vote,) = abi.decode(data, (bytes, bytes32[], bytes, address));
 
         input = vote;
     }


### PR DESCRIPTION
Use latest abi encoding for mock input validator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected input validation decoding so data elements are interpreted in the proper order and types, ensuring the expected field is assigned reliably; the empty-input check behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->