### PR TITLE
fix: small changes to aid crisp e2e test to run locally

### DIFF
--- a/examples/CRISP/scripts/dev.sh
+++ b/examples/CRISP/scripts/dev.sh
@@ -29,7 +29,7 @@ cleanup() {
 
 trap cleanup INT TERM
 
-concurrently \
+pnpm concurrently \
   -ks first \
   --names "ANVIL,DEPLOY,NODES" \
   --prefix-colors "blue,green,yellow" \

--- a/examples/CRISP/scripts/dev_cipher.sh
+++ b/examples/CRISP/scripts/dev_cipher.sh
@@ -15,9 +15,9 @@ enclave nodes up -v &
 
 sleep 2
 
-CN1=$(cat ./enclave.config.yaml | yq '.nodes.cn1.address')
-CN2=$(cat ./enclave.config.yaml | yq '.nodes.cn2.address')
-CN3=$(cat ./enclave.config.yaml | yq '.nodes.cn3.address')
+CN1=$(cat ./enclave.config.yaml | yq -r '.nodes.cn1.address')
+CN2=$(cat ./enclave.config.yaml | yq -r '.nodes.cn2.address')
+CN3=$(cat ./enclave.config.yaml | yq -r '.nodes.cn3.address')
 
 # Add ciphernodes using variables from config.sh
 pnpm ciphernode:add --ciphernode-address "$CN1" --network "localhost"


### PR DESCRIPTION
A couple of small changes I needed to make to run the CRISP e2e test locally.

So I was trying to get CRISP e2e test running locally.

I had an older python version of `yq` installed which caused me grief because the -r flag was not present for some reason. I have updated but adding the `-r` flag solved the issue and is compatible with the new version as otherwise I was getting double quotes getting sent through to the hardhat scripts which broke stuff.

`'"0x123456"'`

So it seems to make sense to me to keep the `-r` flag as it is simply the default in the latest go version of yq so we can be compatible with both.

```
❯ yq --version
yq 3.4.3
```

Secondly concurrently was not available when running the scripts outside of pnpm so it helps to run it through pnpm so I added that too.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development script invocation to use package manager.

* **Bug Fixes**
  * Fixed output parsing for cipher node address configuration.

* **New Features**
  * Expanded cipher node setup to support additional nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->