### PR TITLE
refactor: Add ArcBytes::from_bytes that accepts &[u8]

### DIFF
--- a/crates/events/src/enclave_event/compute_request/bytes.rs
+++ b/crates/events/src/enclave_event/compute_request/bytes.rs
@@ -7,3 +7,36 @@ use std::sync::Arc;
 
 /// Reference count bytes so event can be cloned and shared between threads
 pub type Bytes = Arc<Vec<u8>>;
+
+/// Extension trait for Bytes to provide `from_bytes` method that accepts `&[u8]`
+pub trait ArcBytes {
+    /// Create Bytes from a byte slice
+    fn from_bytes(bytes: &[u8]) -> Self;
+}
+
+impl ArcBytes for Bytes {
+    fn from_bytes(bytes: &[u8]) -> Self {
+        Arc::new(bytes.to_vec())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ArcBytes, Bytes};
+
+    #[test]
+    fn test_from_bytes_with_slice() {
+        let input: &[u8] = &[1, 2, 3, 4, 5];
+        let bytes = Bytes::from_bytes(input);
+        
+        assert_eq!(bytes.as_ref(), &vec![1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn test_from_bytes_with_empty_slice() {
+        let input: &[u8] = &[];
+        let bytes = Bytes::from_bytes(input);
+        
+        assert_eq!(bytes.as_ref(), &Vec::<u8>::new());
+    }
+}


### PR DESCRIPTION
Closes #855

Adds `ArcBytes` trait with `from_bytes` method that accepts `&[u8]` instead of `Vec<u8>`.

- Added `ArcBytes` trait with `from_bytes(bytes: &[u8])` method
- Implemented trait for `Bytes` type
- Added unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal byte handling infrastructure with improved utility methods.

* **Tests**
  * Added unit tests to validate byte handling functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->