### PR TITLE
fix: make submit ticket more gas efficient

### DIFF
--- a/packages/enclave-contracts/contracts/registry/CiphernodeRegistryOwnable.sol
+++ b/packages/enclave-contracts/contracts/registry/CiphernodeRegistryOwnable.sol
@@ -325,7 +325,6 @@ contract CiphernodeRegistryOwnable is ICiphernodeRegistry, OwnableUpgradeable {
 
         // Store submission
         c.submitted[msg.sender] = true;
-        c.scoreOf[msg.sender] = score;
 
         // Insert into top-N (ascending score)
         _insertTopN(c, msg.sender, score);
@@ -505,58 +504,43 @@ contract CiphernodeRegistryOwnable is ICiphernodeRegistry, OwnableUpgradeable {
         require(ticketNumber <= availableTickets, InvalidTicketNumber());
     }
 
-    /// @notice Inserts a node into the top-N sorted list by score
-    /// @dev Maintains sorted order (ascending by score)
+    /// @notice Inserts a node into the top-N list - Smallest scores
+    /// @dev If the node is not in the top-N, it is added to the top-N.
     /// @param c Committee storage reference
-    /// @param node Address of the ciphernode
-    /// @param score The computed score
+    /// @param node Address of the node
+    /// @param score Score of the node
+    /// @return entered Whether the node was inserted into the top-N
     function _insertTopN(
         Committee storage c,
         address node,
         uint256 score
-    ) internal {
-        address[] storage topNodes = c.topNodes;
+    ) internal returns (bool entered) {
+        address[] storage top = c.topNodes;
+        uint256 cap = c.threshold[1];
 
-        // If list not full, insert in sorted order
-        if (topNodes.length < c.threshold[1]) {
-            _insertSorted(c, node, score);
-            return;
+        if (top.length < cap) {
+            top.push(node);
+            c.scoreOf[node] = score;
+            return true;
         }
 
-        // If list is full, only add if score is better than worst
-        uint256 worstScore = c.scoreOf[topNodes[topNodes.length - 1]];
-        if (score < worstScore) {
-            topNodes.pop();
-            _insertSorted(c, node, score);
-        }
-    }
-
-    /// @notice Inserts a node at the correct sorted position (ascending by score)
-    /// @param c Committee storage reference
-    /// @param node Address of the ciphernode
-    /// @param score The computed score
-    function _insertSorted(
-        Committee storage c,
-        address node,
-        uint256 score
-    ) internal {
-        address[] storage topNodes = c.topNodes;
-
-        // Find insertion position
-        uint256 insertPos = topNodes.length;
-        for (uint256 i = 0; i < topNodes.length; i++) {
-            uint256 existingScore = c.scoreOf[topNodes[i]];
-            if (score < existingScore) {
-                insertPos = i;
-                break;
+        uint256 worstIdx = 0;
+        uint256 worstScore = c.scoreOf[top[0]];
+        unchecked {
+            for (uint256 i = 1; i < top.length; ++i) {
+                uint256 s = c.scoreOf[top[i]];
+                if (s > worstScore) {
+                    worstScore = s;
+                    worstIdx = i;
+                }
             }
         }
 
-        // Insert at position
-        topNodes.push(address(0));
-        for (uint256 i = topNodes.length - 1; i > insertPos; i--) {
-            topNodes[i] = topNodes[i - 1];
-        }
-        topNodes[insertPos] = node;
+        if (score >= worstScore) return false;
+
+        top[worstIdx] = node;
+        c.scoreOf[node] = score;
+
+        return true;
     }
 }

--- a/packages/enclave-contracts/scripts/deployEnclave.ts
+++ b/packages/enclave-contracts/scripts/deployEnclave.ts
@@ -40,7 +40,7 @@ export const deployEnclave = async (withMocks?: boolean) => {
   );
 
   const THIRTY_DAYS_IN_SECONDS = 60 * 60 * 24 * 30;
-  const SORTITION_SUBMISSION_WINDOW = 3;
+  const SORTITION_SUBMISSION_WINDOW = 5;
   const addressOne = "0x0000000000000000000000000000000000000001";
 
   const poseidonT3 = await deployAndSavePoseidonT3({ hre });


### PR DESCRIPTION
We were running out of gas during submitTicket (e.g., on the 4th ticket) because maintaining a sorted/top-N via storage shifts or O(N) scans is too expensive at scale.

Replaced sorted insert with an unsorted bounded set in `_insertTopN`. 
- When not full, we append once and store the `scoreOf` 
- When full, we scan to find current worst and replace in place if the new score is smaller.
- Keeps top N smallest scores.


