### PR TITLE
chore: revert make submit ticket more gas efficient

### DIFF
--- a/packages/enclave-contracts/scripts/deployEnclave.ts
+++ b/packages/enclave-contracts/scripts/deployEnclave.ts
@@ -40,7 +40,7 @@ export const deployEnclave = async (withMocks?: boolean) => {
   );
 
   const THIRTY_DAYS_IN_SECONDS = 60 * 60 * 24 * 30;
-  const SORTITION_SUBMISSION_WINDOW = 5;
+  const SORTITION_SUBMISSION_WINDOW = 3;
   const addressOne = "0x0000000000000000000000000000000000000001";
 
   const poseidonT3 = await deployAndSavePoseidonT3({ hre });


### PR DESCRIPTION
This reverts commit 558e13bc52a0882a8f907593177dc9c318e23e19.

Reason is that it appears #965 did not pass the crisp e2e tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimized node scoring and ranking logic in the registry for improved efficiency.
  * Adjusted sortition submission window timing to 3 blocks for stricter submission constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->