### PR TITLE
chore: revert make submit ticket more gas efficient

### DIFF
--- a/packages/enclave-contracts/scripts/deployEnclave.ts
+++ b/packages/enclave-contracts/scripts/deployEnclave.ts
@@ -40,7 +40,7 @@ export const deployEnclave = async (withMocks?: boolean) => {
   );
 
   const THIRTY_DAYS_IN_SECONDS = 60 * 60 * 24 * 30;
-  const SORTITION_SUBMISSION_WINDOW = 5;
+  const SORTITION_SUBMISSION_WINDOW = 3;
   const addressOne = "0x0000000000000000000000000000000000000001";
 
   const poseidonT3 = await deployAndSavePoseidonT3({ hre });


### PR DESCRIPTION
This reverts commit 558e13bc52a0882a8f907593177dc9c318e23e19.

This did not pass crisp_e2e so it needs to be reverted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced registry node selection mechanism with improved score storage and optimized top-N insertion logic to ensure accurate ranking and tracking of registered nodes.

* **Chores**
  * Updated sortition submission window timing configuration to adjust the registration submission period duration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->