### PR TITLE
chore: v0.0.2-test

### DIFF
--- a/examples/CRISP/packages/crisp-contracts/package.json
+++ b/examples/CRISP/packages/crisp-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crisp-e3/contracts",
-  "version": "0.0.1-test",
+  "version": "0.0.2-test",
   "type": "module",
   "files": [
     "contracts",

--- a/examples/CRISP/packages/crisp-sdk/package.json
+++ b/examples/CRISP/packages/crisp-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crisp-e3/sdk",
-  "version": "0.0.1-test",
+  "version": "0.0.2-test",
   "type": "module",
   "author": {
     "name": "gnosisguild",

--- a/examples/CRISP/packages/crisp-zk-inputs/package.json
+++ b/examples/CRISP/packages/crisp-zk-inputs/package.json
@@ -2,7 +2,7 @@
   "name": "@crisp-e3/zk-inputs",
   "type": "module",
   "description": "Core logic to pre-compute CRISP ZK inputs (WASM/JavaScript bindings).",
-  "version": "0.0.1-test",
+  "version": "0.0.2-test",
   "license": "LGPL-3.0-only",
   "repository": {
     "type": "git",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped versions of core CRISP packages (contracts, SDK, and ZK inputs) from 0.0.1-test to 0.0.2-test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->