### PR TITLE
chore: enable linking workspace packages

### DIFF
--- a/examples/CRISP/client/.npmrc
+++ b/examples/CRISP/client/.npmrc
@@ -1,1 +1,0 @@
-link-workspace-packages=true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,3 +12,4 @@ packages:
   - packages/enclave-contracts
   - templates/default
   - templates/default/client
+linkWorkspacePackages: true


### PR DESCRIPTION
Related: https://github.com/gnosisguild/enclave/issues/999

Centralizes workspace package linking configuration by moving it from a package-specific `.npmrc` file to the root `pnpm-workspace.yaml`. So that, when we install dependencies in the root or any other place we still get the same behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated workspace configuration to link packages using pnpm settings instead of npm configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->