### PR TITLE
refactor: dynamic tree depth

### DIFF
--- a/crates/compute-provider/src/compute_input.rs
+++ b/crates/compute-provider/src/compute_input.rs
@@ -34,7 +34,7 @@ impl ComputeInput {
             "Ciphertext hash mismatch"
         );
 
-        let merkle_root = MerkleTreeBuilder::new()
+        let merkle_root = MerkleTreeBuilder::new(self.leaf_hashes.len())
             .with_leaf_hashes(self.leaf_hashes.clone())
             .build_tree()
             .root()

--- a/crates/compute-provider/src/compute_manager.rs
+++ b/crates/compute-provider/src/compute_manager.rs
@@ -56,7 +56,8 @@ where
     }
 
     fn start_sequential(&mut self) -> (P::Output, Vec<u8>) {
-        let mut tree_builder = MerkleTreeBuilder::new();
+        let num_leaves = self.input.fhe_inputs.ciphertexts.len();
+        let mut tree_builder = MerkleTreeBuilder::new(num_leaves);
 
         tree_builder.compute_leaf_hashes(&self.input.fhe_inputs.ciphertexts);
         self.input.leaf_hashes = tree_builder.leaf_hashes.clone();
@@ -84,7 +85,7 @@ where
         let tally_results: Vec<(P::Output, Vec<u8>, String)> = chunks
             .into_par_iter()
             .map(|chunk| {
-                let mut tree_builder = MerkleTreeBuilder::new();
+                let mut tree_builder = MerkleTreeBuilder::new(chunk.len());
 
                 tree_builder.compute_leaf_hashes(&chunk);
                 let merkle_root = tree_builder.build_tree().root().unwrap();

--- a/crates/compute-provider/src/merkle_tree_builder.rs
+++ b/crates/compute-provider/src/merkle_tree_builder.rs
@@ -21,12 +21,12 @@ pub struct MerkleTreeBuilder {
 }
 
 impl MerkleTreeBuilder {
-    pub fn new() -> Self {
+    pub fn new(num_leaves: usize) -> Self {
         Self {
             leaf_hashes: Vec::new(),
             arity: 2,
             zero_value: "0".to_string(),
-            depth: 20,
+            depth: (num_leaves as f64).log2().ceil() as usize,
         }
     }
 
@@ -86,5 +86,25 @@ impl MerkleTreeBuilder {
         }
 
         tree
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::MerkleTreeBuilder;
+
+    #[test]
+    fn test_depth_computation() {
+        // Test various numbers of leaves to verify depth calculation
+        // For binary tree: depth = ceil(log2(num_leaves))
+        assert_eq!(MerkleTreeBuilder::new(1).depth, 0); // ceil(log2(1)) = 0
+        assert_eq!(MerkleTreeBuilder::new(2).depth, 1); // ceil(log2(2)) = 1
+        assert_eq!(MerkleTreeBuilder::new(3).depth, 2); // ceil(log2(3)) = 2
+        assert_eq!(MerkleTreeBuilder::new(4).depth, 2); // ceil(log2(4)) = 2
+        assert_eq!(MerkleTreeBuilder::new(5).depth, 3); // ceil(log2(5)) = 3
+        assert_eq!(MerkleTreeBuilder::new(8).depth, 3); // ceil(log2(8)) = 3
+        assert_eq!(MerkleTreeBuilder::new(9).depth, 4); // ceil(log2(9)) = 4
+        assert_eq!(MerkleTreeBuilder::new(16).depth, 4); // ceil(log2(16)) = 4
+        assert_eq!(MerkleTreeBuilder::new(17).depth, 5); // ceil(log2(17)) = 5
     }
 }

--- a/examples/CRISP/packages/crisp-contracts/contracts/CRISPProgram.sol
+++ b/examples/CRISP/packages/crisp-contracts/contracts/CRISPProgram.sol
@@ -192,7 +192,7 @@ contract CRISPProgram is IE3Program, Ownable {
   /// @inheritdoc IE3Program
   function verify(uint256 e3Id, bytes32 ciphertextOutputHash, bytes memory proof) external view override returns (bool) {
     if (e3Data[e3Id].paramsHash == bytes32(0)) revert E3DoesNotExist();
-    bytes32 inputRoot = bytes32(e3Data[e3Id].votes._root(TREE_DEPTH));
+    bytes32 inputRoot = bytes32(e3Data[e3Id].votes._root());
     bytes memory journal = new bytes(396); // (32 + 1) * 4 * 3
 
     _encodeLengthPrefixAndHash(journal, 0, ciphertextOutputHash);


### PR DESCRIPTION
Closes #1044 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Merkle tree depth is now calculated from the actual number of leaves instead of a fixed value.
* **Behavior Change**
  * Per-input Merkle builders are initialized with explicit leaf counts; root values are derived directly in the verification path.
* **Tests**
  * Added tests covering depth calculation for various leaf counts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->