### PR TITLE
chore: add profiling support for risc0

### DIFF
--- a/crates/support/Cargo.lock
+++ b/crates/support/Cargo.lock
@@ -2989,6 +2989,28 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 [[package]]
 name = "e3-bfv-helpers"
 version = "0.1.5"
+dependencies = [
+ "alloy-dyn-abi",
+ "alloy-primitives",
+ "anyhow",
+ "fhe",
+ "fhe-math",
+ "fhe-traits",
+ "fhe-util",
+ "itertools 0.14.0",
+ "ndarray",
+ "num-bigint",
+ "num-traits",
+ "rand 0.8.5",
+ "strum",
+ "thiserror 1.0.69",
+ "zkfhe-greco",
+ "zkfhe-shared",
+]
+
+[[package]]
+name = "e3-bfv-helpers"
+version = "0.1.5"
 source = "git+https://github.com/gnosisguild/enclave?rev=632766e4ed1ceeccdeb023a56f16413a33be6f46#632766e4ed1ceeccdeb023a56f16413a33be6f46"
 dependencies = [
  "alloy-dyn-abi",
@@ -3052,6 +3074,7 @@ dependencies = [
  "boundless-market",
  "bytemuck",
  "dotenvy",
+ "e3-bfv-helpers 0.1.5",
  "e3-compute-provider",
  "e3-user-program",
  "fhe",
@@ -3082,7 +3105,7 @@ dependencies = [
 name = "e3-user-program"
 version = "0.1.0"
 dependencies = [
- "e3-bfv-helpers",
+ "e3-bfv-helpers 0.1.5 (git+https://github.com/gnosisguild/enclave?rev=632766e4ed1ceeccdeb023a56f16413a33be6f46)",
  "e3-compute-provider",
  "fhe",
  "fhe-traits",

--- a/crates/support/host/Cargo.toml
+++ b/crates/support/host/Cargo.toml
@@ -26,3 +26,4 @@ tracing-subscriber = { workspace = true }
 boundless-market = { workspace = true }
 url = { workspace = true }
 dotenvy = { workspace = true }
+e3-bfv-helpers = { path = "../../bfv-helpers" }

--- a/crates/support/host/src/bin/profile_risc0.rs
+++ b/crates/support/host/src/bin/profile_risc0.rs
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+//
+// This file is provided WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE.
+
+use e3_bfv_helpers::{build_bfv_params_from_set_arc, encode_bfv_params, BfvParamSets};
+use e3_compute_provider::FHEInputs;
+use e3_support_host::run_risc0_compute;
+use fhe::bfv::{Encoding, Plaintext, PublicKey, SecretKey};
+use fhe_traits::{FheEncoder, FheEncrypter, Serialize};
+use rand::thread_rng;
+
+fn main() {
+    println!("Starting RISC0 profiling with mock ciphertexts...");
+
+    // Use InsecureSet512_10_1 parameter set
+    let param_set = BfvParamSets::InsecureSet512_10_1.into();
+    let params = build_bfv_params_from_set_arc(param_set);
+
+    println!(
+        "Generated BFV parameters: degree={}, plaintext_modulus={}",
+        params.degree(),
+        params.plaintext()
+    );
+
+    // Generate keys
+    let mut rng = thread_rng();
+    let secret_key = SecretKey::random(&params, &mut rng);
+    let public_key = PublicKey::new(&secret_key, &mut rng);
+
+    println!("Generated secret and public keys");
+
+    // Encrypt values 1, 2, 3
+    let values = vec![1u64, 2u64, 3u64];
+    let mut ciphertexts = Vec::new();
+
+    for (idx, value) in values.iter().enumerate() {
+        let plaintext = Plaintext::try_encode(&[*value], Encoding::poly(), &params)
+            .expect("Failed to encode plaintext");
+        let ciphertext = public_key
+            .try_encrypt(&plaintext, &mut rng)
+            .expect("Failed to encrypt");
+
+        ciphertexts.push((ciphertext.to_bytes(), idx as u64));
+        println!("Encrypted value {} as ciphertext {}", value, idx);
+    }
+
+    // Encode params to bytes
+    let params_bytes = encode_bfv_params(&params);
+    println!("Encoded params to {} bytes", params_bytes.len());
+
+    // Create FHEInputs
+    let fhe_inputs = FHEInputs {
+        ciphertexts,
+        params: params_bytes,
+    };
+
+    println!("Calling run_risc0_compute...");
+
+    // Call run_risc0_compute
+    match run_risc0_compute(fhe_inputs) {
+        Ok((output, ciphertext)) => {
+            println!("Success! RISC0 computation completed");
+            println!("Output result: {:?}", output.result);
+            println!("Output bytes length: {}", output.bytes.len());
+            println!("Seal length: {}", output.seal.len());
+            println!("Processed ciphertext length: {}", ciphertext.len());
+        }
+        Err(e) => {
+            eprintln!("Error during RISC0 computation: {:?}", e);
+            std::process::exit(1);
+        }
+    }
+}


### PR DESCRIPTION
run
```
RISC0_PPROF_OUT=./profile.pb RUST_LOG=info RISC0_DEV_MODE=1 RISC0_INFO=1 cargo run --bin profile_risc0
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added RISC0 as an alternative proof computation backend for enhanced flexibility
* Integrated BFV homomorphic encryption support enabling secure computation workflows
* Enabled development mode for testing proof generation without production-level overhead
* System now supports multiple compute provider backends for different operational needs

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->