### PR TITLE
chore: store block numbers

### DIFF
--- a/examples/CRISP/packages/crisp-contracts/deploy/crisp.ts
+++ b/examples/CRISP/packages/crisp-contracts/deploy/crisp.ts
@@ -58,6 +58,7 @@ export const deployCRISPContracts = async () => {
   storeDeploymentArgs(
     {
       address: honkVerifierAddress,
+      blockNumber: await ethers.provider.getBlockNumber(),
     },
     'HonkVerifier',
     chain,
@@ -77,6 +78,7 @@ export const deployCRISPContracts = async () => {
   storeDeploymentArgs(
     {
       address: crispAddress,
+      blockNumber: await ethers.provider.getBlockNumber(),
       constructorArgs: {
         enclave: enclaveAddress,
         verifierAddress: verifier,
@@ -125,6 +127,7 @@ export const deployVerifier = async (useMockVerifier: boolean): Promise<string> 
     storeDeploymentArgs(
       {
         address,
+        blockNumber: await ethers.provider.getBlockNumber(),
       },
       'RiscZeroGroth16Verifier',
       chain,
@@ -144,6 +147,7 @@ export const deployVerifier = async (useMockVerifier: boolean): Promise<string> 
   storeDeploymentArgs(
     {
       address: mockVerifierAddress,
+      blockNumber: await ethers.provider.getBlockNumber(),
     },
     'MockRISC0Verifier',
     hre.globalOptions.network,


### PR DESCRIPTION
Store block numbers for crisp contracts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Deployment metadata now records the current block number during contract deployments, improving traceability of deployed artifacts and on-chain context.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->