### PR TITLE
chore: simplify network test execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,7 +236,8 @@ jobs:
       - name: 'Check out the repo'
         uses: 'actions/checkout@v4'
       - name: 'Run network tests'
-        run: './tests/integration/test.sh net --no-prebuild'
+        working-directory: tests/integration
+        run: './test.sh net --no-prebuild'
       - name: 'Add test summary'
         run: |
           echo "## Network test results" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
The `test_net` job was failing in some PRs and in the main branch, and those PR got merged anyway surprisingly.

This PR should fix that error.