### PR TITLE
fix: aggregator address and remove stale libp2p nodes

### DIFF
--- a/crates/cli/src/start.rs
+++ b/crates/cli/src/start.rs
@@ -33,6 +33,7 @@ pub async fn execute(
         } => {
             e3_entrypoint::start::aggregator_start::execute(
                 &config,
+                address,
                 pubkey_write_path,
                 plaintext_write_path,
                 experimental_trbfv,

--- a/crates/entrypoint/src/start/aggregator_start.rs
+++ b/crates/entrypoint/src/start/aggregator_start.rs
@@ -4,6 +4,7 @@
 // without even the implied warranty of MERCHANTABILITY
 // or FITNESS FOR A PARTICULAR PURPOSE.
 
+use alloy::primitives::Address;
 use anyhow::Result;
 use e3_ciphernode_builder::CiphernodeBuilder;
 use e3_config::AppConfig;
@@ -22,6 +23,7 @@ use tokio::task::JoinHandle;
 
 pub async fn execute(
     config: &AppConfig,
+    address: Address,
     pubkey_write_path: Option<PathBuf>,
     plaintext_write_path: Option<PathBuf>,
     experimental_trbfv: bool,
@@ -29,6 +31,7 @@ pub async fn execute(
     let rng = Arc::new(Mutex::new(ChaCha20Rng::from_rng(OsRng)?));
     let cipher = Arc::new(Cipher::from_file(config.key_file()).await?);
     let mut builder = CiphernodeBuilder::new(&config.name(), rng.clone(), cipher.clone())
+        .with_address(&address.to_string())
         .with_persistence(&config.log_file(), &config.db_file())
         .with_chains(&config.chains())
         .with_sortition_score()


### PR DESCRIPTION
closes #1158 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for connection failures by detecting and removing stale peer information.
  * Enhanced error reporting for incoming connection errors with refined logging levels.

* **Improvements**
  * Reduced log spam by logging connection messages only on initial peer connection establishment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->