### PR TITLE
chore(release): bump version to 0.1.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,298 @@
+## [0.1.11](https://github.com/gnosisguild/enclave/compare/v0.1.2...v0.1.11) (2026-02-06)
+
+### Bug Fixes
+
+- abi encode custom params ([#1108](https://github.com/gnosisguild/enclave/issues/1108))
+  ([3b81758](https://github.com/gnosisguild/enclave/commit/3b81758fa3304e9037142d060c27863f1d90884f))
+- add some stability improvements to crisp_e2e test
+  ([#936](https://github.com/gnosisguild/enclave/issues/936))
+  ([8e14a29](https://github.com/gnosisguild/enclave/commit/8e14a2916fce36c62accdeecdbe690834d3431ea))
+- aggregator address and remove stale libp2p nodes
+  ([#1162](https://github.com/gnosisguild/enclave/issues/1162))
+  ([5568c1f](https://github.com/gnosisguild/enclave/commit/5568c1f730caa9fe450a724f40270fb864a608e5))
+- change bound types in Greco to Field ([#972](https://github.com/gnosisguild/enclave/issues/972))
+  ([4fd945e](https://github.com/gnosisguild/enclave/commit/4fd945e432a86b7d93745e6f490d61bd3a9da5b7))
+- coderabbit config ([#893](https://github.com/gnosisguild/enclave/issues/893))
+  ([82c09ea](https://github.com/gnosisguild/enclave/commit/82c09eae57f1635ac053d51a24ef99edfad126a9))
+- commitments [skip-line-limit] ([#1196](https://github.com/gnosisguild/enclave/issues/1196))
+  ([a3ef19d](https://github.com/gnosisguild/enclave/commit/a3ef19d64142e5dd6916864c6d3dbc82f55f2bf8))
+- contracts exports ([#732](https://github.com/gnosisguild/enclave/issues/732))
+  ([c0686c6](https://github.com/gnosisguild/enclave/commit/c0686c6b42b351c07adf400c47d8cc5b2573f8e6))
+- correctly parse custom params event ([#891](https://github.com/gnosisguild/enclave/issues/891))
+  ([afc2b35](https://github.com/gnosisguild/enclave/commit/afc2b3503558a3d4cfdf7c15c519a6c3a18e7382))
+- crisp circuit validation of encoded vote
+  ([#973](https://github.com/gnosisguild/enclave/issues/973))
+  ([d14826c](https://github.com/gnosisguild/enclave/commit/d14826c8be20c72165c8f48898e6539cdfe89afe))
+- crisp voting ux fixes [skip-line-limit]
+  ([#1053](https://github.com/gnosisguild/enclave/issues/1053))
+  ([22764dd](https://github.com/gnosisguild/enclave/commit/22764dd3998f645a886885907bd832bdf5e3614e))
+- deploy risc0verifier with hardhat ([#894](https://github.com/gnosisguild/enclave/issues/894))
+  ([e52d6e5](https://github.com/gnosisguild/enclave/commit/e52d6e59e9a1ff86bf2154afb67b89b73aaad4cb))
+- deploy the right input validator ([#889](https://github.com/gnosisguild/enclave/issues/889))
+  ([09c34ea](https://github.com/gnosisguild/enclave/commit/09c34ea2e295e9741e91fe5b9c4e6d139704b361))
+- ensure we can deploy the full risc0 verifier
+  ([#886](https://github.com/gnosisguild/enclave/issues/886))
+  ([b94d0ef](https://github.com/gnosisguild/enclave/commit/b94d0ef81fb7cca19f7e5c622cdcd05fc52a2f7a))
+- ensure we don't have uncommited files ([#676](https://github.com/gnosisguild/enclave/issues/676))
+  ([a46e707](https://github.com/gnosisguild/enclave/commit/a46e70795655b8ff3a9896651f09f5ccee2592c7))
+- ensure we push to the correct branch ([#770](https://github.com/gnosisguild/enclave/issues/770))
+  ([9d630a6](https://github.com/gnosisguild/enclave/commit/9d630a6eab7c2329eb4603e1bebe48a82b35adcc))
+- fix reentrancy issue in enclave contracts
+  ([#752](https://github.com/gnosisguild/enclave/issues/752))
+  ([3806a87](https://github.com/gnosisguild/enclave/commit/3806a870b39fa47a1b4b77f9484c0a1d74bfbaa4))
+- increase integration test ci duration
+  ([#1198](https://github.com/gnosisguild/enclave/issues/1198))
+  ([21202c3](https://github.com/gnosisguild/enclave/commit/21202c3e61cf90b9521bad93e3825edb4f9aa297))
+- increase timeout for crisp e2e for committee finalization
+  ([#970](https://github.com/gnosisguild/enclave/issues/970))
+  ([18a729d](https://github.com/gnosisguild/enclave/commit/18a729d750121d3e43e5bfb8ff4b035d422c21de))
+- make submit ticket more gas efficient ([#965](https://github.com/gnosisguild/enclave/issues/965))
+  ([558e13b](https://github.com/gnosisguild/enclave/commit/558e13bc52a0882a8f907593177dc9c318e23e19))
+- pnpm install not working ([#921](https://github.com/gnosisguild/enclave/issues/921))
+  ([f3f0631](https://github.com/gnosisguild/enclave/commit/f3f0631063c2f5c2a8364e84342209e4964846fa))
+- refactor arcbytes to accept &[u8] ([#961](https://github.com/gnosisguild/enclave/issues/961))
+  ([4ac6743](https://github.com/gnosisguild/enclave/commit/4ac6743ad2a87d314cd51abcfba668956ded7b72))
+- release add back registry url and update npm to latest
+  ([#1098](https://github.com/gnosisguild/enclave/issues/1098))
+  ([8bb78ae](https://github.com/gnosisguild/enclave/commit/8bb78aef798ee0e91a3e76d98e4e90ff02b7c61c))
+- release rust crates error ([#689](https://github.com/gnosisguild/enclave/issues/689))
+  ([3c25929](https://github.com/gnosisguild/enclave/commit/3c25929f2317003c81d3a21d6b4fc9b1e44573cc))
+- remove already published files from gitignore
+  ([#680](https://github.com/gnosisguild/enclave/issues/680))
+  ([283205d](https://github.com/gnosisguild/enclave/commit/283205dffc665d83cc741c07f697c1ecaf2d1d84))
+- remove ci artifacts deep clean ([#681](https://github.com/gnosisguild/enclave/issues/681))
+  ([242aac9](https://github.com/gnosisguild/enclave/commit/242aac96b9800043b0d24b5716b3262baefd4472))
+- remove mac intel build and allow crates publishing to fail
+  ([#777](https://github.com/gnosisguild/enclave/issues/777))
+  ([8025c27](https://github.com/gnosisguild/enclave/commit/8025c277d5c4aa1005ab93d84d34158266458800))
+- require threshold_n nodes for committee finalization
+  ([#1167](https://github.com/gnosisguild/enclave/issues/1167))
+  ([1167728](https://github.com/gnosisguild/enclave/commit/116772855541b4b4e8d850c7b8ad0a3f89038aaa))
+- retry ciphernode tx with backoff ([#1168](https://github.com/gnosisguild/enclave/issues/1168))
+  ([d3b1200](https://github.com/gnosisguild/enclave/commit/d3b120030260e77b59796284418dbef1e631ed64))
+- retry publish plaintext output ([#1183](https://github.com/gnosisguild/enclave/issues/1183))
+  ([d562ae6](https://github.com/gnosisguild/enclave/commit/d562ae6ee81966b78300bccfd80be85f8d078df6))
+- retry tx in crisp server ([#1169](https://github.com/gnosisguild/enclave/issues/1169))
+  ([5e8df62](https://github.com/gnosisguild/enclave/commit/5e8df62bef1138cc30ad31db362291ba7ca66a3d))
+- risc0 dev mode env var ([#810](https://github.com/gnosisguild/enclave/issues/810))
+  ([7e09bad](https://github.com/gnosisguild/enclave/commit/7e09bad3373ecf4b7868840e2587d05a8a05160f))
+- rust crate release error ([#694](https://github.com/gnosisguild/enclave/issues/694))
+  ([56e9b12](https://github.com/gnosisguild/enclave/commit/56e9b12c2b319d1ea1081df4577b6b0cd0ccfc7d))
+- rust crates release workflow ([#715](https://github.com/gnosisguild/enclave/issues/715))
+  ([fc330c6](https://github.com/gnosisguild/enclave/commit/fc330c625742bce01def98ef3ccec5ae15fbdb96))
+- rust releases ([#774](https://github.com/gnosisguild/enclave/issues/774))
+  ([16870a4](https://github.com/gnosisguild/enclave/commit/16870a42973fccae7a376ccbc4b952f9e971fffa))
+- small changes to aid crisp e2e test to run locally
+  ([#926](https://github.com/gnosisguild/enclave/issues/926))
+  ([92ff34e](https://github.com/gnosisguild/enclave/commit/92ff34eaeff1167bc9d125f14f5bda46f1389716))
+- sortition ticket calculation to match on chain
+  ([#1224](https://github.com/gnosisguild/enclave/issues/1224))
+  ([760c965](https://github.com/gnosisguild/enclave/commit/760c9657ad496a566fc8bdfdff43e751a53b44f7))
+- support crate contract path ([#1038](https://github.com/gnosisguild/enclave/issues/1038))
+  ([c57aa99](https://github.com/gnosisguild/enclave/commit/c57aa9969b1b0295b8c72088d07422cae06dbc26))
+- template init was not using up-to-date dependencies
+  ([#1008](https://github.com/gnosisguild/enclave/issues/1008))
+  ([b9c052f](https://github.com/gnosisguild/enclave/commit/b9c052fe90141be618c4d21af91787499994a329))
+- update ciphernode operator links ([#1182](https://github.com/gnosisguild/enclave/issues/1182))
+  ([eca8639](https://github.com/gnosisguild/enclave/commit/eca86399867dbb56f64060ecc33d24b1d671f161))
+- update getOptimalThreadCount to work in browsers
+  ([#1137](https://github.com/gnosisguild/enclave/issues/1137))
+  ([007d0c2](https://github.com/gnosisguild/enclave/commit/007d0c28e784961f86bfacd1f2009f47c94595ce))
+- update relative paths to use git ([#708](https://github.com/gnosisguild/enclave/issues/708))
+  ([e0bd2bc](https://github.com/gnosisguild/enclave/commit/e0bd2bc7a5e2515013188fc7e40927630d1f6d58))
+- use npm and install solc for release build
+  ([#1096](https://github.com/gnosisguild/enclave/issues/1096))
+  ([3f89f3d](https://github.com/gnosisguild/enclave/commit/3f89f3d1f8e72a4a0e62d0c3a9f4d822c83f9eb1))
+- use simulated network for hardhat ([#1024](https://github.com/gnosisguild/enclave/issues/1024))
+  ([a6b5fd5](https://github.com/gnosisguild/enclave/commit/a6b5fd54ce209692ebda9e7ff641dde9231b0b0e))
+- wait until start window before activating an e3
+  ([#902](https://github.com/gnosisguild/enclave/issues/902))
+  ([f797b3d](https://github.com/gnosisguild/enclave/commit/f797b3d2fd3742a11f92f917a8d2c578fea4bdd4))
+- wasm init ([#740](https://github.com/gnosisguild/enclave/issues/740))
+  ([58f7905](https://github.com/gnosisguild/enclave/commit/58f7905dd5bd33070be84b0bd5d88b5f44d98267))
+
+### Features
+
+- add a function to get an e3 public key ([#760](https://github.com/gnosisguild/enclave/issues/760))
+  ([4db5dac](https://github.com/gnosisguild/enclave/commit/4db5dacf2f60872cfbafa16728b3da4f9244c248))
+- add ciphertext addition to circuit ([#912](https://github.com/gnosisguild/enclave/issues/912))
+  ([70857d4](https://github.com/gnosisguild/enclave/commit/70857d46df7e36a76e9961cf3221613522b1b45a))
+- add cli methods for ciphernode registration [skip-line-limit]
+  ([#1089](https://github.com/gnosisguild/enclave/issues/1089))
+  ([9afdb9d](https://github.com/gnosisguild/enclave/commit/9afdb9d7ffb69a8622c6baeeb0ffa9e49f5a4ef8))
+- add contract verification on CRISP ([#885](https://github.com/gnosisguild/enclave/issues/885))
+  ([f82c24a](https://github.com/gnosisguild/enclave/commit/f82c24a770871abe16711a45b6389c9a57d4b398))
+- add crate for zk input generation [skip-line-limit]
+  ([#901](https://github.com/gnosisguild/enclave/issues/901))
+  ([c316a53](https://github.com/gnosisguild/enclave/commit/c316a53c03e6a5cb24400cea97261334cde8bf27))
+- add dappnode pkg & update ci docker images tags [skip-line-limit]
+  ([#1061](https://github.com/gnosisguild/enclave/issues/1061))
+  ([46a40e7](https://github.com/gnosisguild/enclave/commit/46a40e77a591eb0b7a64a07f96e90aa7d0416f86))
+- add dht get_record and set_record commands
+  ([#904](https://github.com/gnosisguild/enclave/issues/904))
+  ([09c4e2d](https://github.com/gnosisguild/enclave/commit/09c4e2d49cb32daf1aa7c51c9f76273f27172bb3))
+- add ecdsa proving circuit ([#781](https://github.com/gnosisguild/enclave/issues/781))
+  ([3acf773](https://github.com/gnosisguild/enclave/commit/3acf773b8664938b3d4a67291bb3cc3ee7f159b5))
+- add functionality to encrypt a u64 vector
+  ([#853](https://github.com/gnosisguild/enclave/issues/853))
+  ([e9a8b9b](https://github.com/gnosisguild/enclave/commit/e9a8b9b42766a6c1500d6e8c92100326e4da8e1a))
+- add historical events ordering on ciphernode startup
+  ([#1012](https://github.com/gnosisguild/enclave/issues/1012))
+  ([9287de5](https://github.com/gnosisguild/enclave/commit/9287de584bbd3afd98e4430ede6adb1d6b704505))
+- add hybrid logical clock to codebase ([#1057](https://github.com/gnosisguild/enclave/issues/1057))
+  ([c7d3a0f](https://github.com/gnosisguild/enclave/commit/c7d3a0f20c2c3d112db6949a135669831b2d13f7))
+- add merkle tree proof inputs to circuit and sdk
+  ([#917](https://github.com/gnosisguild/enclave/issues/917))
+  ([ebd06c3](https://github.com/gnosisguild/enclave/commit/ebd06c31ea375cdd3e35058eb7bc93ae3df3a2e7))
+- add pk_commitment for greco ([#1083](https://github.com/gnosisguild/enclave/issues/1083))
+  ([2ba971b](https://github.com/gnosisguild/enclave/commit/2ba971ba39838032c144319cad0dc1d81b12116e))
+- add production ready sets for trbfv and bfv
+  ([#942](https://github.com/gnosisguild/enclave/issues/942))
+  ([bdc1adf](https://github.com/gnosisguild/enclave/commit/bdc1adf12e23e888ffa810b1af6e0827155f2e1b))
+- add pvss and pvss-cli rust crates with C0 [skip-line-limit]
+  ([#1217](https://github.com/gnosisguild/enclave/issues/1217))
+  ([ffceb25](https://github.com/gnosisguild/enclave/commit/ffceb25b8eb6bc752530bda33d0c6f6d88b1e33f))
+- add share encryption [skip-line-limit]
+  ([#1114](https://github.com/gnosisguild/enclave/issues/1114))
+  ([6b576ea](https://github.com/gnosisguild/enclave/commit/6b576ea91728d05abe89645db686b72cff877882))
+- add share-encryption circuit gen [skip-line-limit]
+  ([#1267](https://github.com/gnosisguild/enclave/issues/1267))
+  ([867ac1d](https://github.com/gnosisguild/enclave/commit/867ac1db46717fcb89ad551c29a0ccbc0372c8bd))
+- add support for dnsaddr resolution ([#1060](https://github.com/gnosisguild/enclave/issues/1060))
+  ([d822758](https://github.com/gnosisguild/enclave/commit/d8227583da51ce34829af71494c5d3aa33a05f78))
+- add support for masking on frontend ([#1140](https://github.com/gnosisguild/enclave/issues/1140))
+  ([ad8c74b](https://github.com/gnosisguild/enclave/commit/ad8c74becdb97608f3279f6a6cb1feba9e68dd1c))
+- add trbfv actor test ([#660](https://github.com/gnosisguild/enclave/issues/660))
+  ([3dd1a51](https://github.com/gnosisguild/enclave/commit/3dd1a5136e15fbb2ae39faeb7402c105955467e6))
+- add vote validation and encoding in ts ([#848](https://github.com/gnosisguild/enclave/issues/848))
+  ([914948d](https://github.com/gnosisguild/enclave/commit/914948d0a299bbae60f0e0232e228c2a14b713cb))
+- add zk-inputs-wasm crate [skip-line-limit]
+  ([#905](https://github.com/gnosisguild/enclave/issues/905))
+  ([f2463fa](https://github.com/gnosisguild/enclave/commit/f2463fa46f7c3190c3083b387abb79bdc3894ff0))
+- allow crisp to work with constant credits
+  ([#1263](https://github.com/gnosisguild/enclave/issues/1263))
+  ([b552c99](https://github.com/gnosisguild/enclave/commit/b552c99d8d71ef33a6b58b8a4b8e4bd69e2748c2))
+- allow to encode multiple options in CRISP votes [skip-line-limit]
+  ([#1262](https://github.com/gnosisguild/enclave/issues/1262))
+  ([4f84a52](https://github.com/gnosisguild/enclave/commit/4f84a52d69eef2aa998aad1b18c5bc6fe7f562b8))
+- assign voter slot ([#843](https://github.com/gnosisguild/enclave/issues/843))
+  ([4637a78](https://github.com/gnosisguild/enclave/commit/4637a785b9284e7442e598c3c2a0306a401acbe5))
+- automatically config enclave.config.yaml
+  ([#1014](https://github.com/gnosisguild/enclave/issues/1014))
+  ([4c468fc](https://github.com/gnosisguild/enclave/commit/4c468fcca266a911cc0197e6181d1edbbdae1f51))
+- bonsai to boundless migration [skip-line-limit]
+  ([#1030](https://github.com/gnosisguild/enclave/issues/1030))
+  ([6fd1668](https://github.com/gnosisguild/enclave/commit/6fd1668ebbd82435843847030b37fe6b18130b63))
+- census tree on CRISP ([#763](https://github.com/gnosisguild/enclave/issues/763))
+  ([ecd0ac2](https://github.com/gnosisguild/enclave/commit/ecd0ac23c8e18a8c2768992adfa6d8bb96740a0e)),
+  closes [#779](https://github.com/gnosisguild/enclave/issues/779)
+- ciphernode economic contracts [skip-line-limit]
+  ([#766](https://github.com/gnosisguild/enclave/issues/766))
+  ([c478909](https://github.com/gnosisguild/enclave/commit/c478909bd8aedebf93a3223dcbe91d85fceceb63))
+- circuits distribution ([#1243](https://github.com/gnosisguild/enclave/issues/1243))
+  ([a77f9d4](https://github.com/gnosisguild/enclave/commit/a77f9d451a22524e08f436baeee82c26ccdb5fa0))
+- connect crisp to blockchain time [skip-line-limit]
+  ([#1052](https://github.com/gnosisguild/enclave/issues/1052))
+  ([9ac6408](https://github.com/gnosisguild/enclave/commit/9ac64085f276ab622ba572e2d7f21f372a838efb))
+- crisp use param set 512_10_1 ([#1009](https://github.com/gnosisguild/enclave/issues/1009))
+  ([5b72042](https://github.com/gnosisguild/enclave/commit/5b72042f544d85e953000942991692b41def7460))
+- decode tally in ts ([#852](https://github.com/gnosisguild/enclave/issues/852))
+  ([0a96b8e](https://github.com/gnosisguild/enclave/commit/0a96b8e20445364f01f2551e0a9f494bc33ad79c))
+- deploy transparent proxy contracts [skip-line-limit]
+  ([#987](https://github.com/gnosisguild/enclave/issues/987))
+  ([b6f9b7b](https://github.com/gnosisguild/enclave/commit/b6f9b7ba71efa419902a0e707f93a2f9b150d6ea))
+- deploy with hardhat in CRISP ([#875](https://github.com/gnosisguild/enclave/issues/875))
+  ([f1567b8](https://github.com/gnosisguild/enclave/commit/f1567b8308d6468e6ec380535448d616d37be82b))
+- do not use external input validator for programs [skip-line-limit]
+  ([#996](https://github.com/gnosisguild/enclave/issues/996))
+  ([9aa1e30](https://github.com/gnosisguild/enclave/commit/9aa1e30e7685236baf04663e5a6e8c8a4100d335))
+- enable trbfv on the ciphernodes ([#1194](https://github.com/gnosisguild/enclave/issues/1194))
+  ([dd9095c](https://github.com/gnosisguild/enclave/commit/dd9095cb560ff1b8c3c8e36cfd6ed2edf86ed2c2))
+- enclave start --experimental-trbfv and use ciphernodebuilder
+  ([#856](https://github.com/gnosisguild/enclave/issues/856))
+  ([d135c82](https://github.com/gnosisguild/enclave/commit/d135c8234661ee4b13806b076a450d8354316e38))
+- encrypt vote and generate initial inputs
+  ([#872](https://github.com/gnosisguild/enclave/issues/872))
+  ([bab94ad](https://github.com/gnosisguild/enclave/commit/bab94ad663982a81c2c1156db23faca31ae7f209))
+- expose params via wasm ([#993](https://github.com/gnosisguild/enclave/issues/993))
+  ([e9e3590](https://github.com/gnosisguild/enclave/commit/e9e35909f06753e5e9b65030b25c43915423d12a))
+- fetch round data from crisp server ([#811](https://github.com/gnosisguild/enclave/issues/811))
+  ([0b305d1](https://github.com/gnosisguild/enclave/commit/0b305d1474073788c84d2cd0394c432c86d80499))
+- fetch token data data from crisp server
+  ([#804](https://github.com/gnosisguild/enclave/issues/804))
+  ([4bac0c4](https://github.com/gnosisguild/enclave/commit/4bac0c4f5c6d6be1e62c6062baaa396895c9aec6))
+- fetch token holders with etherscan api [skip-line-limit]
+  ([#929](https://github.com/gnosisguild/enclave/issues/929))
+  ([41abd8e](https://github.com/gnosisguild/enclave/commit/41abd8e75d8dc9639818b9bd710ddb7498f78d0f))
+- fix infrastructure and prefactor net interface
+  ([#903](https://github.com/gnosisguild/enclave/issues/903))
+  ([b4610a8](https://github.com/gnosisguild/enclave/commit/b4610a8aacf1b786cd70cef641be941c4f0ba31f))
+- generate merkle tree ([#826](https://github.com/gnosisguild/enclave/issues/826))
+  ([d471fa5](https://github.com/gnosisguild/enclave/commit/d471fa546ac00ba23c3edd9d2e2b30d35856483a))
+- get previous ciphertext from server [skip-line-limit]
+  ([#1109](https://github.com/gnosisguild/enclave/issues/1109))
+  ([38440ca](https://github.com/gnosisguild/enclave/commit/38440ca45095ab7caf1a63cc4d2c2b50c18093a8))
+- greco gamma optimization ([#911](https://github.com/gnosisguild/enclave/issues/911))
+  ([73b7ad4](https://github.com/gnosisguild/enclave/commit/73b7ad41de7ee1c0bfefc8f5fa3aa860e6a581f5))
+- greco, e0 == e0is[i] check ([#1049](https://github.com/gnosisguild/enclave/issues/1049))
+  ([237746a](https://github.com/gnosisguild/enclave/commit/237746aad8e2d667a33d0a4090d541b83d10b08e))
+- inclusion proof ([#846](https://github.com/gnosisguild/enclave/issues/846))
+  ([ba69679](https://github.com/gnosisguild/enclave/commit/ba696790f72c6f8c345b62f21c30081c85778bf3))
+- indexer refactor - consolidate listeners and add ctx
+  ([#1043](https://github.com/gnosisguild/enclave/issues/1043))
+  ([eecd272](https://github.com/gnosisguild/enclave/commit/eecd2726aa075197a068494ba3a991cf19f9a20e))
+- kademlia dht publishing: receiving document
+  ([#828](https://github.com/gnosisguild/enclave/issues/828))
+  ([84ed064](https://github.com/gnosisguild/enclave/commit/84ed06458eba18e94cfe08bd3af6bb77e714885a))
+- limit PRs to 700 lines ([#821](https://github.com/gnosisguild/enclave/issues/821))
+  ([26cd4a9](https://github.com/gnosisguild/enclave/commit/26cd4a985e82346182259b5d1e761ae9e5effb08))
+- mask vote utilities ([#924](https://github.com/gnosisguild/enclave/issues/924))
+  ([8d9d326](https://github.com/gnosisguild/enclave/commit/8d9d326c8da9ac4366d2f5ebd2bf210b2fedb005))
+- multithread enable threadpool ([#1016](https://github.com/gnosisguild/enclave/issues/1016))
+  ([7048a47](https://github.com/gnosisguild/enclave/commit/7048a473181a691cba07ec747bafa65825a2aca4))
+- optimization by concatenating coefficients
+  ([#734](https://github.com/gnosisguild/enclave/issues/734))
+  ([00e2f6d](https://github.com/gnosisguild/enclave/commit/00e2f6d5eaaf2089488f414dc57675f7120cf2a0))
+- params crate [skip-line-limit] ([#1197](https://github.com/gnosisguild/enclave/issues/1197))
+  ([a358cb0](https://github.com/gnosisguild/enclave/commit/a358cb0417c657b2397c43e1687e1a9b92e42101))
+- porting of C2 [skip-line-limit] ([#1261](https://github.com/gnosisguild/enclave/issues/1261))
+  ([33994f0](https://github.com/gnosisguild/enclave/commit/33994f066e0c11c71d96a058c0a8c37cdd7e7140))
+- prefactor for sync mode tidy up event structure [skip-line-limit]
+  ([#1056](https://github.com/gnosisguild/enclave/issues/1056))
+  ([9ddff8c](https://github.com/gnosisguild/enclave/commit/9ddff8ccb72d0917696e44d22bedc416731c47b7))
+- release dappnode v0.1.8 ([#1242](https://github.com/gnosisguild/enclave/issues/1242))
+  ([ebf6f38](https://github.com/gnosisguild/enclave/commit/ebf6f386dcefd6ab9c5060d4b8932ed1fa1132b9))
+- safe refactoring ([#1079](https://github.com/gnosisguild/enclave/issues/1079))
+  ([8dec370](https://github.com/gnosisguild/enclave/commit/8dec370e2873a6bc482992227628cbc866dd2ca4))
+- signature generation and parsing ([#914](https://github.com/gnosisguild/enclave/issues/914))
+  ([31ad834](https://github.com/gnosisguild/enclave/commit/31ad8342a921775e644b038ec16b6983d48a555b))
+- store merkle tree on program [skip-line-limit]
+  ([#1027](https://github.com/gnosisguild/enclave/issues/1027))
+  ([e1a8f22](https://github.com/gnosisguild/enclave/commit/e1a8f22f6796f3b8907fe5b59ec4ad28a2e15f6d))
+- sync mode preparation [skip-line-limit]
+  ([#1153](https://github.com/gnosisguild/enclave/issues/1153))
+  ([ec6debd](https://github.com/gnosisguild/enclave/commit/ec6debdc8bbce08f4fcb072325576c5f66d09c29))
+- ticket score sortition ([#698](https://github.com/gnosisguild/enclave/issues/698))
+  ([ba2d8ef](https://github.com/gnosisguild/enclave/commit/ba2d8ef88f7bdf3bacccf7f808dd89c9de04b8ca))
+- trbfv integration test [skip-line-limit]
+  ([#969](https://github.com/gnosisguild/enclave/issues/969))
+  ([418e42f](https://github.com/gnosisguild/enclave/commit/418e42feceb5596a50f4f039f45d0f102fb7d50b))
+- update submission deadline task ([#1102](https://github.com/gnosisguild/enclave/issues/1102))
+  ([35f7687](https://github.com/gnosisguild/enclave/commit/35f7687276398b3f0939455a0e2189a3ca2ab295))
+- upgrade to hardhat v3 and configure repo
+  ([#677](https://github.com/gnosisguild/enclave/issues/677))
+  ([7ccf6fa](https://github.com/gnosisguild/enclave/commit/7ccf6fa4d62a972a4d2336bd436d71bbc9b54535))
+- validate vote is <= balance ([#954](https://github.com/gnosisguild/enclave/issues/954))
+  ([bd5d35a](https://github.com/gnosisguild/enclave/commit/bd5d35ad7e8ec2fea7e8fd677ac24bf615fadd6b))
+- validate voting power ([#851](https://github.com/gnosisguild/enclave/issues/851))
+  ([d6e04bb](https://github.com/gnosisguild/enclave/commit/d6e04bb560f588c9f125dfef67bf9d27736011e2))
+- verify contracts on etherscan ([#867](https://github.com/gnosisguild/enclave/issues/867))
+  ([bd8d5bc](https://github.com/gnosisguild/enclave/commit/bd8d5bc95475859a42f5a55e37aa8581d4885df6))
+- verify external contracts ([#1106](https://github.com/gnosisguild/enclave/issues/1106))
+  ([70913fd](https://github.com/gnosisguild/enclave/commit/70913fd8df0c9d9fd02d96a129bcf0fbc1e86320))
+- zk-helpers crate [skip-line-limit] ([#1212](https://github.com/gnosisguild/enclave/issues/1212))
+  ([65c7c61](https://github.com/gnosisguild/enclave/commit/65c7c61ade0b9d66ce846aa1be3cd4545571553c))
+
 ## [0.1.9](https://github.com/gnosisguild/enclave/compare/v0.1.2...v0.1.9) (2026-02-05)
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2789,7 +2789,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "e3-aggregator"
-version = "0.1.9"
+version = "0.1.11"
 dependencies = [
  "actix",
  "anyhow",
@@ -2812,7 +2812,7 @@ dependencies = [
 
 [[package]]
 name = "e3-bfv-client"
-version = "0.1.9"
+version = "0.1.11"
 dependencies = [
  "anyhow",
  "e3-fhe-params",
@@ -2826,7 +2826,7 @@ dependencies = [
 
 [[package]]
 name = "e3-ciphernode-builder"
-version = "0.1.9"
+version = "0.1.11"
 dependencies = [
  "actix",
  "alloy",
@@ -2857,7 +2857,7 @@ dependencies = [
 
 [[package]]
 name = "e3-cli"
-version = "0.1.9"
+version = "0.1.11"
 dependencies = [
  "actix",
  "alloy",
@@ -2890,7 +2890,7 @@ dependencies = [
 
 [[package]]
 name = "e3-compute-provider"
-version = "0.1.9"
+version = "0.1.11"
 dependencies = [
  "ark-bn254 0.4.0",
  "ark-ff 0.4.2",
@@ -2909,7 +2909,7 @@ dependencies = [
 
 [[package]]
 name = "e3-config"
-version = "0.1.9"
+version = "0.1.11"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -2930,7 +2930,7 @@ dependencies = [
 
 [[package]]
 name = "e3-crypto"
-version = "0.1.9"
+version = "0.1.11"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2948,7 +2948,7 @@ dependencies = [
 
 [[package]]
 name = "e3-data"
-version = "0.1.9"
+version = "0.1.11"
 dependencies = [
  "actix",
  "anyhow",
@@ -2966,7 +2966,7 @@ dependencies = [
 
 [[package]]
 name = "e3-entrypoint"
-version = "0.1.9"
+version = "0.1.11"
 dependencies = [
  "actix",
  "actix-web",
@@ -3005,7 +3005,7 @@ dependencies = [
 
 [[package]]
 name = "e3-events"
-version = "0.1.9"
+version = "0.1.11"
 dependencies = [
  "actix",
  "alloy",
@@ -3038,7 +3038,7 @@ dependencies = [
 
 [[package]]
 name = "e3-evm"
-version = "0.1.9"
+version = "0.1.11"
 dependencies = [
  "actix",
  "alloy",
@@ -3070,7 +3070,7 @@ dependencies = [
 
 [[package]]
 name = "e3-evm-helpers"
-version = "0.1.9"
+version = "0.1.11"
 dependencies = [
  "alloy",
  "anyhow",
@@ -3086,7 +3086,7 @@ dependencies = [
 
 [[package]]
 name = "e3-fhe"
-version = "0.1.9"
+version = "0.1.11"
 dependencies = [
  "actix",
  "anyhow",
@@ -3111,7 +3111,7 @@ dependencies = [
 
 [[package]]
 name = "e3-fhe-params"
-version = "0.1.9"
+version = "0.1.11"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -3125,7 +3125,7 @@ dependencies = [
 
 [[package]]
 name = "e3-fs"
-version = "0.1.9"
+version = "0.1.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3138,7 +3138,7 @@ dependencies = [
 
 [[package]]
 name = "e3-indexer"
-version = "0.1.9"
+version = "0.1.11"
 dependencies = [
  "alloy",
  "async-trait",
@@ -3158,7 +3158,7 @@ dependencies = [
 
 [[package]]
 name = "e3-init"
-version = "0.1.9"
+version = "0.1.11"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -3176,7 +3176,7 @@ dependencies = [
 
 [[package]]
 name = "e3-keyshare"
-version = "0.1.9"
+version = "0.1.11"
 dependencies = [
  "actix",
  "anyhow",
@@ -3203,7 +3203,7 @@ dependencies = [
 
 [[package]]
 name = "e3-logger"
-version = "0.1.9"
+version = "0.1.11"
 dependencies = [
  "actix",
  "base64",
@@ -3213,7 +3213,7 @@ dependencies = [
 
 [[package]]
 name = "e3-multithread"
-version = "0.1.9"
+version = "0.1.11"
 dependencies = [
  "actix",
  "anyhow",
@@ -3232,7 +3232,7 @@ dependencies = [
 
 [[package]]
 name = "e3-net"
-version = "0.1.9"
+version = "0.1.11"
 dependencies = [
  "actix",
  "anyhow",
@@ -3260,7 +3260,7 @@ dependencies = [
 
 [[package]]
 name = "e3-parity-matrix"
-version = "0.1.9"
+version = "0.1.11"
 dependencies = [
  "num-bigint",
  "num-traits",
@@ -3271,7 +3271,7 @@ dependencies = [
 
 [[package]]
 name = "e3-polynomial"
-version = "0.1.9"
+version = "0.1.11"
 dependencies = [
  "bincode",
  "criterion",
@@ -3285,7 +3285,7 @@ dependencies = [
 
 [[package]]
 name = "e3-program-server"
-version = "0.1.9"
+version = "0.1.11"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -3300,7 +3300,7 @@ dependencies = [
 
 [[package]]
 name = "e3-request"
-version = "0.1.9"
+version = "0.1.11"
 dependencies = [
  "actix",
  "anyhow",
@@ -3316,7 +3316,7 @@ dependencies = [
 
 [[package]]
 name = "e3-safe"
-version = "0.1.9"
+version = "0.1.11"
 dependencies = [
  "ark-bn254 0.5.0",
  "ark-ff 0.5.0",
@@ -3327,7 +3327,7 @@ dependencies = [
 
 [[package]]
 name = "e3-sdk"
-version = "0.1.9"
+version = "0.1.11"
 dependencies = [
  "e3-bfv-client",
  "e3-evm-helpers",
@@ -3337,7 +3337,7 @@ dependencies = [
 
 [[package]]
 name = "e3-sortition"
-version = "0.1.9"
+version = "0.1.11"
 dependencies = [
  "actix",
  "alloy",
@@ -3358,7 +3358,7 @@ dependencies = [
 
 [[package]]
 name = "e3-support-scripts"
-version = "0.1.9"
+version = "0.1.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3369,7 +3369,7 @@ dependencies = [
 
 [[package]]
 name = "e3-sync"
-version = "0.1.9"
+version = "0.1.11"
 dependencies = [
  "actix",
  "anyhow",
@@ -3381,7 +3381,7 @@ dependencies = [
 
 [[package]]
 name = "e3-test-helpers"
-version = "0.1.9"
+version = "0.1.11"
 dependencies = [
  "actix",
  "alloy",
@@ -3415,7 +3415,7 @@ dependencies = [
 
 [[package]]
 name = "e3-tests"
-version = "0.1.9"
+version = "0.1.11"
 dependencies = [
  "actix",
  "alloy",
@@ -3459,7 +3459,7 @@ dependencies = [
 
 [[package]]
 name = "e3-trbfv"
-version = "0.1.9"
+version = "0.1.11"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3488,7 +3488,7 @@ dependencies = [
 
 [[package]]
 name = "e3-utils"
-version = "0.1.9"
+version = "0.1.11"
 dependencies = [
  "actix",
  "alloy",
@@ -3503,7 +3503,7 @@ dependencies = [
 
 [[package]]
 name = "e3-wasm"
-version = "0.1.9"
+version = "0.1.11"
 dependencies = [
  "e3-bfv-client",
  "e3-fhe-params",
@@ -3515,7 +3515,7 @@ dependencies = [
 
 [[package]]
 name = "e3-zk-helpers"
-version = "0.1.9"
+version = "0.1.11"
 dependencies = [
  "anyhow",
  "ark-bn254 0.5.0",
@@ -3623,7 +3623,7 @@ dependencies = [
 
 [[package]]
 name = "enclaveup"
-version = "0.1.9"
+version = "0.1.11"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,48 +63,48 @@ push-remote = "origin"
 publish = true
 
 [workspace.package]
-version = "0.1.9"
+version = "0.1.11"
 edition = "2021"
 license = "LGPL-3.0-only"
 description = "E3 — Encrypted Execution Environments"
 repository = "https://github.com/gnosisguild/enclave"
 
 [workspace.dependencies]
-e3-aggregator = { version = "0.1.9", path = "./crates/aggregator" }
-e3-bfv-client = { version = "0.1.9", path = "./crates/bfv-client" }
-e3-config = { version = "0.1.9", path = "./crates/config" }
-e3-ciphernode-builder = { version = "0.1.9", path = "./crates/ciphernode-builder" }
-e3-crypto = { version = "0.1.9", path = "./crates/crypto" }
-e3-data = { version = "0.1.9", path = "./crates/data" }
-e3-request = { version = "0.1.9", path = "./crates/request" }
-e3-sdk = { version = "0.1.9", path = "./crates/sdk" }
-e3-cli = { version = "0.1.9", path = "./crates/cli" }
-e3-entrypoint = { version = "0.1.9", path = "./crates/entrypoint" }
-e3-init = { version = "0.1.9", path = "./crates/init" }
-e3-events = { version = "0.1.9", path = "./crates/events" }
-e3-evm = { version = "0.1.9", path = "./crates/evm" }
-e3-evm-helpers = { version = "0.1.9", path = "./crates/evm-helpers" }
-e3-fhe = { version = "0.1.9", path = "./crates/fhe" }
-e3-fhe-params = { version = "0.1.9", path = "./crates/fhe-params" }
-e3-fs = { version = "0.1.9", path = "./crates/fs" }
-e3-indexer = { version = "0.1.9", path = "./crates/indexer" }
-e3-multithread = { version = "0.1.9", path = "./crates/multithread" }
-e3-keyshare = { version = "0.1.9", path = "./crates/keyshare" }
-e3-logger = { version = "0.1.9", path = "./crates/logger" }
-e3-net = { version = "0.1.9", path = "./crates/net" }
-e3-compute-provider = { version = "0.1.9", path = "./crates/compute-provider" }
-e3-sortition = { version = "0.1.9", path = "./crates/sortition" }
-e3-program-server = { version = "0.1.9", path = "./crates/program-server" }
-e3-polynomial = { version = "0.1.9", path = "./crates/polynomial" }
-e3-support-scripts = { version = "0.1.9", path = "./crates/support-scripts" }
-e3-sync = { version = "0.1.9", path = "./crates/sync" }
-e3-test-helpers = { version = "0.1.9", path = "./crates/test-helpers" }
-e3-tests = { version = "0.1.9", path = "./crates/tests" }
-e3-trbfv = { version = "0.1.9", path = "./crates/trbfv" }
-e3-utils = { version = "0.1.9", path = "./crates/utils" }
-e3-safe = { version = "0.1.9", path = "./crates/safe" }
-e3-zk-helpers = { version = "0.1.9", path = "./crates/zk-helpers" }
-e3-parity-matrix = { version = "0.1.9", path = "./crates/parity-matrix" }
+e3-aggregator = { version = "0.1.11", path = "./crates/aggregator" }
+e3-bfv-client = { version = "0.1.11", path = "./crates/bfv-client" }
+e3-config = { version = "0.1.11", path = "./crates/config" }
+e3-ciphernode-builder = { version = "0.1.11", path = "./crates/ciphernode-builder" }
+e3-crypto = { version = "0.1.11", path = "./crates/crypto" }
+e3-data = { version = "0.1.11", path = "./crates/data" }
+e3-request = { version = "0.1.11", path = "./crates/request" }
+e3-sdk = { version = "0.1.11", path = "./crates/sdk" }
+e3-cli = { version = "0.1.11", path = "./crates/cli" }
+e3-entrypoint = { version = "0.1.11", path = "./crates/entrypoint" }
+e3-init = { version = "0.1.11", path = "./crates/init" }
+e3-events = { version = "0.1.11", path = "./crates/events" }
+e3-evm = { version = "0.1.11", path = "./crates/evm" }
+e3-evm-helpers = { version = "0.1.11", path = "./crates/evm-helpers" }
+e3-fhe = { version = "0.1.11", path = "./crates/fhe" }
+e3-fhe-params = { version = "0.1.11", path = "./crates/fhe-params" }
+e3-fs = { version = "0.1.11", path = "./crates/fs" }
+e3-indexer = { version = "0.1.11", path = "./crates/indexer" }
+e3-multithread = { version = "0.1.11", path = "./crates/multithread" }
+e3-keyshare = { version = "0.1.11", path = "./crates/keyshare" }
+e3-logger = { version = "0.1.11", path = "./crates/logger" }
+e3-net = { version = "0.1.11", path = "./crates/net" }
+e3-compute-provider = { version = "0.1.11", path = "./crates/compute-provider" }
+e3-sortition = { version = "0.1.11", path = "./crates/sortition" }
+e3-program-server = { version = "0.1.11", path = "./crates/program-server" }
+e3-polynomial = { version = "0.1.11", path = "./crates/polynomial" }
+e3-support-scripts = { version = "0.1.11", path = "./crates/support-scripts" }
+e3-sync = { version = "0.1.11", path = "./crates/sync" }
+e3-test-helpers = { version = "0.1.11", path = "./crates/test-helpers" }
+e3-tests = { version = "0.1.11", path = "./crates/tests" }
+e3-trbfv = { version = "0.1.11", path = "./crates/trbfv" }
+e3-utils = { version = "0.1.11", path = "./crates/utils" }
+e3-safe = { version = "0.1.11", path = "./crates/safe" }
+e3-zk-helpers = { version = "0.1.11", path = "./crates/zk-helpers" }
+e3-parity-matrix = { version = "0.1.11", path = "./crates/parity-matrix" }
 
 actix = "=0.13.5"
 actix-web = "=4.11.0"

--- a/crates/wasm/package.json
+++ b/crates/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@enclave-e3/wasm",
-  "version": "0.1.9",
+  "version": "0.1.11",
   "description": "Wasm modules for enclave.",
   "main": "dist/node/e3_wasm.js",
   "module": "dist/web/e3_wasm.js",

--- a/examples/CRISP/Cargo.lock
+++ b/examples/CRISP/Cargo.lock
@@ -2345,7 +2345,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "e3-bfv-client"
-version = "0.1.9"
+version = "0.1.11"
 dependencies = [
  "anyhow",
  "e3-fhe-params",
@@ -2359,7 +2359,7 @@ dependencies = [
 
 [[package]]
 name = "e3-compute-provider"
-version = "0.1.9"
+version = "0.1.11"
 dependencies = [
  "ark-bn254 0.4.0",
  "ark-ff 0.4.2",
@@ -2378,7 +2378,7 @@ dependencies = [
 
 [[package]]
 name = "e3-evm-helpers"
-version = "0.1.9"
+version = "0.1.11"
 dependencies = [
  "alloy",
  "anyhow",
@@ -2394,7 +2394,7 @@ dependencies = [
 
 [[package]]
 name = "e3-fhe-params"
-version = "0.1.9"
+version = "0.1.11"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -2408,7 +2408,7 @@ dependencies = [
 
 [[package]]
 name = "e3-indexer"
-version = "0.1.9"
+version = "0.1.11"
 dependencies = [
  "alloy",
  "async-trait",
@@ -2423,7 +2423,7 @@ dependencies = [
 
 [[package]]
 name = "e3-parity-matrix"
-version = "0.1.9"
+version = "0.1.11"
 dependencies = [
  "num-bigint",
  "num-traits",
@@ -2433,7 +2433,7 @@ dependencies = [
 
 [[package]]
 name = "e3-polynomial"
-version = "0.1.9"
+version = "0.1.11"
 dependencies = [
  "fhe-math",
  "ndarray",
@@ -2445,7 +2445,7 @@ dependencies = [
 
 [[package]]
 name = "e3-program-server"
-version = "0.1.9"
+version = "0.1.11"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -2460,7 +2460,7 @@ dependencies = [
 
 [[package]]
 name = "e3-safe"
-version = "0.1.9"
+version = "0.1.11"
 dependencies = [
  "ark-bn254 0.5.0",
  "ark-ff 0.5.0",
@@ -2471,7 +2471,7 @@ dependencies = [
 
 [[package]]
 name = "e3-sdk"
-version = "0.1.9"
+version = "0.1.11"
 dependencies = [
  "e3-bfv-client",
  "e3-evm-helpers",
@@ -2502,7 +2502,7 @@ dependencies = [
 
 [[package]]
 name = "e3-utils"
-version = "0.1.9"
+version = "0.1.11"
 dependencies = [
  "actix",
  "alloy",
@@ -2517,7 +2517,7 @@ dependencies = [
 
 [[package]]
 name = "e3-zk-helpers"
-version = "0.1.9"
+version = "0.1.11"
 dependencies = [
  "anyhow",
  "ark-bn254 0.5.0",
@@ -3609,9 +3609,9 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jiff"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e67e8da4c49d6d9909fe03361f9b620f58898859f5c7aded68351e85e71ecf50"
+checksum = "d89a5b5e10d5a9ad6e5d1f4bd58225f655d6fe9767575a5e8ac5a6fe64e04495"
 dependencies = [
  "jiff-static",
  "log",
@@ -3622,9 +3622,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c84ee7f197eca9a86c6fd6cb771e55eb991632f15f2bc3ca6ec838929e6e78"
+checksum = "ff7a39c8862fc1369215ccf0a8f12dd4598c7f6484704359f0351bd617034dbf"
 dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.44",
@@ -6646,18 +6646,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.38"
+version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57cf3aa6855b23711ee9852dfc97dfaa51c45feaba5b645d0c777414d494a961"
+checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.38"
+version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a616990af1a287837c4fe6596ad77ef57948f787e46ce28e166facc0cc1cb75"
+checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
 dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.44",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@enclave/main",
   "description": "Enclave is an open-source protocol for Encrypted Execution Environments (E3).",
-  "version": "0.1.9",
+  "version": "0.1.11",
   "private": true,
   "license": "LGPL-3.0-only",
   "author": {

--- a/packages/enclave-config/package.json
+++ b/packages/enclave-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@enclave-e3/config",
-  "version": "0.1.9",
+  "version": "0.1.11",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/enclave-contracts/package.json
+++ b/packages/enclave-contracts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@enclave-e3/contracts",
   "description": "Enclave is an open-source protocol for Encrypted Execution Environments (E3).",
-  "version": "0.1.9",
+  "version": "0.1.11",
   "license": "LGPL-3.0-only",
   "type": "module",
   "author": {

--- a/packages/enclave-react/package.json
+++ b/packages/enclave-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@enclave-e3/react",
-  "version": "0.1.9",
+  "version": "0.1.11",
   "description": "React hooks and utilities for Enclave SDK",
   "type": "module",
   "private": false,

--- a/packages/enclave-sdk/package.json
+++ b/packages/enclave-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@enclave-e3/sdk",
-  "version": "0.1.9",
+  "version": "0.1.11",
   "type": "module",
   "exports": {
     ".": {

--- a/templates/default/Cargo.lock
+++ b/templates/default/Cargo.lock
@@ -888,9 +888,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
 ]
@@ -1212,7 +1212,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "e3-bfv-client"
-version = "0.1.9"
+version = "0.1.11"
 dependencies = [
  "anyhow",
  "e3-fhe-params",
@@ -1226,7 +1226,7 @@ dependencies = [
 
 [[package]]
 name = "e3-compute-provider"
-version = "0.1.9"
+version = "0.1.11"
 dependencies = [
  "ark-bn254 0.4.0",
  "ark-ff 0.4.2",
@@ -1245,7 +1245,7 @@ dependencies = [
 
 [[package]]
 name = "e3-fhe-params"
-version = "0.1.9"
+version = "0.1.11"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "e3-parity-matrix"
-version = "0.1.9"
+version = "0.1.11"
 dependencies = [
  "num-bigint",
  "num-traits",
@@ -1269,7 +1269,7 @@ dependencies = [
 
 [[package]]
 name = "e3-polynomial"
-version = "0.1.9"
+version = "0.1.11"
 dependencies = [
  "fhe-math",
  "ndarray",
@@ -1281,7 +1281,7 @@ dependencies = [
 
 [[package]]
 name = "e3-program-server"
-version = "0.1.9"
+version = "0.1.11"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -1296,7 +1296,7 @@ dependencies = [
 
 [[package]]
 name = "e3-safe"
-version = "0.1.9"
+version = "0.1.11"
 dependencies = [
  "ark-bn254 0.5.0",
  "ark-ff 0.5.0",
@@ -1330,7 +1330,7 @@ dependencies = [
 
 [[package]]
 name = "e3-zk-helpers"
-version = "0.1.9"
+version = "0.1.11"
 dependencies = [
  "anyhow",
  "ark-bn254 0.5.0",
@@ -1592,9 +1592,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b375d6465b98090a5f25b1c7703f3859783755aa9a80433b36e0379a3ec2f369"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -2633,9 +2633,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.5"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9eb05c21a464ea704b53158d358a31e6425db2f63a1a7312268b05fe2b75f7"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -2777,9 +2777,9 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee689443a2bd0a16ab0348b52ee43e3b2d1b1f931c8aa5c9f8de4c86fbe8c40"
+checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
 dependencies = [
  "bit-set",
  "bit-vec",
@@ -2991,9 +2991,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3003,9 +3003,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3014,15 +3014,15 @@ dependencies = [
 
 [[package]]
 name = "regex-lite"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d942b98df5e658f56f20d592c7f868833fe38115e65c33003d8cd224b0155da"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "reqwest"
@@ -3619,15 +3619,15 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.20.0"
+version = "3.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
 dependencies = [
  "fastrand",
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4362,18 +4362,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.37"
+version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7456cf00f0685ad319c5b1693f291a650eaf345e941d082fc4e03df8a03996ac"
+checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.37"
+version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1328722bbf2115db7e19d69ebcc15e795719e2d66b60827c6a69a117365e37a0"
+checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
  - Updated all Rust crates to 0.1.11
  - Updated all npm packages to 0.1.11
  - Updated lock files
  - Generated CHANGELOG.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.1.11 across all workspace packages and projects.
  * Changelog updated with new release entry documenting bug fixes and features for version 0.1.11.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->