### PR TITLE
fix: config circuit [skip-line-limit]

### DIFF
--- a/circuits/bin/config/src/main.nr
+++ b/circuits/bin/config/src/main.nr
@@ -361,8 +361,8 @@ fn verify_pk_generation_bounds() {
         // r2_bounds[i] = (q_i - 1) / 2
         assert(PK_GENERATION_R2_BOUNDS[i] as u128 == qi_bound, "PK_GENERATION_R2_BOUNDS mismatch");
 
-        // r1_bounds[i] = ((n * eek_bound + 2) * qi_bound + eek_bound) / q_i
-        let expected_r1: u128 = ((n * eek + 2) * qi_bound + eek) / qi;
+        // r1_bounds[i] = ((n + 2) * qi_bound + eek_bound) / q_i
+        let expected_r1: u128 = ((n + 2) * qi_bound + eek) / qi;
         assert(
             PK_GENERATION_R1_BOUNDS[i] as u128 == expected_r1,
             "PK_GENERATION_R1_BOUNDS mismatch",
@@ -393,11 +393,11 @@ fn verify_e_sm_bound() {
     // b_c = N_CIPHERTEXTS * (b_fresh + Q_MOD_T)
     let b_c = num_ciphertexts * (b_fresh + THRESHOLD_Q_MOD_T);
 
-    // 2^80
-    let two_pow_80: Field = 0x100000000000000000000;
+    // 2^60
+    let two_pow_60: Field = 0x1000000000000000;
 
-    // e_sm_bound = 2^80 * b_c
-    let expected_e_sm_bound = two_pow_80 * b_c;
+    // e_sm_bound = 2^60 * b_c
+    let expected_e_sm_bound = two_pow_60 * b_c;
 
     assert(expected_e_sm_bound == PK_GENERATION_E_SM_BOUND, "PK_GENERATION_E_SM_BOUND mismatch");
 }
@@ -418,8 +418,8 @@ fn verify_share_decryption_bounds() {
             "SHARE_DECRYPTION_R2_BOUNDS mismatch",
         );
 
-        // r1_bounds[i] = (qi_bound * (qi_bound * n + 3) - qi_bound) / q_i
-        let expected_r1: u128 = (qi_bound * (qi_bound * n + 3) - qi_bound) / qi;
+        // r1_bounds[i] = (((q_j-1)/2)^2 * n + 4 * (q_j-1)/2) / q_j
+        let expected_r1: u128 = (qi_bound * qi_bound * n + 4 * qi_bound) / qi;
         assert(
             THRESHOLD_SHARE_DECRYPTION_R1_BOUNDS[i] as u128 == expected_r1,
             "SHARE_DECRYPTION_R1_BOUNDS mismatch",

--- a/circuits/lib/src/configs/secure/threshold.nr
+++ b/circuits/lib/src/configs/secure/threshold.nr
@@ -15,8 +15,8 @@ use crate::math::polynomial::Polynomial;
 /// Threshold BFV parameter set search defaults configurations.
 /// These are for the SecureThreshold8192 preset.
 /// The InsecureThreshold512 preset has been generated manually.
-pub global PARAMS_SEARCH_N: Field = 100;
-pub global PARAMS_SEARCH_Z: Field = 100;
+pub global PARAMS_SEARCH_N: Field = 7;
+pub global PARAMS_SEARCH_Z: Field = 1024;
 
 // Global configs for threshold secure preset
 pub global N: u32 = 8192;

--- a/crates/zk-helpers/src/circuits/threshold/share_decryption/computation.rs
+++ b/crates/zk-helpers/src/circuits/threshold/share_decryption/computation.rs
@@ -219,7 +219,7 @@ impl Computation for Bounds {
             // r_2j bounds: [- (q_j-1)/2 , (q_j-1)/2] (cyclotomic quotients)
             r2_bounds.push(qi_bound.clone());
 
-            // r_1j upper bound: (n * ((q_j-1)/2)^2 + 4 * (q_j-1)/2) / q_j
+            // r_1j upper bound: (((q_j-1)/2)^2 * n + 4 * (q_j-1)/2) / q_j
             // Symmetric lower bound used by range_check_2bounds. Variables: qi_bound = (q_j-1)/2,
             // qi_bigint = q_j, n = degree.
             r1_bounds.push(


### PR DESCRIPTION
This PR fixes the [config](https://github.com/gnosisguild/enclave/blob/main/circuits/bin/config/src/main.nr) circuit wrong `esm` and `r1_bounds` computations due to being not aligned with latest changes for the new parameter set (lambda = 60) and other fixes. Note that this does not change anything in terms of parameter generation or configs (just that the circuit was doing the wrong checks).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected verification parameter bounds formulas for threshold cryptographic configuration.
  * Adjusted parameter search configuration values for optimized threshold parameter selection.

* **Documentation**
  * Clarified share decryption bounds formula documentation for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->