### PR TITLE
fix: pin pnpm version

### DIFF
--- a/templates/default/package.json
+++ b/templates/default/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
+  "packageManager": "pnpm@10.7.1+sha512.2d92c86b7928dc8284f53494fb4201f983da65f0fb4f0d40baafa5cf628fa31dae3e5968f12466f17df7e97310e30f343a648baea1b9b350685dafafffdf5808",
   "scripts": {
     "compile": "hardhat compile",
     "lint": "eslint .",

--- a/templates/default/pnpm-workspace.yaml.bak
+++ b/templates/default/pnpm-workspace.yaml.bak
@@ -1,2 +1,29 @@
 packages:
   - client
+
+# pnpm >= 10 does not run dependency lifecycle (build) scripts unless they are
+# explicitly allowed. pnpm 11 goes further: strictDepBuilds defaults to true, so
+# ignored build scripts abort `pnpm install` with ERR_PNPM_IGNORED_BUILDS rather
+# than just warning. Allow the build scripts this template actually needs so
+# `enclave init` can install non-interactively on any pnpm >= 10.
+#
+# `onlyBuiltDependencies` is the pnpm 10 key; pnpm 11 removed it in favour of
+# `allowBuilds`. Both are declared so the install succeeds regardless of which
+# pnpm major the user's machine resolves. Each major reads its own key and
+# ignores the other.
+onlyBuiltDependencies:
+  - "@swc/core"
+  - bufferutil
+  - esbuild
+  - keccak
+  - msgpackr-extract
+  - utf-8-validate
+  - wasm-pack
+allowBuilds:
+  "@swc/core": true
+  bufferutil: true
+  esbuild: true
+  keccak: true
+  msgpackr-extract: true
+  utf-8-validate: true
+  wasm-pack: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Locked package manager to a specific version with integrity verification for reproducible builds.
  * Enhanced workspace configuration with dependency-build allowlisting to ensure compatibility across package manager versions and prevent installation interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->