### PR TITLE
fix: config generator node top level

### DIFF
--- a/crates/cli/src/ciphernode/setup.rs
+++ b/crates/cli/src/ciphernode/setup.rs
@@ -59,8 +59,12 @@ pub async fn execute(
         .interact_text()?
         .into();
 
+    // Derive the node address from the private key so it can be written into
+    // the generated config (the loader reads it from `node.address`).
+    let node_address = setup::derive_address(&private_key)?;
+
     // Execute
-    let config = setup::execute(&rpc_url, &config_dir)?;
+    let config = setup::execute(&rpc_url, &node_address, &config_dir)?;
 
     e3_entrypoint::password::set::preflight(&config).await?;
     e3_entrypoint::password::set::execute(&config, pw).await?;

--- a/crates/cli/src/config_setup.rs
+++ b/crates/cli/src/config_setup.rs
@@ -12,7 +12,9 @@
 //! CLI command. Production deployments should use a proper deployment artifact
 //! file instead of this compile-time approach.
 
-use alloy::primitives::Address;
+use alloy::hex::FromHex;
+use alloy::primitives::{Address, FixedBytes};
+use alloy::signers::local::PrivateKeySigner;
 use anyhow::{anyhow, bail, Result};
 use e3_config::load_config;
 use e3_config::AppConfig;
@@ -49,8 +51,17 @@ pub fn validate_eth_address(address: &String) -> Result<()> {
     }
 }
 
+/// Derive the node's Ethereum address from its private key. Mirrors the
+/// derivation in `e3_entrypoint::wallet::set` so the value written to the
+/// config matches the address stored in the keystore.
+pub fn derive_address(private_key: &str) -> Result<Address> {
+    let bytes = FixedBytes::<32>::from_hex(private_key)
+        .map_err(|e| anyhow!("Invalid private key: {}", e))?;
+    Ok(PrivateKeySigner::from_bytes(&bytes)?.address())
+}
+
 #[instrument(name = "app", skip_all)]
-pub fn execute(rpc_url: &str, config_dir: &PathBuf) -> Result<AppConfig> {
+pub fn execute(rpc_url: &str, address: &Address, config_dir: &PathBuf) -> Result<AppConfig> {
     fs::create_dir_all(config_dir)?;
 
     let config_path = config_dir.join("enclave.config.yaml");
@@ -61,6 +72,7 @@ pub fn execute(rpc_url: &str, config_dir: &PathBuf) -> Result<AppConfig> {
 node:
   peers:
     - "{}"
+  address: "{}"
 chains:
   - name: "devnet"
     rpc_url: "{}"
@@ -79,6 +91,7 @@ chains:
         deploy_block: {}
 "#,
         BOOTSTRAP_PEER,
+        address,
         rpc_url,
         get_contract_info("Enclave")?.address,
         get_contract_info("Enclave")?.deploy_block,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The setup process now automatically derives the node address from your private key and writes it into the generated configuration. This removes the need for manual address entry, streamlines initialization, and ensures downstream steps receive a populated node.address to avoid misconfiguration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->