### PR TITLE
fix: add slashing manager to sample config

### DIFF
--- a/docs/pages/ciphernode-operators/running.mdx
+++ b/docs/pages/ciphernode-operators/running.mdx
@@ -105,6 +105,12 @@ chains:
       bonding_registry:
         address: '0xb9b64c5e0a30f38ed33760f299613087aAe87283'
         deploy_block: 10939870
+      slashing_manager:
+        address: "0x0553387EE0992Fe339579728B6c777164fD1de40"
+        deploy_block: 10939868
+      fee_token:
+        address: "0x2721Cdf281d40744aD567cBf3e7100F60bcbAE79"
+        deploy_block: 10939865
 ```
 
 ### Start Your Node
@@ -185,6 +191,12 @@ chains:
       bonding_registry:
         address: '0xb9b64c5e0a30f38ed33760f299613087aAe87283'
         deploy_block: 10939870
+      slashing_manager:
+        address: '0x0553387EE0992Fe339579728B6c777164fD1de40'
+        deploy_block: 10939868
+      fee_token:
+        address: '0x2721Cdf281d40744aD567cBf3e7100F60bcbAE79'
+        deploy_block: 10939865
 ```
 
 ### Run the Container


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated CipherNode operator running instructions: example configuration files for both CLI and Docker methods now include two additional chain contract entries (slashing_manager and fee_token) with accompanying address and deploy block fields to make sample configs more complete and setup easier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->