### PR TITLE
fix: log flooding by redialing old entries

### DIFF
--- a/crates/net/src/dialer.rs
+++ b/crates/net/src/dialer.rs
@@ -131,17 +131,30 @@ async fn wait_for_connection(
                     } => {
                         trace!("OutgoingConnectionError!");
                         if connection_id == dial_connection {
-                            warn!(
-                                "Connection {} failed because of error {}. Retrying...",
-                                connection_id, error
-                            );
                             return match error.as_ref() {
                                 // If we are dialing ourself then we should just fail
                                 DialError::NoAddresses => {
                                     Err(RetryError::Failure(error.clone().into()))
                                 }
+                                // The peer at this address has a different identity than
+                                // the /p2p/ component in the multiaddr pins — retrying the
+                                // same address can never succeed. The swarm event handler
+                                // has already re-keyed the routing entry to the new peer.
+                                DialError::WrongPeerId { .. } => {
+                                    warn!(
+                                        "Connection {} failed: {}. Not retrying stale address.",
+                                        connection_id, error
+                                    );
+                                    Err(RetryError::Failure(error.clone().into()))
+                                }
                                 // Try again otherwise
-                                _ => Err(RetryError::Retry(error.clone().into())),
+                                _ => {
+                                    warn!(
+                                        "Connection {} failed because of error {}. Retrying...",
+                                        connection_id, error
+                                    );
+                                    Err(RetryError::Retry(error.clone().into()))
+                                }
                             };
                         }
                     }

--- a/crates/net/src/net_interface.rs
+++ b/crates/net/src/net_interface.rs
@@ -87,6 +87,17 @@ fn should_filter_loopback(swarm: &Swarm<NodeBehaviour>) -> bool {
         .any(|addr| !is_loopback_addr(addr) && !is_unspecified_addr(addr))
 }
 
+/// Strip a trailing `/p2p/<peer-id>` component from a multiaddr.
+/// Needed when re-keying a routing entry after a peer ID mismatch: the dialed
+/// address still pins the stale peer ID, and re-adding it verbatim under the
+/// new peer ID would make every subsequent dial fail with `WrongPeerId` again.
+fn strip_peer_id(mut addr: Multiaddr) -> Multiaddr {
+    if matches!(addr.iter().last(), Some(Protocol::P2p(_))) {
+        addr.pop();
+    }
+    addr
+}
+
 fn is_unspecified_addr(addr: &Multiaddr) -> bool {
     addr.iter().any(|p| match p {
         Protocol::Ip4(ip) => ip.is_unspecified(),
@@ -166,6 +177,11 @@ impl Libp2pNetInterface {
         let cmd_rx = &mut self.cmd_rx;
         let mut correlator = Correlator::new();
         let mut peer_failures = PeerFailureTracker::new();
+        // Tracks WrongPeerId occurrences per stale peer ID, separately from
+        // generic dial failures: a node that was offline accumulates ordinary
+        // failures before coming back with new keys, and the first mismatch
+        // must still be treated as the first (triggering redial + bootstrap).
+        let mut peer_id_mismatches = PeerFailureTracker::new();
         // This is to make sure we dont spam warnings in the logs
         let mut last_backpressure_warn = Instant::now();
 
@@ -222,7 +238,7 @@ impl Libp2pNetInterface {
                 }
                 // Process events
                 event = self.swarm.select_next_some() =>  {
-                    match process_swarm_event(&mut self.swarm, &event_tx, &cmd_tx, &mut correlator, &mut peer_failures, event).await {
+                    match process_swarm_event(&mut self.swarm, &event_tx, &cmd_tx, &mut correlator, &mut peer_failures, &mut peer_id_mismatches, event).await {
                         Ok(_) => (),
                         Err(e) => error!("Error processing NetEvent: {e}")
                     }
@@ -305,6 +321,7 @@ async fn process_swarm_event(
     cmd_tx: &mpsc::Sender<NetCommand>,
     correlator: &mut Correlator,
     peer_failures: &mut PeerFailureTracker,
+    peer_id_mismatches: &mut PeerFailureTracker,
     event: SwarmEvent<NodeBehaviourEvent>,
 ) -> Result<()> {
     match event {
@@ -315,8 +332,9 @@ async fn process_swarm_event(
             num_established,
             ..
         } => {
-            // Reset failure count on successful connection
+            // Reset failure counts on successful connection
             peer_failures.reset(&peer_id);
+            peer_id_mismatches.reset(&peer_id);
             if num_established.get() == 1 {
                 let total = swarm.connected_peers().count();
                 info!("Peer connected: {peer_id} (total: {total})");
@@ -352,28 +370,68 @@ async fn process_swarm_event(
                 {
                     // The node at this address has a new PeerId (e.g. restarted with new keys).
                     // Remove the stale entry and add the new one so we don't loop.
+                    // The stale entry can be re-learned from other peers' routing tables,
+                    // so repeats are expected: handle them quietly (debug, no bootstrap)
+                    // to avoid flooding the logs and re-fueling the dial loop.
                     let remote_addr = endpoint.get_remote_address().clone();
-                    info!(
-                        "Peer ID mismatch at {remote_addr}: expected {failed_peer}, got {obtained} — \
-                         replacing stale routing entry"
-                    );
+                    let mismatch_count = peer_id_mismatches.record_failure(failed_peer);
+                    // The stale ID is being removed from the routing table, so its
+                    // generic dial-failure history is no longer meaningful.
+                    peer_failures.reset(failed_peer);
+                    if mismatch_count == 1 {
+                        info!(
+                            "Peer ID mismatch at {remote_addr}: expected {failed_peer}, got {obtained} — \
+                             replacing stale routing entry"
+                        );
+                    } else {
+                        debug!(
+                            "Peer ID mismatch at {remote_addr}: expected {failed_peer}, got {obtained} \
+                             (seen {mismatch_count} times) — stale entry re-learned from the network"
+                        );
+                    }
                     let local_peer = *swarm.local_peer_id();
                     swarm.behaviour_mut().kademlia.remove_peer(failed_peer);
-                    if obtained != local_peer
-                        && !(should_filter_loopback(swarm) && is_loopback_addr(&remote_addr))
-                    {
-                        swarm
-                            .behaviour_mut()
-                            .kademlia
-                            .add_address(&obtained, remote_addr);
-                    }
-                    peer_failures.reset(failed_peer);
+                    if obtained != local_peer {
+                        // Strip the stale /p2p/<old-id> suffix, otherwise dials to the
+                        // new peer via this address fail with WrongPeerId forever.
+                        let corrected_addr = strip_peer_id(remote_addr.clone());
 
-                    // Trigger Kademlia bootstrap to discover peers beyond direct connections.
-                    if let Err(e) = swarm.behaviour_mut().kademlia.bootstrap() {
-                        debug!(
-                            "Kademlia bootstrap after peer ID replacement not possible yet: {e}"
-                        );
+                        // Only publish the address to Kademlia if it wouldn't leak a
+                        // loopback address to remote peers (see should_filter_loopback).
+                        if !(should_filter_loopback(swarm) && is_loopback_addr(&remote_addr)) {
+                            swarm
+                                .behaviour_mut()
+                                .kademlia
+                                .add_address(&obtained, corrected_addr.clone());
+                        }
+
+                        // Redial the node under its actual identity — a direct dial
+                        // doesn't propagate the address, so no loopback filtering is
+                        // needed. Only on the first mismatch: repeats mean the stale
+                        // entry was re-learned from neighbours and we are already
+                        // connected (or connecting) to the real peer.
+                        if mismatch_count == 1 {
+                            let opts = DialOpts::peer_id(obtained)
+                                .addresses(vec![corrected_addr])
+                                .build();
+                            if let Err(e) = swarm.dial(opts) {
+                                debug!(
+                                    "Redial of {obtained} after peer ID replacement failed: {e}"
+                                );
+                            }
+                        }
+                    }
+
+                    // Trigger Kademlia bootstrap to discover peers beyond direct
+                    // connections — but only on the first mismatch: bootstrapping on
+                    // every repeat re-learns the stale entry from neighbours and
+                    // redials it, creating a self-sustaining loop.
+                    if mismatch_count == 1 {
+                        if let Err(e) = swarm.behaviour_mut().kademlia.bootstrap() {
+                            debug!(
+                                "Kademlia bootstrap after peer ID replacement not possible yet: {e}"
+                            );
+                        }
                     }
                 } else {
                     let count = peer_failures.record_failure(failed_peer);
@@ -948,6 +1006,23 @@ mod tests {
     use libp2p::kad::{Record, RecordKey};
     use libp2p::PeerId;
     use std::time::{Duration, Instant};
+
+    #[test]
+    fn strip_peer_id_removes_trailing_p2p_component() {
+        let peer = PeerId::random();
+        let addr: libp2p::Multiaddr = format!("/ip4/172.20.0.1/udp/9091/quic-v1/p2p/{peer}")
+            .parse()
+            .unwrap();
+        let stripped = super::strip_peer_id(addr);
+        assert_eq!(
+            stripped,
+            "/ip4/172.20.0.1/udp/9091/quic-v1"
+                .parse::<libp2p::Multiaddr>()
+                .unwrap()
+        );
+        // Idempotent on addresses without a /p2p/ suffix
+        assert_eq!(super::strip_peer_id(stripped.clone()), stripped);
+    }
 
     #[test]
     fn expired_records_are_pruned_on_full_store() {

--- a/crates/net/src/net_interface.rs
+++ b/crates/net/src/net_interface.rs
@@ -407,18 +407,16 @@ async fn process_swarm_event(
 
                         // Redial the node under its actual identity — a direct dial
                         // doesn't propagate the address, so no loopback filtering is
-                        // needed. Only on the first mismatch: repeats mean the stale
-                        // entry was re-learned from neighbours and we are already
-                        // connected (or connecting) to the real peer.
-                        if mismatch_count == 1 {
-                            let opts = DialOpts::peer_id(obtained)
-                                .addresses(vec![corrected_addr])
-                                .build();
-                            if let Err(e) = swarm.dial(opts) {
-                                debug!(
-                                    "Redial of {obtained} after peer ID replacement failed: {e}"
-                                );
-                            }
+                        // needed. The default dial condition (DisconnectedAndNotDialing)
+                        // makes this a no-op while we are already connected or
+                        // connecting to the real peer, so repeated mismatches cause no
+                        // churn — while a dropped connection is re-attempted on any
+                        // later mismatch (recovery is not one-shot).
+                        let opts = DialOpts::peer_id(obtained)
+                            .addresses(vec![corrected_addr])
+                            .build();
+                        if let Err(e) = swarm.dial(opts) {
+                            debug!("Redial of {obtained} after peer ID replacement skipped: {e}");
                         }
                     }
 

--- a/crates/net/tests/peer_id_mismatch.rs
+++ b/crates/net/tests/peer_id_mismatch.rs
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+//
+// This file is provided WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE.
+
+//! Integration test for stale peer ID handling.
+//!
+//! Reproduces the scenario where a node restarts with new keys: other nodes
+//! still hold a multiaddr pinning the old `/p2p/<peer-id>`, so dialing it
+//! fails with `DialError::WrongPeerId`. The expected behaviour is that the
+//! stale routing entry is replaced exactly once (no retry storm, no
+//! bootstrap-fueled redial loop) and the dialer then connects to the node
+//! under its new identity via the re-keyed routing entry.
+
+use std::time::Duration;
+
+use anyhow::Result;
+use e3_net::events::{NetCommand, NetEvent};
+use e3_net::{Libp2pKeypair, Libp2pNetInterface, NetInterface};
+use libp2p::swarm::DialError;
+use tokio::time::{sleep, timeout};
+
+/// Grab a free UDP port by binding to port 0 and dropping the socket.
+fn free_udp_port() -> u16 {
+    let socket = std::net::UdpSocket::bind("127.0.0.1:0").expect("bind udp");
+    socket.local_addr().expect("local addr").port()
+}
+
+fn is_wrong_peer_id(event: &NetEvent) -> bool {
+    matches!(
+        event,
+        NetEvent::OutgoingConnectionError { error, .. }
+            if matches!(error.as_ref(), DialError::WrongPeerId { .. })
+    )
+}
+
+#[tokio::test]
+async fn stale_peer_id_is_replaced_once_and_connection_recovers() -> Result<()> {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .try_init();
+    // Node B: the "restarted" node, listening with its real (new) identity.
+    let port_b = free_udp_port();
+    let mut node_b =
+        Libp2pNetInterface::new(Libp2pKeypair::generate(), vec![], Some(port_b), "test")?;
+    let handle_b = node_b.handle();
+    tokio::spawn(async move { node_b.start().await });
+
+    // Give B a moment to bind its QUIC listener.
+    sleep(Duration::from_millis(500)).await;
+
+    // Node A: dials B's address pinned to a STALE peer ID (B's pre-restart
+    // identity), exactly like a stale routing/config entry.
+    let stale_id = Libp2pKeypair::generate().peer_id();
+    let stale_addr = format!("/ip4/127.0.0.1/udp/{port_b}/quic-v1/p2p/{stale_id}");
+    let mut node_a =
+        Libp2pNetInterface::new(Libp2pKeypair::generate(), vec![stale_addr], None, "test")?;
+    let handle_a = node_a.handle();
+    let mut rx_a = handle_a.rx();
+    tokio::spawn(async move { node_a.start().await });
+
+    // Phase 1: the dial must fail with WrongPeerId, then A must recover and
+    // connect to B under its real identity (via the re-keyed routing entry
+    // and the bootstrap triggered by the first mismatch).
+    let mut mismatches = 0usize;
+    let mut connected = false;
+    timeout(Duration::from_secs(30), async {
+        loop {
+            let event = rx_a.recv().await?;
+            if is_wrong_peer_id(&event) {
+                mismatches += 1;
+            }
+            if matches!(event, NetEvent::ConnectionEstablished { .. }) {
+                connected = true;
+                break;
+            }
+        }
+        anyhow::Ok(())
+    })
+    .await
+    .expect("timed out waiting for A to recover and connect to B")?;
+
+    assert!(connected, "A should connect to B under its new identity");
+    assert_eq!(
+        mismatches, 1,
+        "stale routing entry should be replaced after a single WrongPeerId"
+    );
+
+    // Phase 2: quiet window. The old behaviour redialed the stale address
+    // (dialer retries every ~3s + bootstrap loop), flooding WrongPeerId
+    // errors. After the fix there must be no further mismatches.
+    let extra_mismatches = {
+        let mut count = 0usize;
+        let _ = timeout(Duration::from_secs(10), async {
+            loop {
+                let event = rx_a.recv().await?;
+                if is_wrong_peer_id(&event) {
+                    count += 1;
+                }
+            }
+            #[allow(unreachable_code)]
+            anyhow::Ok(())
+        })
+        .await; // timeout here is the success path
+        count
+    };
+    assert_eq!(
+        extra_mismatches, 0,
+        "no further WrongPeerId errors should occur after the entry is replaced"
+    );
+
+    handle_a.tx().send(NetCommand::Shutdown).await?;
+    handle_b.tx().send(NetCommand::Shutdown).await?;
+    Ok(())
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents repeated retries on stale peer identifiers; records mismatches, resets stale failure history, and cleans stale addresses.
  * Publishes corrected addresses and always attempts reconnect with the discovered peer identity; triggers bootstrap only on first mismatch.
  * Improved, clearer logging around peer ID mismatches and recovery behavior.

* **Tests**
  * Added integration and unit tests validating peer-ID stripping, single-mismatch handling, and successful recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->