### PR TITLE
feat: lock TTL

### DIFF
--- a/agent/flow-trace/02_TOKENS_AND_ACTIVATION.md
+++ b/agent/flow-trace/02_TOKENS_AND_ACTIVATION.md
@@ -56,7 +56,14 @@ Before a node can register, it must stake two types of collateral:
 │      BONDING_REGISTRY.totalBonded(account))                │
 │    Transfer reverts with InsufficientUnlockedBalance       │
 │    if value > transferable                                 │
-│                                                           │
+│                                                            │
+│  Lock sunset (NO_MORE_LOCKS, immutable):                   │
+│    - Absolute timestamp set at deployment                  │
+│    - createLockPolicy rejects any policy that could        │
+│      outlast the sunset (curves and holdUntil)             │
+│    - From NO_MORE_LOCKS on, _update skips all lock         │
+│      accounting (vanilla ERC20); PENDING locks die too     │
+│                                                            │
 │  Whitelisting:                                             │
 │    - setTransferWhitelisted(addr, bool)                    │
 │      WHITELIST_ROLE — pre-TGE transfer gate                │

--- a/packages/interfold-contracts/contracts/token/InterfoldToken.sol
+++ b/packages/interfold-contracts/contracts/token/InterfoldToken.sol
@@ -921,11 +921,6 @@ contract InterfoldToken is
         return 0;
     }
 
-    /// @dev Earliest possible TGE timestamp.
-    function _earliestTge() internal view returns (uint256) {
-        return uint256(CCA_END) + TGE_COOLDOWN;
-    }
-
     /// @dev Ensures the policy cannot keep anything locked past the lock
     ///      sunset. Ending exactly at the sunset is allowed: the curve has
     ///      fully released and the hold has lapsed at that moment, which is
@@ -939,7 +934,7 @@ contract InterfoldToken is
             : curve.vestDuration;
 
         uint256 policyEnd = curve.anchor == Anchor.Tge
-            ? _earliestTge() + curveEnd
+            ? uint256(CCA_END) + TGE_COOLDOWN + curveEnd
             : curve.start + curveEnd;
 
         if (policyEnd > NO_MORE_LOCKS) {

--- a/packages/interfold-contracts/contracts/token/InterfoldToken.sol
+++ b/packages/interfold-contracts/contracts/token/InterfoldToken.sol
@@ -927,7 +927,9 @@ contract InterfoldToken is
     }
 
     /// @dev Ensures the policy cannot keep anything locked past the lock
-    ///      sunset.
+    ///      sunset. Ending exactly at the sunset is allowed: the curve has
+    ///      fully released and the hold has lapsed at that moment, which is
+    ///      also when the sunset takes effect.
     function _validatePolicyMaturity(LockPolicy calldata policy) internal view {
         Curve calldata curve = policy.unlock;
         // The curve validation guarantees cliff <= vest when vest != 0, so
@@ -940,10 +942,10 @@ contract InterfoldToken is
             ? _earliestTge() + curveEnd
             : curve.start + curveEnd;
 
-        if (policyEnd >= NO_MORE_LOCKS) {
+        if (policyEnd > NO_MORE_LOCKS) {
             revert InvalidPolicy();
         }
-        if (policy.holdUntil >= NO_MORE_LOCKS) {
+        if (policy.holdUntil > NO_MORE_LOCKS) {
             revert InvalidPolicy();
         }
     }

--- a/packages/interfold-contracts/contracts/token/InterfoldToken.sol
+++ b/packages/interfold-contracts/contracts/token/InterfoldToken.sol
@@ -126,8 +126,12 @@ contract InterfoldToken is
     ///         future.
     error InvalidCcaWindow(uint64 ccaStart, uint64 ccaEnd);
 
-    /// @notice Policy parameters are internally inconsistent.
+    /// @notice Policy parameters are internally inconsistent, or the policy
+    ///         could keep tokens locked past the lock sunset.
     error InvalidPolicy();
+
+    /// @notice The lock sunset timestamp must be after the earliest TGE.
+    error InvalidNoMoreLocks(uint256 noMoreLocks, uint256 minimum);
 
     /// @notice The requested relink amount exceeds the amount available under
     ///         the source policy.
@@ -197,6 +201,9 @@ contract InterfoldToken is
 
     /// @notice End of the CCA auction window, fixed at deployment
     uint64 public immutable CCA_END;
+
+    /// @notice Absolute timestamp after which token locks no longer apply.
+    uint64 public immutable NO_MORE_LOCKS;
 
     /// @notice The CCA auction contract
     address public immutable CLAIM_SOURCE;
@@ -288,6 +295,7 @@ contract InterfoldToken is
      * @param initialOwner_ Initial owner; receives all roles.
      * @param ccaStart_ CCA auction window start;
      * @param ccaEnd_ CCA auction window end; after `ccaStart_`.
+     * @param noMoreLocks_ Absolute timestamp after which token locks no longer apply.
      * @param claimSource_ The CCA auction contract
      * @param bondingRegistry_ Registry whose bonded INTF
      */
@@ -295,6 +303,7 @@ contract InterfoldToken is
         address initialOwner_,
         uint64 ccaStart_,
         uint64 ccaEnd_,
+        uint64 noMoreLocks_,
         address claimSource_,
         IBondingRegistry bondingRegistry_
     )
@@ -312,8 +321,14 @@ contract InterfoldToken is
         if (registry.code.length == 0) {
             revert InvalidBondingRegistry(registry);
         }
+        if (noMoreLocks_ == 0) revert ZeroAmount();
+        uint256 earliestTge = uint256(ccaEnd_) + TGE_COOLDOWN;
+        if (noMoreLocks_ <= earliestTge) {
+            revert InvalidNoMoreLocks(noMoreLocks_, earliestTge + 1);
+        }
         CCA_START = ccaStart_;
         CCA_END = ccaEnd_;
+        NO_MORE_LOCKS = noMoreLocks_;
         CLAIM_SOURCE = claimSource_;
         BONDING_REGISTRY = bondingRegistry_;
     }
@@ -428,6 +443,7 @@ contract InterfoldToken is
             revert PolicyAlreadyDefined(policyId);
         }
         _validateCurve(policy.unlock);
+        _validatePolicyMaturity(policy);
 
         lockPolicies[policyId] = policy;
         emit PolicyDefined(policyId, policy);
@@ -510,11 +526,16 @@ contract InterfoldToken is
 
     /// @notice Locked balance of `account` at `timestamp`, evaluated against the
     ///         current configuration (an unset TGE keeps {Anchor.Tge} policies
-    ///         fully locked for any timestamp).
+    ///         fully locked for any timestamp). Always zero from the lock
+    ///         sunset onwards.
     function lockedBalanceAt(
         address account,
         uint64 timestamp
     ) public view returns (uint256 lockedBalance) {
+        if (timestamp >= NO_MORE_LOCKS) {
+            return 0;
+        }
+
         Lock[] storage accountLocks = locks[account];
         for (uint256 i = 0; i < accountLocks.length; i++) {
             Lock storage accountLock = accountLocks[i];
@@ -575,17 +596,23 @@ contract InterfoldToken is
 
     /**
      * @dev Applies, in order:
-     *      1. The pre-TGE transfer gate (_isTransferRestricted)
-     *      2. The lock check, the sender can move at most its transferable
+     *      1. The lock sunset short-circuit.
+     *      2. The pre-TGE transfer gate (_isTransferRestricted)
+     *      3. The lock check, the sender can move at most its transferable
      *         balance
-     *      3. The transfer itself, via parent contract
-     *      4. Claim-lock creation, unless the recipient is claim-lock exempt.
+     *      4. The transfer itself, via parent contract
+     *      5. Claim-lock creation, unless the recipient is claim-lock exempt.
      */
     function _update(
         address from,
         address to,
         uint256 value
     ) internal override(ERC20, ERC20Votes) {
+        if (block.timestamp >= NO_MORE_LOCKS) {
+            super._update(from, to, value);
+            return;
+        }
+
         bool isMint = from == address(0);
         bool isBurn = to == address(0);
 
@@ -892,6 +919,33 @@ contract InterfoldToken is
             }
         }
         return 0;
+    }
+
+    /// @dev Earliest possible TGE timestamp.
+    function _earliestTge() internal view returns (uint256) {
+        return uint256(CCA_END) + TGE_COOLDOWN;
+    }
+
+    /// @dev Ensures the policy cannot keep anything locked past the lock
+    ///      sunset.
+    function _validatePolicyMaturity(LockPolicy calldata policy) internal view {
+        Curve calldata curve = policy.unlock;
+        // The curve validation guarantees cliff <= vest when vest != 0, so
+        // the curve fully releases at cliff (vest == 0) or at vest end.
+        uint256 curveEnd = curve.vestDuration == 0
+            ? curve.cliffDuration
+            : curve.vestDuration;
+
+        uint256 policyEnd = curve.anchor == Anchor.Tge
+            ? _earliestTge() + curveEnd
+            : curve.start + curveEnd;
+
+        if (policyEnd >= NO_MORE_LOCKS) {
+            revert InvalidPolicy();
+        }
+        if (policy.holdUntil >= NO_MORE_LOCKS) {
+            revert InvalidPolicy();
+        }
     }
 
     /// @dev Validates the unlock curve: it must lock something and be

--- a/packages/interfold-contracts/ignition/modules/interfoldToken.ts
+++ b/packages/interfold-contracts/ignition/modules/interfoldToken.ts
@@ -11,11 +11,13 @@ export default buildModule("InterfoldToken", (m) => {
   const ccaEnd = m.getParameter("ccaEnd");
   const claimSource = m.getParameter("claimSource");
   const bondingRegistry = m.getParameter("bondingRegistry");
+  const noMoreLocks = m.getParameter("noMoreLocks");
 
   const interfoldToken = m.contract("InterfoldToken", [
     owner,
     ccaStart,
     ccaEnd,
+    noMoreLocks,
     claimSource,
     bondingRegistry,
   ]);

--- a/packages/interfold-contracts/scripts/deployAndSave/interfoldToken.ts
+++ b/packages/interfold-contracts/scripts/deployAndSave/interfoldToken.ts
@@ -24,6 +24,7 @@ export interface InterfoldTokenArgs {
   ccaEnd?: bigint;
   claimSource?: string;
   bondingRegistry?: string;
+  noMoreLocks?: bigint;
   hre: HardhatRuntimeEnvironment;
 }
 
@@ -61,6 +62,7 @@ export const deployAndSaveInterfoldToken = async ({
   ccaEnd,
   claimSource,
   bondingRegistry,
+  noMoreLocks,
   hre,
 }: InterfoldTokenArgs): Promise<{
   interfoldToken: InterfoldToken;
@@ -77,6 +79,7 @@ export const deployAndSaveInterfoldToken = async ({
     ccaEnd === undefined ||
     !claimSource ||
     !bondingRegistry ||
+    noMoreLocks === undefined ||
     preDeployedArgs?.constructorArgs?.owner === owner
   ) {
     if (!preDeployedArgs?.address) {
@@ -100,6 +103,7 @@ export const deployAndSaveInterfoldToken = async ({
     owner,
     ccaStart,
     ccaEnd,
+    noMoreLocks,
     claimSource,
     bondingRegistry,
   );
@@ -118,6 +122,7 @@ export const deployAndSaveInterfoldToken = async ({
         ccaEnd: ccaEnd.toString(),
         claimSource,
         bondingRegistry,
+        noMoreLocks: noMoreLocks.toString(),
       },
       blockNumber,
       address: interfoldTokenAddress,

--- a/packages/interfold-contracts/scripts/deployInterfold.ts
+++ b/packages/interfold-contracts/scripts/deployInterfold.ts
@@ -84,30 +84,6 @@ function parseRequiredUint64(value: string, label: string): bigint {
   return parsed;
 }
 
-function resolveInterfoldTgeTimestamp(
-  networkName: string,
-  latestBlockTimestamp: number,
-): string {
-  const configured = process.env.INTERFOLD_TGE_TIMESTAMP;
-  if (configured?.trim()) {
-    return parseRequiredUint64(
-      configured.trim(),
-      "INTERFOLD_TGE_TIMESTAMP",
-    ).toString();
-  }
-
-  if (!isLocalDeploymentChain(networkName)) {
-    throw new Error(
-      "INTERFOLD_TGE_TIMESTAMP must be set for non-local token-lock deployment",
-    );
-  }
-
-  console.warn(
-    "[WARN] INTERFOLD_TGE_TIMESTAMP not set; using latest local block timestamp for INTF token locks.",
-  );
-  return latestBlockTimestamp.toString();
-}
-
 /** Circuit names required for BFV ZK verification in this script */
 const DKG_AGGREGATOR_VERIFIER = "DkgAggregatorVerifier";
 const DECRYPTION_AGGREGATOR_VERIFIER = "DecryptionAggregatorVerifier";

--- a/packages/interfold-contracts/scripts/deployInterfold.ts
+++ b/packages/interfold-contracts/scripts/deployInterfold.ts
@@ -138,6 +138,8 @@ export const deployInterfold = async (
 
   const THIRTY_DAYS_IN_SECONDS = 60 * 60 * 24 * 30;
   const SEVEN_DAYS_IN_SECONDS = 60 * 60 * 24 * 7;
+  const TGE_COOLDOWN_SECONDS = 60 * 60 * 24 * 45;
+  const FOUR_YEARS_IN_SECONDS = 60 * 60 * 24 * 365 * 4;
   const SORTITION_SUBMISSION_WINDOW = 10;
   const addressOne = "0x0000000000000000000000000000000000000001";
 
@@ -266,6 +268,7 @@ export const deployInterfold = async (
     ccaEnd,
     claimSource: ownerAddress,
     bondingRegistry: bondingRegistryAddress,
+    noMoreLocks: ccaEnd + BigInt(TGE_COOLDOWN_SECONDS + FOUR_YEARS_IN_SECONDS),
     hre,
   });
   const interfoldTokenAddress = await interfoldToken.getAddress();

--- a/packages/interfold-contracts/test/Token/InterfoldToken.spec.ts
+++ b/packages/interfold-contracts/test/Token/InterfoldToken.spec.ts
@@ -317,6 +317,32 @@ describe("InterfoldToken", function () {
       );
     });
 
+    it("reverts when noMoreLocks is not after the earliest TGE", async function () {
+      const [deployer] = await ethers.getSigners();
+      const mockRegistry = await new MockBondingRegistryFactory(
+        deployer,
+      ).deploy();
+      await mockRegistry.waitForDeployment();
+      const now = BigInt(await time.latest());
+      const ccaStart = now + DAY;
+      const ccaEnd = ccaStart + 7n * DAY;
+      const earliestTge = ccaEnd + TGE_COOLDOWN;
+
+      await expect(
+        new InterfoldTokenFactory(deployer).deploy(
+          await deployer.getAddress(),
+          ccaStart,
+          ccaEnd,
+          earliestTge, // must be strictly after
+          await deployer.getAddress(),
+          await mockRegistry.getAddress(),
+        ),
+      ).to.be.revertedWithCustomError(
+        { interface: InterfoldTokenFactory.createInterface() },
+        "InvalidNoMoreLocks",
+      );
+    });
+
     it("initial owner receives all roles", async function () {
       const { token, admin } = await loadFixture(deploy);
       const adminAddress = await admin.getAddress();

--- a/packages/interfold-contracts/test/Token/InterfoldToken.spec.ts
+++ b/packages/interfold-contracts/test/Token/InterfoldToken.spec.ts
@@ -15,6 +15,12 @@ const { loadFixture, time } = networkHelpers;
 
 const DAY = 24n * 60n * 60n;
 const YEAR = 365n * DAY;
+const NO_MORE_LOCKS_DELAY = 4n * YEAR;
+const TGE_COOLDOWN = 45n * DAY;
+
+function noMoreLocksFor(ccaEnd: bigint) {
+  return ccaEnd + TGE_COOLDOWN + NO_MORE_LOCKS_DELAY;
+}
 
 describe("InterfoldToken", function () {
   // ── Helpers ─────────────────────────────────────────────────────────────
@@ -43,11 +49,13 @@ describe("InterfoldToken", function () {
     const now = BigInt(await time.latest());
     const ccaStart = now + 10n * DAY; // far future — Virtual phase
     const ccaEnd = ccaStart + 7n * DAY;
+    const noMoreLocks = noMoreLocksFor(ccaEnd);
 
     const token = await new InterfoldTokenFactory(deployer).deploy(
       await admin.getAddress(),
       ccaStart,
       ccaEnd,
+      noMoreLocks,
       await claimSource.getAddress(),
       await mockRegistry.getAddress(),
     );
@@ -65,6 +73,7 @@ describe("InterfoldToken", function () {
       mockRegistry,
       ccaStart,
       ccaEnd,
+      noMoreLocks,
     };
   }
 
@@ -173,12 +182,14 @@ describe("InterfoldToken", function () {
       const now = BigInt(await time.latest());
       const ccaStart = now + DAY;
       const ccaEnd = ccaStart + 7n * DAY;
+      const noMoreLocks = noMoreLocksFor(ccaEnd);
 
       await expect(
         new InterfoldTokenFactory(deployer).deploy(
           await deployer.getAddress(),
           ccaStart,
           ccaEnd,
+          noMoreLocks,
           ethers.ZeroAddress,
           await mockRegistry.getAddress(),
         ),
@@ -193,12 +204,14 @@ describe("InterfoldToken", function () {
       const now = BigInt(await time.latest());
       const ccaStart = now + DAY;
       const ccaEnd = ccaStart + 7n * DAY;
+      const noMoreLocks = noMoreLocksFor(ccaEnd);
 
       await expect(
         new InterfoldTokenFactory(deployer).deploy(
           await deployer.getAddress(),
           ccaStart,
           ccaEnd,
+          noMoreLocks,
           await deployer.getAddress(),
           ethers.ZeroAddress,
         ),
@@ -213,12 +226,14 @@ describe("InterfoldToken", function () {
       const now = BigInt(await time.latest());
       const ccaStart = now + DAY;
       const ccaEnd = ccaStart + 7n * DAY;
+      const noMoreLocks = noMoreLocksFor(ccaEnd);
 
       await expect(
         new InterfoldTokenFactory(deployer).deploy(
           await admin.getAddress(),
           ccaStart,
           ccaEnd,
+          noMoreLocks,
           await deployer.getAddress(),
           await admin.getAddress(), // EOA, not a contract
         ),
@@ -241,6 +256,7 @@ describe("InterfoldToken", function () {
           await deployer.getAddress(),
           now, // in the past (or now)
           now + 7n * DAY,
+          noMoreLocksFor(now + 7n * DAY),
           await deployer.getAddress(),
           await mockRegistry.getAddress(),
         ),
@@ -259,18 +275,45 @@ describe("InterfoldToken", function () {
       const now = BigInt(await time.latest());
       const ccaStart = now + DAY;
       const ccaEnd = ccaStart; // equal, not greater
+      const noMoreLocks = noMoreLocksFor(ccaEnd);
 
       await expect(
         new InterfoldTokenFactory(deployer).deploy(
           await deployer.getAddress(),
           ccaStart,
           ccaEnd,
+          noMoreLocks,
           await deployer.getAddress(),
           await mockRegistry.getAddress(),
         ),
       ).to.be.revertedWithCustomError(
         { interface: InterfoldTokenFactory.createInterface() },
         "InvalidCcaWindow",
+      );
+    });
+
+    it("reverts when noMoreLocks is zero", async function () {
+      const [deployer] = await ethers.getSigners();
+      const mockRegistry = await new MockBondingRegistryFactory(
+        deployer,
+      ).deploy();
+      await mockRegistry.waitForDeployment();
+      const now = BigInt(await time.latest());
+      const ccaStart = now + DAY;
+      const ccaEnd = ccaStart + 7n * DAY;
+
+      await expect(
+        new InterfoldTokenFactory(deployer).deploy(
+          await deployer.getAddress(),
+          ccaStart,
+          ccaEnd,
+          0n,
+          await deployer.getAddress(),
+          await mockRegistry.getAddress(),
+        ),
+      ).to.be.revertedWithCustomError(
+        { interface: InterfoldTokenFactory.createInterface() },
+        "ZeroAmount",
       );
     });
 
@@ -720,6 +763,93 @@ describe("InterfoldToken", function () {
         "AccessControlUnauthorizedAccount",
       );
     });
+
+    it("reverts when Tge-anchored vest outlasts noMoreLocks", async function () {
+      const { token, admin } = await loadFixture(deploy);
+      await expect(
+        token
+          .connect(admin)
+          .createLockPolicy(ethers.encodeBytes32String("TOO_LONG"), {
+            holdUntil: 0n,
+            unlock: {
+              anchor: 1,
+              start: 0n,
+              cliffDuration: 0n,
+              vestDuration: NO_MORE_LOCKS_DELAY + 1n,
+            },
+          }),
+      ).to.be.revertedWithCustomError(token, "InvalidPolicy");
+    });
+
+    it("reverts when Tge-anchored cliff-only release outlasts noMoreLocks", async function () {
+      const { token, admin } = await loadFixture(deploy);
+      await expect(
+        token
+          .connect(admin)
+          .createLockPolicy(ethers.encodeBytes32String("TOO_LONG"), {
+            holdUntil: 0n,
+            unlock: {
+              anchor: 1,
+              start: 0n,
+              cliffDuration: NO_MORE_LOCKS_DELAY + 1n,
+              vestDuration: 0n,
+            },
+          }),
+      ).to.be.revertedWithCustomError(token, "InvalidPolicy");
+    });
+
+    it("accepts Tge-anchored vest of exactly noMoreLocks", async function () {
+      const { token, admin } = await loadFixture(deploy);
+      await expect(
+        token
+          .connect(admin)
+          .createLockPolicy(ethers.encodeBytes32String("FULL_TAIL"), {
+            holdUntil: 0n,
+            unlock: {
+              anchor: 1,
+              start: 0n,
+              cliffDuration: 0n,
+              vestDuration: NO_MORE_LOCKS_DELAY,
+            },
+          }),
+      ).to.emit(token, "PolicyDefined");
+    });
+
+    it("reverts when Absolute curve ends past the earliest sunset", async function () {
+      const { token, admin, ccaEnd } = await loadFixture(deploy);
+      const earliestMaturity = noMoreLocksFor(ccaEnd);
+      await expect(
+        token
+          .connect(admin)
+          .createLockPolicy(ethers.encodeBytes32String("TOO_LONG"), {
+            holdUntil: 0n,
+            unlock: {
+              anchor: 0,
+              start: earliestMaturity - YEAR,
+              cliffDuration: 0n,
+              vestDuration: YEAR + 1n,
+            },
+          }),
+      ).to.be.revertedWithCustomError(token, "InvalidPolicy");
+    });
+
+    it("reverts when holdUntil is past the earliest sunset", async function () {
+      const { token, admin, ccaEnd } = await loadFixture(deploy);
+      const earliestMaturity = noMoreLocksFor(ccaEnd);
+      await expect(
+        token
+          .connect(admin)
+          .createLockPolicy(ethers.encodeBytes32String("TOO_LONG"), {
+            holdUntil: earliestMaturity + 1n,
+            unlock: {
+              anchor: 1,
+              start: 0n,
+              cliffDuration: 0n,
+              vestDuration: YEAR,
+            },
+          }),
+      ).to.be.revertedWithCustomError(token, "InvalidPolicy");
+    });
   });
 
   // ═════════════════════════════════════════════════════════════════════════
@@ -941,6 +1071,79 @@ describe("InterfoldToken", function () {
       await expect(
         token.connect(alice).transfer(await bob.getAddress(), amount),
       ).to.be.revertedWithCustomError(token, "TransferRestricted");
+    });
+  });
+
+  // ═════════════════════════════════════════════════════════════════════════
+  // Lock sunset
+  // ═════════════════════════════════════════════════════════════════════════
+
+  describe("lock sunset", function () {
+    it("NO_MORE_LOCKS is fixed at deployment", async function () {
+      const { token, noMoreLocks } = await loadFixture(deploy);
+      expect(await token.NO_MORE_LOCKS()).to.equal(noMoreLocks);
+    });
+
+    it("locked balance becomes fully transferable at the sunset", async function () {
+      const { token, alice, bob, amount, noMoreLocks } =
+        await deployWithLockAndTge({ mintAmount: ethers.parseEther("1000") });
+      const aliceAddress = await alice.getAddress();
+
+      await time.increaseTo(noMoreLocks);
+
+      expect(await token.lockedBalanceOf(aliceAddress)).to.equal(0n);
+      expect(await token.transferableBalanceOf(aliceAddress)).to.equal(amount);
+      await token.connect(alice).transfer(await bob.getAddress(), amount);
+    });
+
+    it("unlinked PENDING locks sunset too", async function () {
+      const { token, alice, bob, claimSource, amount } =
+        await deployWithUnlockedAndTge(ethers.parseEther("500"));
+      const aliceAddress = await alice.getAddress();
+
+      await token
+        .connect(alice)
+        .transfer(await claimSource.getAddress(), amount);
+      await token.connect(claimSource).transfer(aliceAddress, amount);
+      expect(await token.lockedBalanceOf(aliceAddress)).to.equal(amount);
+
+      await time.increaseTo(await token.NO_MORE_LOCKS());
+
+      expect(await token.lockedBalanceOf(aliceAddress)).to.equal(0n);
+      await token.connect(alice).transfer(await bob.getAddress(), amount);
+    });
+
+    it("lockedBalanceAt reports 0 from the sunset onwards", async function () {
+      const { token, alice, claimSource, amount } =
+        await deployWithUnlockedAndTge(ethers.parseEther("500"));
+      const aliceAddress = await alice.getAddress();
+
+      await token
+        .connect(alice)
+        .transfer(await claimSource.getAddress(), amount);
+      await token.connect(claimSource).transfer(aliceAddress, amount);
+
+      const maturity = await token.NO_MORE_LOCKS();
+      expect(await token.lockedBalanceAt(aliceAddress, maturity - 1n)).to.equal(
+        amount,
+      );
+      expect(await token.lockedBalanceAt(aliceAddress, maturity)).to.equal(0n);
+    });
+
+    it("CLAIM_SOURCE transfers past the sunset create no locks", async function () {
+      const { token, alice, claimSource, amount } =
+        await deployWithUnlockedAndTge(ethers.parseEther("500"));
+      const aliceAddress = await alice.getAddress();
+
+      await token
+        .connect(alice)
+        .transfer(await claimSource.getAddress(), amount);
+
+      await time.increaseTo(await token.NO_MORE_LOCKS());
+
+      await token.connect(claimSource).transfer(aliceAddress, amount);
+      expect(await token.lockCount(aliceAddress)).to.equal(0n);
+      expect(await token.lockedBalanceOf(aliceAddress)).to.equal(0n);
     });
   });
 

--- a/packages/interfold-contracts/test/Token/InterfoldToken.spec.ts
+++ b/packages/interfold-contracts/test/Token/InterfoldToken.spec.ts
@@ -972,7 +972,7 @@ describe("InterfoldToken", function () {
     });
 
     it("transferableBalanceOf = 0 when fully locked and no bond", async function () {
-      const { token, alice, amount } = await deployWithLockAndTge({
+      const { token, alice } = await deployWithLockAndTge({
         mintAmount: ethers.parseEther("1000"),
       });
       expect(

--- a/packages/interfold-contracts/test/Token/InterfoldToken.spec.ts
+++ b/packages/interfold-contracts/test/Token/InterfoldToken.spec.ts
@@ -1057,6 +1057,106 @@ describe("InterfoldToken", function () {
       expect(lb2).to.be.closeTo(linkAmount, ethers.parseEther("0.01"));
     });
 
+    it("linkClaim partly consumes PENDING and queues the remainder", async function () {
+      const { token, admin, alice, claimSource, amount } =
+        await deployWithUnlockedAndTge(ethers.parseEther("300"));
+      const aliceAddress = await alice.getAddress();
+      const policyId = await createLinearPolicy(token, admin, "PART_QUEUE", {
+        vestDuration: 2n * YEAR,
+      });
+
+      await token
+        .connect(alice)
+        .transfer(await claimSource.getAddress(), amount);
+
+      expect(await token.lockCount(aliceAddress)).to.equal(0n);
+      expect(await token.queuedLockCount(aliceAddress)).to.equal(0n);
+
+      await token.connect(claimSource).transfer(aliceAddress, amount);
+
+      const linkAmount = ethers.parseEther("1000");
+      await token.connect(admin).linkClaim(aliceAddress, linkAmount, policyId);
+
+      expect(await token.lockCount(aliceAddress)).to.equal(1n);
+      expect(await token.queuedLockCount(aliceAddress)).to.equal(1n);
+
+      const activeLock = await token.locks(aliceAddress, 0);
+      expect(activeLock.policyId).to.equal(policyId);
+      expect(activeLock.amount).to.equal(amount);
+
+      const queuedLock = await token.queuedLocks(aliceAddress, 0);
+      expect(queuedLock.policyId).to.equal(policyId);
+      expect(queuedLock.amount).to.equal(linkAmount - amount);
+    });
+
+    it("claim after link consumes the queued link", async function () {
+      const fixture = await loadFixture(deploy);
+      const { token, admin, alice, claimSource, ccaEnd } = fixture;
+      const aliceAddress = await alice.getAddress();
+      const policyId = await createLinearPolicy(token, admin, "CLAIM_LINK", {
+        vestDuration: 2n * YEAR,
+      });
+      const linkAmount = ethers.parseEther("500");
+
+      await token.connect(admin).linkClaim(aliceAddress, linkAmount, policyId);
+      expect(await token.queuedLockCount(aliceAddress)).to.equal(1n);
+
+      await token
+        .connect(admin)
+        .mint(await claimSource.getAddress(), linkAmount, ethers.ZeroHash);
+
+      const TGE_COOLDOWN = 45n * DAY;
+      await time.increaseTo(ccaEnd + TGE_COOLDOWN + 1n);
+      await token.tge();
+
+      await token.connect(claimSource).transfer(aliceAddress, linkAmount);
+
+      expect(await token.queuedLockCount(aliceAddress)).to.equal(0n);
+      expect(await token.lockCount(aliceAddress)).to.equal(1n);
+
+      const activeLock = await token.locks(aliceAddress, 0);
+      expect(activeLock.policyId).to.equal(policyId);
+      expect(activeLock.amount).to.equal(linkAmount);
+    });
+
+    it("claim after link fully consumes queued link and adds excess as PENDING", async function () {
+      const fixture = await loadFixture(deploy);
+      const { token, admin, alice, claimSource, ccaEnd } = fixture;
+      const aliceAddress = await alice.getAddress();
+      const policyId = await createLinearPolicy(token, admin, "LINK_PENDING", {
+        vestDuration: 2n * YEAR,
+      });
+      const linkAmount = ethers.parseEther("500");
+      const claimAmount = ethers.parseEther("700");
+      const pendingPolicyId = await token.PENDING_LOCK_POLICY_ID();
+
+      await token.connect(admin).linkClaim(aliceAddress, linkAmount, policyId);
+      await token
+        .connect(admin)
+        .mint(await claimSource.getAddress(), claimAmount, ethers.ZeroHash);
+
+      const TGE_COOLDOWN = 45n * DAY;
+      await time.increaseTo(ccaEnd + TGE_COOLDOWN + 1n);
+      await token.tge();
+
+      await token.connect(claimSource).transfer(aliceAddress, claimAmount);
+
+      expect(await token.queuedLockCount(aliceAddress)).to.equal(0n);
+      expect(await token.lockCount(aliceAddress)).to.equal(2n);
+
+      const firstLock = await token.locks(aliceAddress, 0);
+      const secondLock = await token.locks(aliceAddress, 1);
+      const locksByPolicy = new Map([
+        [firstLock.policyId, firstLock.amount],
+        [secondLock.policyId, secondLock.amount],
+      ]);
+
+      expect(locksByPolicy.get(policyId)).to.equal(linkAmount);
+      expect(locksByPolicy.get(pendingPolicyId)).to.equal(
+        claimAmount - linkAmount,
+      );
+    });
+
     it("linkClaim reverts with undefined policy", async function () {
       const { token, admin, alice } = await loadFixture(deploy);
       await expect(

--- a/packages/interfold-contracts/test/fixtures/system.ts
+++ b/packages/interfold-contracts/test/fixtures/system.ts
@@ -363,6 +363,8 @@ export async function deployInterfoldSystem(
   const ccaStart = deployTime + 1000n; // keep Virtual phase during setup
   const ccaEnd = ccaStart + 7n * 24n * 60n * 60n; // 7-day CCA window
   const claimSource = ownerAddress; // owner as placeholder claim source
+  const noMoreLocks =
+    ccaEnd + 45n * 24n * 60n * 60n + 4n * 365n * 24n * 60n * 60n;
   const { interfoldToken } = await ignition.deploy(InterfoldTokenModule, {
     parameters: {
       InterfoldToken: {
@@ -371,6 +373,7 @@ export async function deployInterfoldSystem(
         ccaEnd,
         claimSource,
         bondingRegistry: bondingRegistryAddress,
+        noMoreLocks,
       },
     },
   });


### PR DESCRIPTION
  ## Summary

Adds a lock sunset to `InterfoldToken`: a `NO_MORE_LOCKS` immutable timestamp after which all lock accounting is dead.

### Why
  
Lock accounting is per-transfer dead weight that never expires: every transfer from a once-locked account loops over its lock entries, loads their policies, and (while anything is still locked) makes an external `BONDING_REGISTRY.totalBonded` call, long after every curve has fully vested.

This PR gives that machinery a hard cutoff.