### PR TITLE
fix: prevent owner role renouncement

### DIFF
--- a/packages/interfold-contracts/contracts/token/InterfoldToken.sol
+++ b/packages/interfold-contracts/contracts/token/InterfoldToken.sol
@@ -167,6 +167,10 @@ contract InterfoldToken is
     ///         freeze admin functions and is disallowed.
     error RenounceOwnershipDisabled();
 
+    /// @notice Thrown when the current owner attempts to renounce a role.
+    ///         Owner roles are synchronized through ownership transfer.
+    error RenounceRoleDisabledForOwner();
+
     // ─────────────────────────────────────────────────────────────────────────
     // Constants and immutables
     // ─────────────────────────────────────────────────────────────────────────
@@ -1022,6 +1026,20 @@ contract InterfoldToken is
     /// @notice Disabled. Reverts unconditionally.
     function renounceOwnership() public view override onlyOwner {
         revert RenounceOwnershipDisabled();
+    }
+
+    /// @inheritdoc AccessControl
+    function renounceRole(
+        bytes32 role,
+        address callerConfirmation
+    ) public override {
+        if (
+            callerConfirmation == _msgSender() &&
+            callerConfirmation == owner()
+        ) {
+            revert RenounceRoleDisabledForOwner();
+        }
+        super.renounceRole(role, callerConfirmation);
     }
 
     /**

--- a/packages/interfold-contracts/test/Token/InterfoldToken.spec.ts
+++ b/packages/interfold-contracts/test/Token/InterfoldToken.spec.ts
@@ -2720,6 +2720,33 @@ describe("InterfoldToken", function () {
       ).to.be.revertedWithCustomError(token, "RenounceOwnershipDisabled");
     });
 
+    it("owner cannot renounce AccessControl roles directly", async function () {
+      const { token, admin } = await loadFixture(deploy);
+      const adminAddress = await admin.getAddress();
+
+      await expect(
+        token
+          .connect(admin)
+          .renounceRole(await token.DEFAULT_ADMIN_ROLE(), adminAddress),
+      ).to.be.revertedWithCustomError(
+        token,
+        "RenounceRoleDisabledForOwner",
+      );
+    });
+
+    it("non-owner role holders can still renounce roles", async function () {
+      const { token, admin, alice } = await loadFixture(deploy);
+      const aliceAddress = await alice.getAddress();
+      const minterRole = await token.MINTER_ROLE();
+
+      await token.connect(admin).grantRole(minterRole, aliceAddress);
+      expect(await token.hasRole(minterRole, aliceAddress)).to.be.true;
+
+      await token.connect(alice).renounceRole(minterRole, aliceAddress);
+
+      expect(await token.hasRole(minterRole, aliceAddress)).to.be.false;
+    });
+
     it("ownership transfer syncs AccessControl roles", async function () {
       const { token, admin, alice } = await loadFixture(deploy);
       const adminAddress = await admin.getAddress();


### PR DESCRIPTION
## What changed

Prevents the current token owner from directly renouncing AccessControl roles while preserving role renouncement for non-owner role holders.

## Why

Zenith audit issue 1 noted that ownership renouncement was disabled, but owner role renouncement could still leave governance in a broken state.

## Validation

- `pnpm --dir packages/interfold-contracts test test/Token/InterfoldToken.spec.ts test/Token/InterfoldTicketToken.spec.ts`
- Push hooks passed: lint, pnpm version check, license headers, committee consistency
- Noir circuit checks were skipped by the hook because `nargo` is not installed
