### PR TITLE
fix: reject exempt queued claim states

### DIFF
--- a/packages/interfold-contracts/contracts/token/InterfoldToken.sol
+++ b/packages/interfold-contracts/contracts/token/InterfoldToken.sol
@@ -162,6 +162,10 @@ contract InterfoldToken is
     /// @notice The bonding registry address has no deployed code.
     error InvalidBondingRegistry(address registry);
 
+    /// @notice Claim-lock exemption cannot coexist with queued claim buckets
+    ///         because exempt claim-source transfers skip queue consumption.
+    error ClaimLockExemptQueuedLocks(address account);
+
     /// @notice Thrown when {renounceOwnership} is called. Ownership is
     ///         critical for protocol governance; renouncing would permanently
     ///         freeze admin functions and is disallowed.
@@ -415,6 +419,9 @@ contract InterfoldToken is
         bool exempt
     ) external onlyRole(LOCK_MANAGER_ROLE) {
         if (account == address(0)) revert ZeroAddress();
+        if (exempt && queuedLocks[account].length != 0) {
+            revert ClaimLockExemptQueuedLocks(account);
+        }
         claimLockExempt[account] = exempt;
         emit ClaimLockExemptUpdated(account, exempt);
     }
@@ -777,6 +784,9 @@ contract InterfoldToken is
 
         // Whatever is left queues under the target policy.
         if (remaining != 0) {
+            if (claimLockExempt[account]) {
+                revert ClaimLockExemptQueuedLocks(account);
+            }
             _addOrIncrementLock(
                 account,
                 queuedLocks[account],

--- a/packages/interfold-contracts/test/Token/InterfoldToken.spec.ts
+++ b/packages/interfold-contracts/test/Token/InterfoldToken.spec.ts
@@ -692,6 +692,22 @@ describe("InterfoldToken", function () {
         "AccessControlUnauthorizedAccount",
       );
     });
+
+    it("cannot enable claim-lock exemption while queued locks exist", async function () {
+      const { token, admin, alice } = await loadFixture(deploy);
+      const aliceAddress = await alice.getAddress();
+      const policyId = await createLinearPolicy(token, admin, "EXEMPT_QUEUE", {
+        vestDuration: 2n * YEAR,
+      });
+
+      await token.connect(admin).linkClaim(aliceAddress, 100n, policyId);
+
+      await expect(
+        token.connect(admin).setClaimLockExempt(aliceAddress, true),
+      )
+        .to.be.revertedWithCustomError(token, "ClaimLockExemptQueuedLocks")
+        .withArgs(aliceAddress);
+    });
   });
 
   // ═════════════════════════════════════════════════════════════════════════
@@ -1700,6 +1716,22 @@ describe("InterfoldToken", function () {
       // rounding from vesting elapsed seconds).
       const lb2 = await token.lockedBalanceOf(await alice.getAddress());
       expect(lb2).to.be.closeTo(linkAmount, ethers.parseEther("0.01"));
+    });
+
+    it("linkClaim cannot create queued locks for a claim-lock exempt account", async function () {
+      const { token, admin, alice } = await loadFixture(deploy);
+      const aliceAddress = await alice.getAddress();
+      const policyId = await createLinearPolicy(token, admin, "EXEMPT_LINK", {
+        vestDuration: 2n * YEAR,
+      });
+
+      await token.connect(admin).setClaimLockExempt(aliceAddress, true);
+
+      await expect(
+        token.connect(admin).linkClaim(aliceAddress, 100n, policyId),
+      )
+        .to.be.revertedWithCustomError(token, "ClaimLockExemptQueuedLocks")
+        .withArgs(aliceAddress);
     });
 
     it("linkClaim partly consumes PENDING and queues the remainder", async function () {


### PR DESCRIPTION
## What changed

Prevents claim-lock exemption from coexisting with queued claim-lock buckets.

## Why

Zenith audit issue 7 found that exempting an account with queued buckets could leave stale queued state that later behaves surprisingly.

## Validation

- `pnpm --dir packages/interfold-contracts test test/Token/InterfoldToken.spec.ts test/Token/InterfoldTicketToken.spec.ts`
- Push hooks passed: lint, pnpm version check, license headers, committee consistency
- Noir circuit checks were skipped by the hook because `nargo` is not installed
