### PR TITLE
fix: reject relink of vested absolute locks

### DIFF
--- a/packages/interfold-contracts/contracts/token/InterfoldToken.sol
+++ b/packages/interfold-contracts/contracts/token/InterfoldToken.sol
@@ -137,6 +137,10 @@ contract InterfoldToken is
     ///         the source policy.
     error RelinkAmountExceeded();
 
+    /// @notice Relinking from this Absolute policy would move already vested
+    ///         principal back under another policy.
+    error RelinkSourceAlreadyVested(bytes32 policyId);
+
     /// @notice An account has reached the maximum number of active lock
     ///         policy entries.
     error TooManyLocks();
@@ -491,9 +495,14 @@ contract InterfoldToken is
     ) external onlyRole(LOCK_MANAGER_ROLE) {
         if (tgeTimestamp != 0) revert AlreadyLive();
         _validateRelinkParams(account, fromPolicyId, toPolicyId, amount);
-        if (_activeLockAmount(account, fromPolicyId) < amount) {
+        uint256 activeAmount = _activeLockAmount(account, fromPolicyId);
+        if (activeAmount < amount) {
             revert RelinkAmountExceeded();
         }
+        _validateRelinkSourceHasNoVestedPrincipal(
+            fromPolicyId,
+            activeAmount
+        );
 
         (uint256 consumed, ) = _consumeLock(
             account,
@@ -903,6 +912,22 @@ contract InterfoldToken is
         }
         if (!_policyDefined(toPolicyId)) {
             revert PolicyNotDefined(toPolicyId);
+        }
+    }
+
+    function _validateRelinkSourceHasNoVestedPrincipal(
+        bytes32 policyId,
+        uint256 activeAmount
+    ) internal view {
+        LockPolicy storage policy = lockPolicies[policyId];
+        if (policy.unlock.anchor != Anchor.Absolute) return;
+        uint256 lockedAmount = _lockedAmount(
+            policy,
+            activeAmount,
+            uint64(block.timestamp)
+        );
+        if (lockedAmount < activeAmount) {
+            revert RelinkSourceAlreadyVested(policyId);
         }
     }
 

--- a/packages/interfold-contracts/test/Token/InterfoldToken.spec.ts
+++ b/packages/interfold-contracts/test/Token/InterfoldToken.spec.ts
@@ -2072,6 +2072,77 @@ describe("InterfoldToken", function () {
       expect(byPolicy.get(toPolicy)).to.equal(relinkAmount);
     });
 
+    it("relink allows an unvested Absolute source policy", async function () {
+      const { token, admin, alice } = await loadFixture(deploy);
+      const aliceAddress = await alice.getAddress();
+      const start = BigInt(await time.latest()) + DAY;
+
+      const fromPolicy = await createLinearPolicy(token, admin, "ABS_UNVEST", {
+        anchor: 0,
+        start,
+        vestDuration: 10n * DAY,
+      });
+      const toPolicy = await createLinearPolicy(token, admin, "ABS_DST", {
+        vestDuration: 2n * YEAR,
+      });
+      const amount = ethers.parseEther("1000");
+
+      await token.connect(admin).mintAllocations([
+        {
+          recipient: aliceAddress,
+          amount,
+          policyId: fromPolicy,
+          label: ethers.encodeBytes32String("abs"),
+        },
+      ]);
+
+      await expect(
+        token.connect(admin).relinkActiveLock(
+          aliceAddress,
+          fromPolicy,
+          toPolicy,
+          ethers.parseEther("100"),
+        ),
+      ).to.emit(token, "ActiveLockRelinked");
+    });
+
+    it("relink rejects an Absolute source policy with vested principal", async function () {
+      const { token, admin, alice } = await loadFixture(deploy);
+      const aliceAddress = await alice.getAddress();
+      const start = BigInt(await time.latest()) + DAY;
+
+      const fromPolicy = await createLinearPolicy(token, admin, "ABS_VEST", {
+        anchor: 0,
+        start,
+        vestDuration: 10n * DAY,
+      });
+      const toPolicy = await createLinearPolicy(token, admin, "ABS_TO", {
+        vestDuration: 2n * YEAR,
+      });
+      const amount = ethers.parseEther("1000");
+
+      await token.connect(admin).mintAllocations([
+        {
+          recipient: aliceAddress,
+          amount,
+          policyId: fromPolicy,
+          label: ethers.encodeBytes32String("abs"),
+        },
+      ]);
+      await time.increaseTo(start + 5n * DAY);
+
+      await expect(
+        token.connect(admin).relinkActiveLock(
+          aliceAddress,
+          fromPolicy,
+          toPolicy,
+          ethers.parseEther("100"),
+        ),
+      )
+        .to.be.revertedWithCustomError(token, "RelinkSourceAlreadyVested")
+        .withArgs(fromPolicy);
+    });
+
     it("relink reverts after TGE", async function () {
       const { token, admin, alice, ccaEnd } = await loadFixture(deploy);
       const aliceAddress = await alice.getAddress();


### PR DESCRIPTION
## What changed

Rejects pre-TGE relinks from absolute policies once any principal has already vested.

## Why

Zenith audit issue 8 found that relinking vested absolute-policy principal could revoke transferability by moving it under a new policy.

## Validation

- `pnpm --dir packages/interfold-contracts test test/Token/InterfoldToken.spec.ts test/Token/InterfoldTicketToken.spec.ts`
- Push hooks passed: lint, pnpm version check, license headers, committee consistency
- Noir circuit checks were skipped by the hook because `nargo` is not installed
