### PR TITLE
fix: reject conflicting queued claim policies

### DIFF
--- a/packages/interfold-contracts/contracts/token/InterfoldToken.sol
+++ b/packages/interfold-contracts/contracts/token/InterfoldToken.sol
@@ -145,6 +145,14 @@ contract InterfoldToken is
     ///         policy entries.
     error TooManyQueuedLocks();
 
+    /// @notice A queued CCA claim bucket already exists under a different
+    ///         policy. Claim transfers do not carry a bucket id, so queued
+    ///         matching must remain unambiguous.
+    error ConflictingQueuedClaimPolicy(
+        bytes32 existingPolicyId,
+        bytes32 newPolicyId
+    );
+
     /// @notice The policy id is already defined; policies are write-once.
     error PolicyAlreadyDefined(bytes32 policyId);
 
@@ -777,6 +785,7 @@ contract InterfoldToken is
 
         // Whatever is left queues under the target policy.
         if (remaining != 0) {
+            _validateQueuedClaimPolicy(account, policyId);
             _addOrIncrementLock(
                 account,
                 queuedLocks[account],
@@ -868,6 +877,23 @@ contract InterfoldToken is
             emit QueuedLockUpdated(account, policyId, amount);
         }
         return amount;
+    }
+
+    function _validateQueuedClaimPolicy(
+        address account,
+        bytes32 policyId
+    ) internal view {
+        Lock[] storage entries = queuedLocks[account];
+        uint256 len = entries.length;
+        for (uint256 i = 0; i < len; i++) {
+            bytes32 existingPolicyId = entries[i].policyId;
+            if (existingPolicyId != policyId) {
+                revert ConflictingQueuedClaimPolicy(
+                    existingPolicyId,
+                    policyId
+                );
+            }
+        }
     }
 
     function _removeLockAt(Lock[] storage entries, uint256 index) internal {

--- a/packages/interfold-contracts/test/Token/InterfoldToken.spec.ts
+++ b/packages/interfold-contracts/test/Token/InterfoldToken.spec.ts
@@ -1239,31 +1239,22 @@ describe("InterfoldToken", function () {
       ).to.be.revertedWithCustomError(token, "TooManyLocks");
     });
 
-    it("MAX_QUEUED_LOCKS_PER_ACCOUNT: 9th queued policy reverts", async function () {
+    it("repeated queued links under one policy increment one queued bucket", async function () {
       const { token, admin, alice } = await loadFixture(deploy);
       const aliceAddress = await alice.getAddress();
       const maxQueued = Number(await token.MAX_QUEUED_LOCKS_PER_ACCOUNT());
-
-      // Create 8 distinct policies and queue links.
-      for (let i = 0; i < maxQueued; i++) {
-        const policyId = ethers.encodeBytes32String(`QCAP_${i}`);
-        await createLinearPolicy(token, admin, `QCAP_${i}`, {
-          vestDuration: 1n * YEAR,
-        });
-        await token.connect(admin).linkClaim(aliceAddress, 1n, policyId);
-      }
-      expect(await token.queuedLockCount(aliceAddress)).to.equal(
-        BigInt(maxQueued),
-      );
-
-      // 9th queued link should revert.
-      const ninthId = ethers.encodeBytes32String("QCAP_9");
-      await createLinearPolicy(token, admin, "QCAP_9", {
+      const policyId = await createLinearPolicy(token, admin, "QCAP", {
         vestDuration: 1n * YEAR,
       });
-      await expect(
-        token.connect(admin).linkClaim(aliceAddress, 1n, ninthId),
-      ).to.be.revertedWithCustomError(token, "TooManyQueuedLocks");
+
+      for (let i = 0; i < maxQueued + 1; i++) {
+        await token.connect(admin).linkClaim(aliceAddress, 1n, policyId);
+      }
+
+      expect(await token.queuedLockCount(aliceAddress)).to.equal(1n);
+      const queuedLock = await token.queuedLocks(aliceAddress, 0);
+      expect(queuedLock.policyId).to.equal(policyId);
+      expect(queuedLock.amount).to.equal(BigInt(maxQueued + 1));
     });
 
     it("incrementing an existing policy does not count as a new entry", async function () {
@@ -1700,6 +1691,41 @@ describe("InterfoldToken", function () {
       // rounding from vesting elapsed seconds).
       const lb2 = await token.lockedBalanceOf(await alice.getAddress());
       expect(lb2).to.be.closeTo(linkAmount, ethers.parseEther("0.01"));
+    });
+
+    it("linkClaim rejects a conflicting queued policy for the same account", async function () {
+      const { token, admin, alice } = await loadFixture(deploy);
+      const aliceAddress = await alice.getAddress();
+      const policyA = await createLinearPolicy(token, admin, "QUEUE_A", {
+        vestDuration: 2n * YEAR,
+      });
+      const policyB = await createLinearPolicy(token, admin, "QUEUE_B", {
+        vestDuration: 4n * YEAR,
+      });
+
+      await token.connect(admin).linkClaim(aliceAddress, 100n, policyA);
+
+      await expect(
+        token.connect(admin).linkClaim(aliceAddress, 100n, policyB),
+      )
+        .to.be.revertedWithCustomError(token, "ConflictingQueuedClaimPolicy")
+        .withArgs(policyA, policyB);
+    });
+
+    it("linkClaim can increment the existing queued policy", async function () {
+      const { token, admin, alice } = await loadFixture(deploy);
+      const aliceAddress = await alice.getAddress();
+      const policyId = await createLinearPolicy(token, admin, "QUEUE_SAME", {
+        vestDuration: 2n * YEAR,
+      });
+
+      await token.connect(admin).linkClaim(aliceAddress, 100n, policyId);
+      await token.connect(admin).linkClaim(aliceAddress, 200n, policyId);
+
+      expect(await token.queuedLockCount(aliceAddress)).to.equal(1n);
+      const queuedLock = await token.queuedLocks(aliceAddress, 0);
+      expect(queuedLock.policyId).to.equal(policyId);
+      expect(queuedLock.amount).to.equal(300n);
     });
 
     it("linkClaim partly consumes PENDING and queues the remainder", async function () {


### PR DESCRIPTION
## What changed

Rejects conflicting queued claim policy buckets for the same account while allowing repeated links under the same policy to increment the existing bucket.

## Why

Zenith audit issue 12 found that multiple queued CCA buckets could make later claims attach to the wrong policy.

## Validation

- `pnpm --dir packages/interfold-contracts test test/Token/InterfoldToken.spec.ts test/Token/InterfoldTicketToken.spec.ts`
- Push hooks passed: lint, pnpm version check, license headers, committee consistency
- Noir circuit checks were skipped by the hook because `nargo` is not installed
