### PR TITLE
docs: mark FOLD auction live and add Start Here link

### DIFF
--- a/docs/pages/faq/auction.mdx
+++ b/docs/pages/faq/auction.mdx
@@ -33,13 +33,13 @@ participant demand. The result is intended to support a more transparent and ord
 
 ## Where can I participate in the FOLD token auction?
 
-The FOLD token auction will be accessible through the Uniswap web app. The official auction page,
-participation instructions, and relevant contract details will be published through Interfold's
-verified channels before the auction opens.
+The FOLD token auction is accessible through the Uniswap web app. The official auction page,
+participation instructions, and relevant contract details can be found using the link below.
 
-<Callout type='warning'>
-  The auction is **not yet live**. Treat any currently active link claiming to offer access to the
-  FOLD auction or FOLD tokens as **fraudulent**.
+[FOLD Auction: Start Here](https://www.theinterfold.com/fold-auction)
+
+<Callout type='info'>
+  The auction is **currently live**.
 </Callout>
 
 Official updates will only be published through:


### PR DESCRIPTION
## What

Updates the auction FAQ (`docs/pages/faq/auction.mdx`) to reflect that the FOLD token auction is now live.

- Reworded the "Where can I participate" paragraph from future tense ("will be accessible", "will be published through verified channels") to present tense, and added a **FOLD Auction: Start Here** link → https://www.theinterfold.com/fold-auction
- Changed the status callout from `warning` ("The auction is **not yet live**…") to `info` ("The auction is **currently live**.")

## Note for reviewers

This edit removes the previous anti-scam sentence ("treat any active link… as fraudulent") that lived in the callout. If we want to retain a fraud warning now that the auction is live, happy to add a trimmed version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)