### PR TITLE
fix(crisp): install interfold CLI matching the active dev profile

### DIFF
--- a/examples/CRISP/scripts/dev_cipher.sh
+++ b/examples/CRISP/scripts/dev_cipher.sh
@@ -32,8 +32,45 @@ sync_interfold_circuit_artifacts
 
 # using & instead of -d so that wait works below
 interfold nodes up -v &
+SWARM_PID=$!
 
-sleep 2
+# `nodes up` keeps running even when every node it supervises has exited, so leaving it behind on
+# an early exit would orphan it - and the next run wipes .interfold/data out from under it.
+cleanup_swarm() {
+  kill -TERM "$SWARM_PID" 2>/dev/null || true
+}
+trap cleanup_swarm EXIT
+
+# A node counts as `Started` as soon as its process is spawned, which is earlier than the point
+# where it is actually usable, so a single sample can catch a node that is about to die. Require
+# the full count to hold across consecutive samples instead.
+# Match the STATUS column exactly: node names come from this config, so a substring match over
+# the whole line could be satisfied by a node name rather than by a real status.
+EXPECTED_NODES=$(yq -r '.nodes | length' ./interfold.config.yaml)
+REQUIRED_STABLE_SAMPLES=3
+STABLE_SAMPLES=0
+STARTED_NODES=0
+
+for _ in $(seq 1 60); do
+  STARTED_NODES=$(interfold nodes ps 2>/dev/null | awk 'NR > 1 && $2 == "Started"' | wc -l | tr -d ' ')
+  if [[ "$STARTED_NODES" -eq "$EXPECTED_NODES" ]]; then
+    STABLE_SAMPLES=$((STABLE_SAMPLES + 1))
+  else
+    STABLE_SAMPLES=0
+  fi
+  if [[ "$STABLE_SAMPLES" -ge "$REQUIRED_STABLE_SAMPLES" ]]; then
+    break
+  fi
+  sleep 1
+done
+
+if [[ "$STABLE_SAMPLES" -lt "$REQUIRED_STABLE_SAMPLES" ]]; then
+  echo "ERROR: only ${STARTED_NODES}/${EXPECTED_NODES} ciphernodes stayed up. Current status:" >&2
+  interfold nodes ps >&2 || true
+  echo "See the node output above for the cause. If it mentions a missing Cargo feature, the" >&2
+  echo "installed interfold binary does not match this dev profile - re-run 'pnpm dev:setup'." >&2
+  exit 1
+fi
 
 CN1=$(cat ./interfold.config.yaml | yq -r '.nodes.cn1.address')
 CN2=$(cat ./interfold.config.yaml | yq -r '.nodes.cn2.address')

--- a/examples/CRISP/scripts/setup.sh
+++ b/examples/CRISP/scripts/setup.sh
@@ -26,11 +26,17 @@ apply_crisp_dev_config_to_server_env
 echo "client"
 (cd ./client && if [[ ! -f .env ]]; then cp .env.example .env; fi)
 echo "ciphernode"
-if [[ ! -f ~/.cargo/bin/interfold ]]; then
-  echo "Building and installing interfold CLI..."
-  (cd "${REPO_ROOT}" && cargo build --locked -p e3-cli && cargo install --locked --path crates/cli)
-else
-  echo "interfold CLI already installed, skipping build"
+# `load_crisp_dev_config` exports E3_NODES__CN*__SKIP_PROOF_AGGREGATION from this profile.
+# The node rejects that setting unless the binary carries the matching Cargo feature, so the
+# feature selection has to follow the profile or every ciphernode exits on startup.
+INTERFOLD_FEATURES=""
+if [[ "$CRISP_SKIP_PROOF_AGGREGATION" == "true" ]]; then
+  INTERFOLD_FEATURES="--features test-only-skip-proof-aggregation"
 fi
+echo "Building and installing interfold CLI (${INTERFOLD_FEATURES:-no extra features})..."
+# Always reinstall: `cargo install --path` rebuilds and replaces in place, so a stale binary
+# from an earlier checkout (or an earlier profile) cannot silently survive.
+# shellcheck disable=SC2086
+(cd "${REPO_ROOT}" && cargo install --locked --path crates/cli $INTERFOLD_FEATURES)
 
 print_crisp_dev_config_summary


### PR DESCRIPTION
# fix(crisp): install interfold CLI matching the active dev profile

## Reproduction

Clean checkout, default profile, following the README:

```bash
git submodule update --init --recursive
cd examples/CRISP
pnpm dev:setup
pnpm dev:up
./target/debug/cli init                      # E3 request succeeds
./target/debug/cli check-e3-ready --e3id 0   # -> false, forever
```

The UI shows `No active poll found` indefinitely. The cause is only visible by scrolling back
through the `dev:up` output to the node startup lines:

```
[cn1] `skip_proof_aggregation` is test/CI-only and this binary was built without the `test-only-skip-proof-aggregation` Cargo feature
[cn2] ... (same for all five)
```

`interfold nodes ps` then reports `0` nodes `Started` while the supervisor `interfold nodes up` is
still alive — which is why nothing downstream notices.

## Why this has not been caught

Three layers each avoid the broken path:

1. **CI never runs `setup.sh`.** `build_interfold_cli` (`.github/workflows/ci.yml:633`) builds the
   CLI **with** the feature and uploads it as an artifact:

   ```yaml
   run: cargo install --locked --path crates/cli --bin interfold --features test-only-skip-proof-aggregation
   ```

   `crisp_e2e` downloads that artifact and reimplements the rest of setup as individual YAML steps.
   So CI is green while the documented local path is broken.

2. **The skip guard hides it from existing developers.** Because of
   `if [[ ! -f ~/.cargo/bin/interfold ]]`, anyone who already has the binary never rebuilds, so
   `dev:setup` cannot surface or fix the mismatch.

3. **The Vercel deployment only builds the client**, using `--ignore-workspace` and the published
   SDK, so it never touches the Rust workspace or ciphernodes.

## What was wrong

`scripts/lib/dev_config.sh` exports `E3_NODES__CN*__SKIP_PROOF_AGGREGATION` from the active profile
(default `true`), but `scripts/setup.sh` installed the CLI without the matching
`test-only-skip-proof-aggregation` feature. Every ciphernode then exited at startup, and because
`dev_cipher.sh` started the swarm with `interfold nodes up -v &` and never checked it, the script
went on to register the ciphernodes on-chain, write the ready file, and bring up the UI. The only
symptom was `No active poll found`.

CI does not hit this because `build_interfold_cli` already passes the feature explicitly
(`ci.yml:633`) and `crisp_e2e` consumes that artifact instead of running `setup.sh`. This PR makes
`setup.sh` agree with CI.

## Changes

**`scripts/setup.sh`**

- Select `--features test-only-skip-proof-aggregation` when the profile sets
  `CRISP_SKIP_PROOF_AGGREGATION=true`, and nothing extra otherwise.
- Always reinstall instead of skipping when `~/.cargo/bin/interfold` exists. `cargo install --path`
  rebuilds and replaces in place, so this also stops a stale binary from surviving a checkout
  change. The redundant `cargo build -p e3-cli` before the install is dropped.

**`scripts/dev_cipher.sh`**

- Wait for every node in `interfold.config.yaml` to report `Started` before registering ciphernodes,
  and abort with the current `interfold nodes ps` table plus a pointer to `pnpm dev:setup` when they
  do not.
- Require the count to hold across consecutive samples. A node is reported `Started` as soon as its
  process is spawned, which is earlier than the point where it is usable, so a single sample can
  accept a node that is about to die.
- Match the `STATUS` column with `awk` rather than grepping the whole line — node names come from
  the config, so a node named e.g. `not-Started-yet` would otherwise be counted as healthy.
- Add an `EXIT` trap that terminates the swarm supervisor. Without it the new early `exit` would
  orphan `interfold nodes up`, and the next run deletes `.interfold/data` out from under it.

## Verification

All on macOS 15 (arm64), against a clean stack.

| Scenario | Result |
| --- | --- |
| 5 healthy nodes | count stable at 5/5, proceeds, `CIPHERNODES HAVE BEEN ADDED` |
| CLI installed without the feature (the bug) | `only 0/5 ciphernodes stayed up`, aborts; no on-chain registration, no UI |
| One node stopped (`interfold nodes stop cn3`) | count 4/5, would abort |
| Node named `not-Started-yet` (synthetic `ps` output) | old `grep -c` counted 1, new `awk` counts 0 |
| Supervisor cleanup | `SIGTERM` to supervisor: children exit, all five QUIC ports released |
| `setup.sh` with `CRISP_SKIP_PROOF_AGGREGATION=true` | installs with the feature, `Replaced package` |
| `setup.sh` with `CRISP_SKIP_PROOF_AGGREGATION=false` | installs with no extra features |
| Full regression | `cli init` -> committee key published in 45s (unchanged from before) |

`bash -n` passes on both scripts. There is no shellcheck step in CI or the hooks, but the
`# shellcheck disable=SC2086` annotation matches the convention used elsewhere in these scripts.

## Notes for reviewers

- The unquoted `$INTERFOLD_FEATURES` expansion is intentional word-splitting of a fixed internal
  literal. An array was avoided because the empty-array expansion is not safe under `set -u` on
  bash 3.2, which is what ships with macOS.
- `interfold nodes ps` renders the derived `Debug` of an internal `ProcessStatus` enum
  (`Started` / `Stopped` / `Exited { .. }` / `Unknown`), so it is not a stable CLI contract. If a
  status like `Restarting` is ever added, this check needs revisiting. A dedicated readiness state
  exposed by the CLI would be a better long-term signal than process liveness.
- Always reinstalling costs roughly 30s of incremental `cargo install` on repeat `dev:setup` runs.
  That seemed a fair trade against silently keeping a wrong binary, but happy to gate it if you
  prefer.
