### PR TITLE
chore: requester decides census mode

### DIFF
--- a/examples/CRISP/packages/crisp-contracts/contracts/CRISPProgram.sol
+++ b/examples/CRISP/packages/crisp-contracts/contracts/CRISPProgram.sol
@@ -24,6 +24,27 @@ contract CRISPProgram is IE3Program, Ownable {
     CUSTOM
   }
 
+  /// @notice Where the eligible voter set for a round comes from.
+  /// @dev Two sources with opposite economics. TOKEN derives the electorate from balances at a
+  /// snapshot: the coordinator enumerates holders, which is expensive and needs an indexer, but it
+  /// is the only way to answer "everyone holding this token". BY_REQUESTER asks the requesting
+  /// contract, which already knows its own membership — a game roster, an allowlisted cohort, a
+  /// committee — so nothing is enumerated and no indexer is involved.
+  ///
+  /// Declared explicitly rather than inferred. A coordinator that probed every requester and
+  /// silently fell back on failure would turn a broken census provider into a token vote with the
+  /// wrong electorate, and nothing would error.
+  ///
+  /// Required, not optional: params must carry it. Making it defaultable would mean a caller that
+  /// forgot it silently got token discovery, which is the same silent-wrong-electorate failure one
+  /// level up.
+  enum CensusMode {
+    /// @notice Derived from token balances by the coordinator. The default.
+    TOKEN,
+    /// @notice Supplied by the requester via `getCensus(uint256 e3Id) returns (address[])`.
+    BY_REQUESTER
+  }
+
   /// @notice Struct to store all data related to a voting round
   struct RoundData {
     uint256 merkleRoot;
@@ -32,6 +53,7 @@ contract CRISPProgram is IE3Program, Ownable {
     LazyIMTData votes;
     uint256 numOptions;
     CreditMode creditMode;
+    CensusMode censusMode;
   }
 
   // Constants
@@ -68,6 +90,10 @@ contract CRISPProgram is IE3Program, Ownable {
   error InvalidMerkleRoot();
   error MerkleRootAlreadySet();
   error InvalidTallyLength();
+  /// @notice A requester-supplied census names who may vote, not how much each vote weighs, so it
+  /// only has meaning when every voter carries the same credits.
+  error CensusModeRequiresConstantCredits();
+  error InvalidCensusMode();
   error SlotIsEmpty();
   error MerkleRootNotSet();
   error InvalidNumOptions();
@@ -150,6 +176,16 @@ contract CRISPProgram is IE3Program, Ownable {
     numberOfVotes = round.votes.numberOfLeaves;
   }
 
+  /// @notice The census source a round was requested with.
+  /// @dev A separate getter rather than a sixth return value on `getRoundData`, whose tuple is
+  /// already consumed by the server and the SDK — widening it would break them for a field most
+  /// callers do not want.
+  /// @param e3Id The E3 to look up.
+  /// @return The census mode recorded at validation.
+  function censusModeOf(uint256 e3Id) external view returns (CensusMode) {
+    return e3Data[e3Id].censusMode;
+  }
+
   /// @inheritdoc IE3Program
   function validate(
     uint256 e3Id,
@@ -161,16 +197,32 @@ contract CRISPProgram is IE3Program, Ownable {
     if (msg.sender != address(interfold) && msg.sender != owner()) revert CallerNotAuthorized();
     if (e3Data[e3Id].paramsHash != bytes32(0)) revert E3AlreadyInitialized();
 
-    // decode custom params to get the number of options
-    (, , uint256 numOptions, CreditMode creditMode, ) = abi.decode(customParams, (address, uint256, uint256, CreditMode, uint256));
-    // The circuit rejects anything above MAX_VOTE_OPTIONS, so a round configured beyond
-    // it could never accept a ballot. Reject at creation rather than stranding the round.
-    if (numOptions < 2 || numOptions > MAX_VOTE_OPTIONS) revert InvalidNumOptions();
+    // Scoped so the decoded values do not outlive their use: `validate` is close enough to the
+    // stack limit that holding all six of them alongside the parameters exceeds it.
+    {
+      // One decode, every field required. `censusMode` is read as a uint and range-checked rather
+      // than decoded straight into the enum, so an unrecognised value gives a named error instead
+      // of a bare panic.
+      (, , uint256 numOptions, CreditMode creditMode, , uint256 rawCensusMode) = abi.decode(
+        customParams,
+        (address, uint256, uint256, CreditMode, uint256, uint256)
+      );
+      if (numOptions < 2) revert InvalidNumOptions();
+      if (rawCensusMode > uint256(type(CensusMode).max)) revert InvalidCensusMode();
 
-    // we need to know the number of options for decoding the tally
-    e3Data[e3Id].numOptions = numOptions;
-    // we want to save the credit mode so it can be verified on chain by everyone
-    e3Data[e3Id].creditMode = creditMode;
+      // Rejected here rather than by the coordinator, so a combination that can never work costs
+      // nothing: this reverts in the same transaction that requests the E3, before any fee is paid.
+      if (CensusMode(rawCensusMode) == CensusMode.BY_REQUESTER && creditMode != CreditMode.CONSTANT) {
+        revert CensusModeRequiresConstantCredits();
+      }
+
+      // we need to know the number of options for decoding the tally
+      e3Data[e3Id].numOptions = numOptions;
+      // we want to save the credit mode so it can be verified on chain by everyone
+      e3Data[e3Id].creditMode = creditMode;
+      // recorded so anyone can verify which electorate the round was requested against
+      e3Data[e3Id].censusMode = CensusMode(rawCensusMode);
+    }
 
     e3Data[e3Id].paramsHash = keccak256(e3ProgramParams);
 

--- a/examples/CRISP/packages/crisp-contracts/contracts/CRISPProgram.sol
+++ b/examples/CRISP/packages/crisp-contracts/contracts/CRISPProgram.sol
@@ -207,7 +207,9 @@ contract CRISPProgram is IE3Program, Ownable {
         customParams,
         (address, uint256, uint256, CreditMode, uint256, uint256)
       );
-      if (numOptions < 2) revert InvalidNumOptions();
+      // The circuit asserts `num_options <= MAX_OPTIONS`, so a round configured above it accepts no
+      // ballot at all. Reject at request time rather than stranding a round nobody can vote in.
+      if (numOptions < 2 || numOptions > MAX_VOTE_OPTIONS) revert InvalidNumOptions();
       if (rawCensusMode > uint256(type(CensusMode).max)) revert InvalidCensusMode();
 
       // Rejected here rather than by the coordinator, so a combination that can never work costs

--- a/examples/CRISP/packages/crisp-contracts/contracts/Mocks/MockInterfold.sol
+++ b/examples/CRISP/packages/crisp-contracts/contracts/Mocks/MockInterfold.sol
@@ -38,7 +38,7 @@ contract MockInterfold {
       encryptionSchemeId: bytes32(0),
       e3Program: IE3Program(address(0)),
       paramSet: 0, // Insecure512
-      customParams: abi.encode(address(0), nextE3Id, numOptions, 0, 0),
+      customParams: abi.encode(address(0), nextE3Id, numOptions, 0, 0, 0),
       decryptionVerifier: IDecryptionVerifier(address(0)),
       pkVerifier: IPkVerifier(address(0)),
       committeePublicKey: committeePublicKey,
@@ -48,7 +48,7 @@ contract MockInterfold {
       ciphertextCommitment: bytes32(0)
     });
 
-    IE3Program(program).validate(nextE3Id, 0, bytes(""), bytes(""), abi.encode(address(0), nextE3Id, numOptions, 0, 0));
+    IE3Program(program).validate(nextE3Id, 0, bytes(""), bytes(""), abi.encode(address(0), nextE3Id, numOptions, 0, 0, 0));
 
     nextE3Id++;
   }
@@ -75,7 +75,7 @@ contract MockInterfold {
         encryptionSchemeId: bytes32(0),
         e3Program: IE3Program(address(0)),
         paramSet: 0, // Insecure512
-        customParams: abi.encode(address(0), 0, 2, 0, 0),
+        customParams: abi.encode(address(0), 0, 2, 0, 0, 0),
         decryptionVerifier: IDecryptionVerifier(address(0)),
         pkVerifier: IPkVerifier(address(0)),
         committeePublicKey: committeePublicKey,

--- a/examples/CRISP/packages/crisp-contracts/tests/census-mode.test.ts
+++ b/examples/CRISP/packages/crisp-contracts/tests/census-mode.test.ts
@@ -35,14 +35,7 @@ describe('CRISPProgram census mode', function () {
     return ethers.AbiCoder.defaultAbiCoder().encode(types, values)
   }
 
-  const encodeWithOptions = (numOptions: number, censusMode: number) =>
-    ethers.AbiCoder.defaultAbiCoder().encode(
-      ['address', 'uint256', 'uint256', 'uint256', 'uint256', 'uint256'],
-      [ethers.ZeroAddress, 0, numOptions, CONSTANT, 1, censusMode],
-    )
-
-  const validate = (e3Id: number, params: string) =>
-    crispProgram.validate(e3Id, 0, '0x', '0x', params)
+  const validate = (e3Id: number, params: string) => crispProgram.validate(e3Id, 0, '0x', '0x', params)
 
   beforeEach(async () => {
     crispProgram = await deployCRISPProgram()
@@ -71,10 +64,7 @@ describe('CRISPProgram census mode', function () {
   /// each vote weighs. Rejected on chain so it costs nothing rather than failing in the indexer
   /// after the E3 has been paid for.
   it('rejects BY_REQUESTER with custom credits', async () => {
-    await expect(validate(4, encode(CUSTOM, BY_REQUESTER))).to.be.revertedWithCustomError(
-      crispProgram,
-      'CensusModeRequiresConstantCredits',
-    )
+    await expect(validate(4, encode(CUSTOM, BY_REQUESTER))).to.be.revertedWithCustomError(crispProgram, 'CensusModeRequiresConstantCredits')
   })
 
   it('still allows custom credits with token discovery', async () => {
@@ -85,9 +75,6 @@ describe('CRISPProgram census mode', function () {
   /// An unrecognised mode is a coordinator that would not know what to do. Better to refuse the
   /// round than to have it silently treated as a token vote.
   it('rejects an unknown census mode', async () => {
-    await expect(validate(6, encode(CONSTANT, 2))).to.be.revertedWithCustomError(
-      crispProgram,
-      'InvalidCensusMode',
-    )
+    await expect(validate(6, encode(CONSTANT, 2))).to.be.revertedWithCustomError(crispProgram, 'InvalidCensusMode')
   })
 })

--- a/examples/CRISP/packages/crisp-contracts/tests/census-mode.test.ts
+++ b/examples/CRISP/packages/crisp-contracts/tests/census-mode.test.ts
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+//
+// This file is provided WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE.
+
+import { expect } from 'chai'
+import { deployCRISPProgram, ethers } from './utils'
+import type { CRISPProgram } from '../types'
+
+const CONSTANT = 0
+const CUSTOM = 1
+const TOKEN = 0
+const BY_REQUESTER = 1
+
+/// `censusMode` says where a round's electorate comes from, and it is declared rather than inferred.
+///
+/// A coordinator that probed every requester and fell back on failure would turn a broken census
+/// provider into a token vote over the wrong voters — the round would run, and nothing would error.
+/// Declaring it also means an impossible combination can be rejected here, in the transaction that
+/// requests the E3, rather than by the coordinator minutes later after the fee has been paid.
+describe('CRISPProgram census mode', function () {
+  this.timeout(120000)
+
+  let crispProgram: CRISPProgram
+  let owner: string
+
+  const encode = (creditMode: number, censusMode?: number) => {
+    const types = ['address', 'uint256', 'uint256', 'uint256', 'uint256']
+    const values: unknown[] = [ethers.ZeroAddress, 0, 2, creditMode, 1]
+    if (censusMode !== undefined) {
+      types.push('uint256')
+      values.push(censusMode)
+    }
+    return ethers.AbiCoder.defaultAbiCoder().encode(types, values)
+  }
+
+  const encodeWithOptions = (numOptions: number, censusMode: number) =>
+    ethers.AbiCoder.defaultAbiCoder().encode(
+      ['address', 'uint256', 'uint256', 'uint256', 'uint256', 'uint256'],
+      [ethers.ZeroAddress, 0, numOptions, CONSTANT, 1, censusMode],
+    )
+
+  const validate = (e3Id: number, params: string) =>
+    crispProgram.validate(e3Id, 0, '0x', '0x', params)
+
+  beforeEach(async () => {
+    crispProgram = await deployCRISPProgram()
+    owner = (await ethers.getSigners())[0].address
+    expect(await crispProgram.owner()).to.equal(owner, 'validate is owner-callable in these tests')
+  })
+
+  /// Required, not optional. A caller that omits it must fail loudly rather than silently receive
+  /// token discovery — which is the same silent-wrong-electorate failure this enum exists to stop,
+  /// one level up.
+  it('rejects params without a census mode', async () => {
+    await expect(validate(1, encode(CONSTANT))).to.be.revert(ethers)
+  })
+
+  it('records a declared TOKEN mode', async () => {
+    await validate(2, encode(CONSTANT, TOKEN))
+    expect(await crispProgram.censusModeOf(2)).to.equal(TOKEN)
+  })
+
+  it('records a declared BY_REQUESTER mode', async () => {
+    await validate(3, encode(CONSTANT, BY_REQUESTER))
+    expect(await crispProgram.censusModeOf(3)).to.equal(BY_REQUESTER)
+  })
+
+  /// The pairing that cannot work: a requester-supplied census names who may vote, not how much
+  /// each vote weighs. Rejected on chain so it costs nothing rather than failing in the indexer
+  /// after the E3 has been paid for.
+  it('rejects BY_REQUESTER with custom credits', async () => {
+    await expect(validate(4, encode(CUSTOM, BY_REQUESTER))).to.be.revertedWithCustomError(
+      crispProgram,
+      'CensusModeRequiresConstantCredits',
+    )
+  })
+
+  it('still allows custom credits with token discovery', async () => {
+    await validate(5, encode(CUSTOM, TOKEN))
+    expect(await crispProgram.censusModeOf(5)).to.equal(TOKEN)
+  })
+
+  /// An unrecognised mode is a coordinator that would not know what to do. Better to refuse the
+  /// round than to have it silently treated as a token vote.
+  it('rejects an unknown census mode', async () => {
+    await expect(validate(6, encode(CONSTANT, 2))).to.be.revertedWithCustomError(
+      crispProgram,
+      'InvalidCensusMode',
+    )
+  })
+})

--- a/examples/CRISP/packages/crisp-contracts/tests/census-mode.test.ts
+++ b/examples/CRISP/packages/crisp-contracts/tests/census-mode.test.ts
@@ -12,6 +12,8 @@ const CONSTANT = 0
 const CUSTOM = 1
 const TOKEN = 0
 const BY_REQUESTER = 1
+/// Mirrors `MAX_VOTE_OPTIONS` in CRISPProgram.sol, which is not public.
+const MAX_VOTE_OPTIONS = 10
 
 /// `censusMode` says where a round's electorate comes from, and it is declared rather than inferred.
 ///
@@ -25,9 +27,9 @@ describe('CRISPProgram census mode', function () {
   let crispProgram: CRISPProgram
   let owner: string
 
-  const encode = (creditMode: number, censusMode?: number) => {
+  const encode = (creditMode: number, censusMode?: number, numOptions = 2) => {
     const types = ['address', 'uint256', 'uint256', 'uint256', 'uint256']
-    const values: unknown[] = [ethers.ZeroAddress, 0, 2, creditMode, 1]
+    const values: unknown[] = [ethers.ZeroAddress, 0, numOptions, creditMode, 1]
     if (censusMode !== undefined) {
       types.push('uint256')
       values.push(censusMode)
@@ -76,5 +78,24 @@ describe('CRISPProgram census mode', function () {
   /// round than to have it silently treated as a token vote.
   it('rejects an unknown census mode', async () => {
     await expect(validate(6, encode(CONSTANT, 2))).to.be.revertedWithCustomError(crispProgram, 'InvalidCensusMode')
+  })
+
+  /// The circuit asserts `num_options <= MAX_OPTIONS`, so a round above the cap accepts no ballot:
+  /// every vote proof fails. Refuse it at request time rather than storing a round nobody can
+  /// vote in. Mirrors `MAX_VOTE_OPTIONS` in CRISPProgram.sol, which is not public.
+  it('rejects more options than the circuit allows', async () => {
+    await expect(validate(7, encode(CONSTANT, TOKEN, MAX_VOTE_OPTIONS + 1))).to.be.revertedWithCustomError(
+      crispProgram,
+      'InvalidNumOptions',
+    )
+  })
+
+  it('accepts a round at exactly MAX_VOTE_OPTIONS options', async () => {
+    await validate(8, encode(CONSTANT, TOKEN, MAX_VOTE_OPTIONS))
+    expect(await crispProgram.censusModeOf(8)).to.equal(TOKEN)
+  })
+
+  it('rejects fewer than two options', async () => {
+    await expect(validate(9, encode(CONSTANT, TOKEN, 1))).to.be.revertedWithCustomError(crispProgram, 'InvalidNumOptions')
   })
 })

--- a/examples/CRISP/server/src/cli/commands.rs
+++ b/examples/CRISP/server/src/cli/commands.rs
@@ -228,6 +228,9 @@ pub async fn initialize_crisp_round(
     let credits = U256::from(1);
 
     // Serialize the custom parameters to bytes.
+    // Census mode 0 = Token: the CLI has no application contract to ask, so the coordinator derives
+    // the electorate from token balances as it always has.
+    let census_mode = U256::from(0);
     let custom_params_bytes = Bytes::from(
         (
             token_address,
@@ -235,6 +238,7 @@ pub async fn initialize_crisp_round(
             num_options,
             credit_mode,
             credits,
+            census_mode,
         )
             .abi_encode(),
     );

--- a/examples/CRISP/server/src/server/indexer.rs
+++ b/examples/CRISP/server/src/server/indexer.rs
@@ -4,9 +4,11 @@
 // without even the implied warranty of MERCHANTABILITY
 // or FITNESS FOR A PARTICULAR PURPOSE.
 
-use crate::server::token_holders::{get_mock_token_holders, EtherscanClient};
+use crate::server::token_holders::{
+    get_mock_token_holders, try_fetch_requester_census, EtherscanClient,
+};
 use crate::server::{
-    models::{CreditMode, CurrentRound, CustomParams},
+    models::{CensusMode, CreditMode, CurrentRound, CustomParams, TokenHolder},
     program_server_request::run_compute,
     repo::{CrispE3Repository, CurrentRoundRepository},
     token_holders::{build_tree, compute_token_holder_hashes},
@@ -64,12 +66,20 @@ pub async fn register_e3_requested(
                 .map_err(|e| eyre::eyre!("{}", e))?;
 
                 // Use sol_data types instead of primitives
-                type CustomParamsTuple = (sol_data::Address, sol_data::Uint<256>, sol_data::Uint<256>, sol_data::Uint<256>, sol_data::Uint<256>);
+                type CustomParamsTuple = (
+                    sol_data::Address,
+                    sol_data::Uint<256>,
+                    sol_data::Uint<256>,
+                    sol_data::Uint<256>,
+                    sol_data::Uint<256>,
+                    sol_data::Uint<256>,
+                );
 
                 let decoded = <CustomParamsTuple as SolType>::abi_decode(&event.e3.customParams)
                     .with_context(|| "Failed to decode custom params from E3 event")?;
 
                 let credit_mode = CreditMode::try_from(decoded.3.to::<u64>())?;
+                let census_mode = CensusMode::try_from(decoded.5.to::<u64>())?;
                 let credits = match credit_mode {
                     CreditMode::Constant => {
                         info!("[e3_id={}] Credit mode: Constant", e3_id);
@@ -89,6 +99,7 @@ pub async fn register_e3_requested(
                     num_options: decoded.2.to_string(),
                     credit_mode,
                     credits,
+                    census_mode,
                 };
 
                 let balance_threshold =
@@ -106,7 +117,56 @@ pub async fn register_e3_requested(
                 let snapshot_block = event.e3.requestBlock.to::<u64>().saturating_sub(1);
 
                 // Get token holders from Etherscan API or mocked data.
-                let token_holders = if matches!(CONFIG.chain_id, 31337 | 1337) {
+                // Asked only when the round declared it. Probing every requester and falling back
+                // on failure would turn a broken census provider into a token vote over the wrong
+                // electorate, silently — the round would run, and nothing would error.
+                //
+                // Checked before the local-network branch because a declared census is exact on any
+                // network, including a devnet where the mock holders would otherwise be substituted.
+                let token_holders = if custom_params.census_mode == CensusMode::ByRequester {
+                    let credits_str = match custom_params.credit_mode {
+                        CreditMode::Constant => credits_clone
+                            .clone()
+                            .expect("credits must be set for Constant mode"),
+                        // A requester-supplied census names *who* may vote, not how much each vote
+                        // weighs, so it only has meaning when every voter carries the same credits.
+                        // `CRISPProgram.validate` rejects this pairing on chain, so reaching it here
+                        // means the round was requested against a different program.
+                        CreditMode::Custom => {
+                            return Err(eyre::eyre!(
+                                "[e3_id={}] CensusMode::ByRequester requires \
+                                 CreditMode::Constant; got Custom",
+                                e3_id
+                            ))
+                        }
+                    };
+
+                    info!(
+                        "[e3_id={}] Census mode: ByRequester; asking {}",
+                        e3_id, e3.requester
+                    );
+
+                    let census =
+                        try_fetch_requester_census(e3.requester, e3_id, &CONFIG.http_rpc_url)
+                            .await
+                            .ok_or_else(|| {
+                                eyre::eyre!(
+                                    "[e3_id={}] Round declared CensusMode::ByRequester but \
+                                     requester {} returned no census. Refusing to fall back to \
+                                     token discovery, which would enfranchise the wrong voters.",
+                                    e3_id,
+                                    e3.requester
+                                )
+                            })?;
+
+                    census
+                        .into_iter()
+                        .map(|address| TokenHolder {
+                            address: address.to_string(),
+                            balance: credits_str.clone(),
+                        })
+                        .collect()
+                } else if matches!(CONFIG.chain_id, 31337 | 1337) {
                     info!(
                         "[e3_id={}] Using mocked token holders for local network (chain_id: {})",
                         e3_id, CONFIG.chain_id
@@ -459,4 +519,68 @@ pub async fn start_indexer(
     crisp_indexer.listen().await?;
     info!("CRISP: Indexer listen loop has finished!");
     Ok(())
+}
+
+#[cfg(test)]
+mod custom_params_decoding_tests {
+    use crate::server::models::CensusMode;
+    use alloy::dyn_abi::SolType;
+    use alloy::primitives::{Address, U256};
+    use alloy::sol_types::sol_data;
+
+    type CustomParamsTuple = (
+        sol_data::Address,
+        sol_data::Uint<256>,
+        sol_data::Uint<256>,
+        sol_data::Uint<256>,
+        sol_data::Uint<256>,
+        sol_data::Uint<256>,
+    );
+
+    fn encode(census_mode: u64) -> Vec<u8> {
+        <CustomParamsTuple as SolType>::abi_encode(&(
+            Address::ZERO,
+            U256::from(0),
+            U256::from(3),
+            U256::from(0),
+            U256::from(1),
+            U256::from(census_mode),
+        ))
+    }
+
+    #[test]
+    fn decodes_the_declared_census_mode() {
+        let decoded = <CustomParamsTuple as SolType>::abi_decode(&encode(1)).unwrap();
+        assert_eq!(
+            CensusMode::try_from(decoded.5.to::<u64>()).unwrap(),
+            CensusMode::ByRequester
+        );
+    }
+
+    /// Params without the field are not a legacy form to tolerate — they are malformed, and must
+    /// fail rather than be read as a token vote.
+    #[test]
+    fn params_missing_the_field_fail_to_decode() {
+        type Short = (
+            sol_data::Address,
+            sol_data::Uint<256>,
+            sol_data::Uint<256>,
+            sol_data::Uint<256>,
+            sol_data::Uint<256>,
+        );
+        let short = <Short as SolType>::abi_encode(&(
+            Address::ZERO,
+            U256::from(0),
+            U256::from(3),
+            U256::from(0),
+            U256::from(1),
+        ));
+        assert!(<CustomParamsTuple as SolType>::abi_decode(&short).is_err());
+    }
+
+    #[test]
+    fn an_unrecognised_mode_is_an_error() {
+        let decoded = <CustomParamsTuple as SolType>::abi_decode(&encode(2)).unwrap();
+        assert!(CensusMode::try_from(decoded.5.to::<u64>()).is_err());
+    }
 }

--- a/examples/CRISP/server/src/server/indexer.rs
+++ b/examples/CRISP/server/src/server/indexer.rs
@@ -78,8 +78,11 @@ pub async fn register_e3_requested(
                 let decoded = <CustomParamsTuple as SolType>::abi_decode(&event.e3.customParams)
                     .with_context(|| "Failed to decode custom params from E3 event")?;
 
-                let credit_mode = CreditMode::try_from(decoded.3.to::<u64>())?;
-                let census_mode = CensusMode::try_from(decoded.5.to::<u64>())?;
+                // `saturating_to` rather than `to`: these fields are attacker-chosen ABI data, and
+                // `to::<u64>()` panics on a value above `u64::MAX`. Clamping lets the `TryFrom`
+                // impls reject it as an unknown mode instead.
+                let credit_mode = CreditMode::try_from(decoded.3.saturating_to::<u64>())?;
+                let census_mode = CensusMode::try_from(decoded.5.saturating_to::<u64>())?;
                 let credits = match credit_mode {
                     CreditMode::Constant => {
                         info!("[e3_id={}] Credit mode: Constant", e3_id);

--- a/examples/CRISP/server/src/server/models.rs
+++ b/examples/CRISP/server/src/server/models.rs
@@ -140,6 +140,7 @@ pub struct CustomParams {
     pub num_options: String,
     pub credit_mode: CreditMode,
     pub credits: Option<String>,
+    pub census_mode: CensusMode,
 }
 
 #[derive(Debug, Deserialize)]
@@ -280,6 +281,32 @@ pub enum CreditMode {
     Custom = 1,
 }
 
+/// Where a round's eligible voter set comes from. Mirrors `CRISPProgram.CensusMode`.
+///
+/// `Token` reconstructs holders from transfer logs. `ByRequester` asks the requesting contract,
+/// which already knows its own membership.
+///
+/// Required in the params and never inferred: a round that omits it fails to decode rather than
+/// quietly becoming a token vote over the wrong people.
+#[derive(Debug, PartialEq, Clone, Copy, Serialize_repr, Deserialize_repr)]
+#[repr(u8)]
+pub enum CensusMode {
+    Token = 0,
+    ByRequester = 1,
+}
+
+impl TryFrom<u64> for CensusMode {
+    type Error = eyre::Error;
+
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(CensusMode::Token),
+            1 => Ok(CensusMode::ByRequester),
+            _ => Err(eyre::eyre!("Unknown census mode: {}", value)),
+        }
+    }
+}
+
 impl TryFrom<u64> for CreditMode {
     type Error = eyre::Error;
 
@@ -290,4 +317,24 @@ impl TryFrom<u64> for CreditMode {
             _ => Err(eyre::eyre!("Unknown credit mode: {}", value)),
         }
     }
+}
+
+#[cfg(test)]
+mod census_mode_tests {
+    use super::CensusMode;
+
+    #[test]
+    fn unknown_values_are_rejected_rather_than_defaulted() {
+        // A mode the coordinator does not understand must stop the round, not quietly become a
+        // token vote — which is the failure this enum exists to prevent.
+        assert!(CensusMode::try_from(2u64).is_err());
+        assert!(CensusMode::try_from(u64::MAX).is_err());
+    }
+
+    #[test]
+    fn known_values_round_trip() {
+        assert_eq!(CensusMode::try_from(0u64).unwrap(), CensusMode::Token);
+        assert_eq!(CensusMode::try_from(1u64).unwrap(), CensusMode::ByRequester);
+    }
+
 }

--- a/examples/CRISP/server/src/server/routes/rounds.rs
+++ b/examples/CRISP/server/src/server/routes/rounds.rs
@@ -202,7 +202,29 @@ pub async fn initialize_crisp_round(
     let balance_threshold = U256::from_str_radix(balance_threshold, 10)?;
 
     // Serialize the custom parameters to bytes.
-    let custom_params_bytes = Bytes::from((token_address, balance_threshold).abi_encode());
+    //
+    // This encoded two fields where every consumer reads six, so rounds requested through this
+    // route could never be indexed — `abi_decode` failed on them and the round was dropped. Fixed
+    // here rather than left, because a route that silently produces unusable rounds is worse than
+    // one that does not exist.
+    //
+    // Two options, constant credits of one and token-derived eligibility are the defaults this
+    // route always implied; it carries no way to express anything else.
+    let num_options = U256::from(2);
+    let credit_mode = U256::from(0); // Constant
+    let credits = U256::from(1);
+    let census_mode = U256::from(0); // Token
+    let custom_params_bytes = Bytes::from(
+        (
+            token_address,
+            balance_threshold,
+            num_options,
+            credit_mode,
+            credits,
+            census_mode,
+        )
+            .abi_encode(),
+    );
 
     info!("Requesting E3...");
     let committee_size = match CONFIG.e3_committee_size {

--- a/examples/CRISP/server/src/server/token_holders/mod.rs
+++ b/examples/CRISP/server/src/server/token_holders/mod.rs
@@ -7,7 +7,9 @@
 pub mod etherscan;
 pub mod hashes;
 pub mod merkle_tree;
+pub mod requester_census;
 
 pub use etherscan::*;
 pub use hashes::*;
 pub use merkle_tree::*;
+pub use requester_census::*;

--- a/examples/CRISP/server/src/server/token_holders/requester_census.rs
+++ b/examples/CRISP/server/src/server/token_holders/requester_census.rs
@@ -27,6 +27,11 @@ use alloy::primitives::Address;
 use alloy::providers::ProviderBuilder;
 use alloy::sol;
 use std::collections::HashSet;
+use std::time::Duration;
+
+/// Ceiling on the census `eth_call`. A requester that cannot answer within this is treated the same
+/// as one that reverts: no census, which the caller turns into a hard error.
+const CENSUS_CALL_TIMEOUT: Duration = Duration::from_secs(30);
 
 sol! {
     #[sol(rpc)]
@@ -67,19 +72,28 @@ pub async fn try_fetch_requester_census(
     // is a requirement on implementors, not an assumption: `getCensus(e3Id)` MUST be immutable once
     // the round is open, or ballots already cast against one eligibility tree would be validated
     // against another.
-    let census = match contract
-        .getCensus(alloy::primitives::U256::from(e3_id))
-        .call()
-        .await
-    {
-        Ok(census) => census,
-        Err(e) => {
+    // Alloy sets no default request timeout, so an unresponsive RPC endpoint would hang this probe
+    // indefinitely and stall the indexer on the E3 that triggered it.
+    // Bound to a `let` so the builder outlives the future that borrows it.
+    let call_builder = contract.getCensus(alloy::primitives::U256::from(e3_id));
+
+    let census = match tokio::time::timeout(CENSUS_CALL_TIMEOUT, call_builder.call()).await {
+        Ok(Ok(census)) => census,
+        Ok(Err(e)) => {
             log::info!(
-                "[e3_id={}] Requester {} does not provide a census ({}); \
-                 falling back to token-holder discovery",
+                "[e3_id={}] Requester {} did not answer getCensus ({})",
                 e3_id,
                 requester,
                 e
+            );
+            return None;
+        }
+        Err(_) => {
+            log::warn!(
+                "[e3_id={}] Requester {} census probe timed out after {:?}",
+                e3_id,
+                requester,
+                CENSUS_CALL_TIMEOUT
             );
             return None;
         }
@@ -87,8 +101,7 @@ pub async fn try_fetch_requester_census(
 
     let Some(sanitized) = sanitize_census(census) else {
         log::warn!(
-            "[e3_id={}] Requester {} returned no usable census addresses; \
-             falling back to token-holder discovery",
+            "[e3_id={}] Requester {} returned no usable census addresses",
             e3_id,
             requester
         );

--- a/examples/CRISP/server/src/server/token_holders/requester_census.rs
+++ b/examples/CRISP/server/src/server/token_holders/requester_census.rs
@@ -33,6 +33,26 @@ use std::time::Duration;
 /// as one that reverts: no census, which the caller turns into a hard error.
 const CENSUS_CALL_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Depth of the eligibility Merkle tree. Hardcoded in the Noir circuit and mirrored by
+/// `MERKLE_TREE_MAX_DEPTH` in `@crisp-e3/sdk`.
+const MERKLE_TREE_MAX_DEPTH: u32 = 20;
+
+/// Largest census this server will accept from a requester.
+///
+/// This is the tree's own capacity, not a tuning knob: the circuit verifies Merkle paths of exactly
+/// `MERKLE_TREE_MAX_DEPTH`, so an electorate above `2^depth` produces proofs it cannot check. A
+/// larger census is therefore always a round nobody can vote in.
+///
+/// It is also the trust boundary on this input. The census is chosen by the requester, and every
+/// downstream step — dedup, per-address Poseidon hashing, tree construction — is linear in its
+/// length, so an unbounded array is an unbounded amount of server work.
+const MAX_CENSUS_SIZE: usize = 1 << MERKLE_TREE_MAX_DEPTH;
+
+/// Whether a census is too large for the eligibility tree to hold.
+fn exceeds_census_capacity(len: usize) -> bool {
+    len > MAX_CENSUS_SIZE
+}
+
 sol! {
     #[sol(rpc)]
     contract ICensusProvider {
@@ -98,6 +118,20 @@ pub async fn try_fetch_requester_census(
             return None;
         }
     };
+
+    // Checked before dedup and hashing: those are what actually scale with the array, so the
+    // rejection has to happen before any of that work is done.
+    if exceeds_census_capacity(census.len()) {
+        log::warn!(
+            "[e3_id={}] Requester {} returned {} census addresses, above the {} the eligibility \
+             tree can hold; refusing rather than building a round that cannot be voted in",
+            e3_id,
+            requester,
+            census.len(),
+            MAX_CENSUS_SIZE
+        );
+        return None;
+    }
 
     let Some(sanitized) = sanitize_census(census) else {
         log::warn!(
@@ -173,5 +207,27 @@ mod tests {
     #[test]
     fn census_of_only_zero_addresses_is_rejected() {
         assert_eq!(sanitize_census(vec![Address::ZERO, Address::ZERO]), None);
+    }
+
+    #[test]
+    fn census_capacity_matches_the_tree_depth() {
+        // Pinned so raising the circuit's depth without revisiting this cap is a test failure
+        // rather than a silently under-sized electorate.
+        assert_eq!(MAX_CENSUS_SIZE, 1_048_576);
+        assert_eq!(MAX_CENSUS_SIZE, 2usize.pow(MERKLE_TREE_MAX_DEPTH));
+    }
+
+    #[test]
+    fn a_census_up_to_tree_capacity_is_accepted() {
+        assert!(!exceeds_census_capacity(0));
+        assert!(!exceeds_census_capacity(1));
+        assert!(!exceeds_census_capacity(MAX_CENSUS_SIZE - 1));
+        assert!(!exceeds_census_capacity(MAX_CENSUS_SIZE));
+    }
+
+    #[test]
+    fn a_census_above_tree_capacity_is_rejected() {
+        assert!(exceeds_census_capacity(MAX_CENSUS_SIZE + 1));
+        assert!(exceeds_census_capacity(usize::MAX));
     }
 }

--- a/examples/CRISP/server/src/server/token_holders/requester_census.rs
+++ b/examples/CRISP/server/src/server/token_holders/requester_census.rs
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+//
+// This file is provided WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE.
+
+//! Requester-provided census.
+//!
+//! The default census is reconstructed from Etherscan transfer/delegation logs, which requires an
+//! API key, only works on networks Etherscan indexes, and can only ever answer "who holds this
+//! token". Applications that already know their own membership — a game with a roster, an
+//! allowlisted cohort, a committee — can answer that question directly and exactly.
+//!
+//! When a round declares `CensusMode::ByRequester`, the requester contract is asked for its
+//! electorate via `getCensus(uint256 e3Id) returns (address[])` and the result is used verbatim.
+//! The probe is a single `eth_call` at chain head — see the comment on the call for why it is not
+//! pinned, and for the immutability that requires of implementors.
+//!
+//! There is no fallback. A round that declared `ByRequester` and cannot be answered is an error,
+//! not a round that quietly becomes a token vote with the wrong electorate.
+//!
+//! Note this returns *voters*, not ballot options. A round where the two differ (a jury voting on
+//! finalists, say) still gets its option list from the E3's `numOptions` and whatever mapping the
+//! requester publishes separately.
+
+use alloy::primitives::Address;
+use alloy::providers::ProviderBuilder;
+use alloy::sol;
+use std::collections::HashSet;
+
+sol! {
+    #[sol(rpc)]
+    contract ICensusProvider {
+        function getCensus(uint256 e3Id) external view returns (address[]);
+    }
+}
+
+/// Reads the eligible voter set from the E3 requester.
+///
+/// Returns `None` when the requester does not implement `getCensus`, the call reverts, or the
+/// result is empty. The caller decides what that means: under `CensusMode::ByRequester` it is a
+/// hard error, because the round declared an electorate nobody can produce.
+pub async fn try_fetch_requester_census(
+    requester: Address,
+    e3_id: u64,
+    rpc_url: &str,
+) -> Option<Vec<Address>> {
+    let url = match rpc_url.parse() {
+        Ok(url) => url,
+        Err(e) => {
+            log::warn!("[e3_id={}] Invalid RPC URL for census probe: {}", e3_id, e);
+            return None;
+        }
+    };
+
+    let provider = ProviderBuilder::new().connect_http(url);
+    let contract = ICensusProvider::new(requester, provider);
+
+    // Read at head rather than pinned to a historical block, for two reasons.
+    //
+    // First, there is no block number to pin to: the E3's `requestBlock` is an EIP-6372 *timestamp*,
+    // not a height, so passing it to `eth_call` asks for a block billions high and the node answers
+    // `BlockOutOfRangeError`.
+    //
+    // Second, pinning is unnecessary. The census is addressed by `e3Id`, and the contract fixes it
+    // when the round opens — the answer cannot change afterwards, so head and snapshot agree. This
+    // is a requirement on implementors, not an assumption: `getCensus(e3Id)` MUST be immutable once
+    // the round is open, or ballots already cast against one eligibility tree would be validated
+    // against another.
+    let census = match contract
+        .getCensus(alloy::primitives::U256::from(e3_id))
+        .call()
+        .await
+    {
+        Ok(census) => census,
+        Err(e) => {
+            log::info!(
+                "[e3_id={}] Requester {} does not provide a census ({}); \
+                 falling back to token-holder discovery",
+                e3_id,
+                requester,
+                e
+            );
+            return None;
+        }
+    };
+
+    let Some(sanitized) = sanitize_census(census) else {
+        log::warn!(
+            "[e3_id={}] Requester {} returned no usable census addresses; \
+             falling back to token-holder discovery",
+            e3_id,
+            requester
+        );
+        return None;
+    };
+
+    log::info!(
+        "[e3_id={}] Using requester-provided census from {}: {} eligible addresses",
+        e3_id,
+        requester,
+        sanitized.len()
+    );
+
+    Some(sanitized)
+}
+
+/// Drops zero addresses and duplicates from a requester-supplied census.
+///
+/// A duplicated address would get two Merkle leaves and therefore two ballots, so this dedupes
+/// rather than trusting the requester to have done it. First-seen order is preserved so the leaf
+/// ordering is deterministic for a given census. Returns `None` when nothing usable remains.
+fn sanitize_census(census: Vec<Address>) -> Option<Vec<Address>> {
+    let mut seen = HashSet::new();
+    let deduped: Vec<Address> = census
+        .into_iter()
+        .filter(|address| !address.is_zero() && seen.insert(*address))
+        .collect();
+
+    (!deduped.is_empty()).then_some(deduped)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn addr(byte: u8) -> Address {
+        Address::from([byte; 20])
+    }
+
+    #[test]
+    fn keeps_distinct_addresses_in_order() {
+        let census = vec![addr(3), addr(1), addr(2)];
+        assert_eq!(
+            sanitize_census(census),
+            Some(vec![addr(3), addr(1), addr(2)])
+        );
+    }
+
+    #[test]
+    fn removes_duplicates_keeping_first_occurrence() {
+        let census = vec![addr(1), addr(2), addr(1), addr(2), addr(3)];
+        assert_eq!(
+            sanitize_census(census),
+            Some(vec![addr(1), addr(2), addr(3)])
+        );
+    }
+
+    #[test]
+    fn removes_zero_addresses() {
+        let census = vec![addr(1), Address::ZERO, addr(2)];
+        assert_eq!(sanitize_census(census), Some(vec![addr(1), addr(2)]));
+    }
+
+    #[test]
+    fn empty_census_is_rejected() {
+        assert_eq!(sanitize_census(vec![]), None);
+    }
+
+    #[test]
+    fn census_of_only_zero_addresses_is_rejected() {
+        assert_eq!(sanitize_census(vec![Address::ZERO, Address::ZERO]), None);
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for token-based and requester-provided electorates when creating voting rounds.
  - Requester-provided voter lists are fetched, validated, deduplicated, and cleaned automatically.
  - Round census mode can be viewed independently after creation.
  - Custom voting credits remain supported for token-based rounds.

- **Bug Fixes**
  - Invalid census settings and incompatible credit combinations are rejected.
  - Unavailable requester census data is handled safely.
  - Voting rounds enforce minimum and maximum option limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->